### PR TITLE
Add first working version of a root_glob object

### DIFF
--- a/cmsl1t/utils/root_glob.py
+++ b/cmsl1t/utils/root_glob.py
@@ -44,7 +44,7 @@ def glob(pathname):
                 continue
             if not fnmatch.fnmatchcase(file, basename):
                 continue
-            files.append(os.path.join(dirname,file))
+            files.append(os.path.join(dirname, file))
         gSystem.FreeDirectory(directory)
     return files
 
@@ -56,22 +56,19 @@ def iglob(pathname):
 
 if __name__ == "__main__":
     test_paths = [
-            "data/*root",
-
-            "data/L1Ntuple_test_3.root",
-
-            """root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/"""
-            """comm_trigger/L1Trigger/L1Menu2016/Stage2/"""
-            """l1t-integration-v88p1-CMSSW-8021/SingleMuon/"""
-            """crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"""
-            """161031_120512/0000/L1Ntuple_999.root""",
-
-            """root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/"""
-            """comm_trigger/L1Trigger/L1Menu2016/Stage2/"""
-            """l1t-integration-v88p1-CMSSW-8021/SingleMuon/"""
-            """crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"""
-            """161031_120512/0000/L1Ntuple_99*.root""",
-            ]
+        "data/*root",
+        "data/L1Ntuple_test_3.root",
+        """root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/"""
+        """comm_trigger/L1Trigger/L1Menu2016/Stage2/"""
+        """l1t-integration-v88p1-CMSSW-8021/SingleMuon/"""
+        """crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"""
+        """161031_120512/0000/L1Ntuple_999.root""",
+        """root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/"""
+        """comm_trigger/L1Trigger/L1Menu2016/Stage2/"""
+        """l1t-integration-v88p1-CMSSW-8021/SingleMuon/"""
+        """crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"""
+        """161031_120512/0000/L1Ntuple_99*.root""",
+    ]
     for i, path in enumerate(test_paths):
         expanded = glob(path)
         print(i, path)

--- a/cmsl1t/utils/root_glob.py
+++ b/cmsl1t/utils/root_glob.py
@@ -44,7 +44,7 @@ def glob(pathname):
                 continue
             if not fnmatch.fnmatchcase(file, basename):
                 continue
-            files.append(file)
+            files.append(os.path.join(dirname,file))
         gSystem.FreeDirectory(directory)
     return files
 

--- a/cmsl1t/utils/root_glob.py
+++ b/cmsl1t/utils/root_glob.py
@@ -1,0 +1,78 @@
+"""
+Reproduce the standard glob package behaviour but use TSystem to be able to
+query remote file systems, like xrootd
+"""
+from __future__ import print_function
+from rootpy.ROOT import gSystem
+import glob as gl
+import os.path
+import fnmatch
+
+
+def __directory_iter(directory):
+    while True:
+        file = gSystem.GetDirEntry(directory)
+        if not file:
+            break
+        yield file
+    return
+
+
+def glob(pathname):
+    # Let normal python glob try first
+    try_glob = gl.glob(pathname)
+    if try_glob:
+        return try_glob
+
+    # If pathname does not contain a wildcard:
+    if not gl.has_magic(pathname):
+        return [pathname]
+
+    # Split the pathname into a directory and basename
+    # (which should include the wild-card)
+    dirname, basename = os.path.split(pathname)
+
+    # Uses `TSystem` to open the directory.
+    # TSystem itself wraps up the calls needed to query xrootd.
+    dirname = gSystem.ExpandPathName(dirname)
+    directory = gSystem.OpenDirectory(dirname)
+
+    files = []
+    if directory:
+        for file in __directory_iter(directory):
+            if file in [".", ".."]:
+                continue
+            if not fnmatch.fnmatchcase(file, basename):
+                continue
+            files.append(file)
+        gSystem.FreeDirectory(directory)
+    return files
+
+
+def iglob(pathname):
+    for name in glob(pathname):
+        yield name
+
+
+if __name__ == "__main__":
+    test_paths = [
+            "data/*root",
+
+            "data/L1Ntuple_test_3.root",
+
+            """root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/"""
+            """comm_trigger/L1Trigger/L1Menu2016/Stage2/"""
+            """l1t-integration-v88p1-CMSSW-8021/SingleMuon/"""
+            """crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"""
+            """161031_120512/0000/L1Ntuple_999.root""",
+
+            """root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/"""
+            """comm_trigger/L1Trigger/L1Menu2016/Stage2/"""
+            """l1t-integration-v88p1-CMSSW-8021/SingleMuon/"""
+            """crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"""
+            """161031_120512/0000/L1Ntuple_99*.root""",
+            ]
+    for i, path in enumerate(test_paths):
+        expanded = glob(path)
+        print(i, path)
+        print(i, expanded)

--- a/test/utils/test_root_glob.py
+++ b/test/utils/test_root_glob.py
@@ -1,9 +1,9 @@
 import unittest
 from cmsl1t.utils.root_glob import glob as root_glob
-import glob as py_glob
+from glob import glob as py_glob
 
 
-class TestGlob(unittest.TestCase):
+class TestRootGlob(unittest.TestCase):
 
     def test_glob_local_single(self):
         filename = "data/L1Ntuple_test_3.root"

--- a/test/utils/test_root_glob.py
+++ b/test/utils/test_root_glob.py
@@ -1,0 +1,28 @@
+import unittest
+from cmsl1t.utils.root_glob import glob as root_glob
+import glob as py_glob
+
+
+class TestGlob(unittest.TestCase):
+
+    def test_glob_local_single(self):
+        filename = "data/L1Ntuple_test_3.root"
+        self.assertEqual([filename], root_glob(filename))
+
+    def test_glob_local_wildcard(self):
+        filename = "data/*root"
+        self.assertEqual(root_glob(filename), py_glob(filename))
+
+#    def test_glob_xrootd_single(self):
+#       filename = """root://eoscms.cern.ch//eos/cms/store/group/"""
+#       """dpg_trigger/comm_trigger/L1Trigger/L1Menu2016/Stage2/"""
+#       """l1t-integration-v88p1-CMSSW-8021/SingleMuon/"""
+#       """crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"""
+#       """161031_120512/0000/L1Ntuple_999.root""",
+
+#    def test_glob_xrootd_wildcard(self):
+#       filename = """root://eoscms.cern.ch//eos/cms/store/group/"""
+#       """dpg_trigger/comm_trigger/L1Trigger/L1Menu2016/Stage2/"""
+#       """l1t-integration-v88p1-CMSSW-8021/SingleMuon/"""
+#       """crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"""
+#       """161031_120512/0000/L1Ntuple_99*.root"""


### PR DESCRIPTION
This adds an implementation of `root_glob` which extends python's `glob` module to work over remote file systems.  It's based heavily on the way TChain handles wildcards, and as such has the same shortcoming, that only wild-cards in the basename are handled, and not in any directory name.

We can expand this in the future, to make things more like full globbing (which needs some recursion as python `glob` does) but my goal is to give us something that works for now.   I'll also put up a PR for this on rootpy so hopefully we can actually remove this in the future.

Should fix issue #16 