### PR TITLE
Add the tower widths in eta to geometry.

### DIFF
--- a/cmsl1t/geometry.py
+++ b/cmsl1t/geometry.py
@@ -27,8 +27,10 @@ def is_in_region(region, eta, regions=eta_regions):
     return regions[region](eta)
 
 
-__etaSizes_21onwards=[0.09 , 0.1   , 0.113 , 0.129 , 0.15, 0.178 ,
-                      0.15 , 0.35  , 0.5   , 0.5   , 0.5 , 0.5   ]
+__etaSizes_21onwards = [
+        0.09, 0.1, 0.113, 0.129, 0.15, 0.178,
+        0.15, 0.35, 0.5, 0.5, 0.5, 0.5
+        ]
 
 
 def towerEtaWidth(ieta):
@@ -37,7 +39,7 @@ def towerEtaWidth(ieta):
     :param ieta: the index of the tower
     :type int
     """
-    width=0.087
-    if abs(ieta) > 20 :
-        width=__etaSizes[abs(ieta)-21]
+    width = 0.087
+    if abs(ieta) > 20:
+        width = __etaSizes_21onwards[abs(ieta)-21]
     return width

--- a/cmsl1t/geometry.py
+++ b/cmsl1t/geometry.py
@@ -28,9 +28,9 @@ def is_in_region(region, eta, regions=eta_regions):
 
 
 __etaSizes_21onwards = [
-        0.09, 0.1, 0.113, 0.129, 0.15, 0.178,
-        0.15, 0.35, 0.5, 0.5, 0.5, 0.5
-        ]
+    0.09, 0.1, 0.113, 0.129, 0.15, 0.178,
+    0.15, 0.35, 0.5, 0.5, 0.5, 0.5
+]
 
 
 def towerEtaWidth(ieta):
@@ -41,5 +41,5 @@ def towerEtaWidth(ieta):
     """
     width = 0.087
     if abs(ieta) > 20:
-        width = __etaSizes_21onwards[abs(ieta)-21]
+        width = __etaSizes_21onwards[abs(ieta) - 21]
     return width

--- a/cmsl1t/geometry.py
+++ b/cmsl1t/geometry.py
@@ -25,3 +25,19 @@ def is_in_region(region, eta, regions=eta_regions):
         raise KeyError(msg)
 
     return regions[region](eta)
+
+
+__etaSizes_21onwards=[0.09 , 0.1   , 0.113 , 0.129 , 0.15, 0.178 ,
+                      0.15 , 0.35  , 0.5   , 0.5   , 0.5 , 0.5   ]
+
+
+def towerEtaWidth(ieta):
+    """
+    Get the relative width of each tower compared to towers in the barrel
+    :param ieta: the index of the tower
+    :type int
+    """
+    width=0.087
+    if abs(ieta) > 20 :
+        width=__etaSizes[abs(ieta)-21]
+    return width


### PR DESCRIPTION
This is useful for some PUS schemes which account for the different Eta widths.

I might be duplicating code here, since I'm guessing something like this is available in cmssw already.  If so, could someone point me to it and I'll close this?