### PR TITLE
Add an initial draft of the sort of 'analyzer' I would suggest we use

### DIFF
--- a/bin/analyze
+++ b/bin/analyze
@@ -1,0 +1,153 @@
+#!/bin/env python
+from __future__ import print_function
+import ROOT
+import os
+from datetime import datetime
+from cmsl1t.utils.timers import timerfunc
+
+import logging
+logger = logging.getLogger(__name__)
+logging.getLogger("rootpy.tree.chain").setLevel(logging.WARNING)
+
+TODAY = datetime.now().timetuple()
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+ROOT.gROOT.SetBatch(1)
+ROOT.TH1.SetDefaultSumw2(True)
+separator = '=' * 80
+section = [separator, '{0}', separator]
+section = '\n'.join(section)
+
+
+def create_cli_parser():
+    from argparse import ArgumentParser
+    from importlib import import_module
+    from cmsl1t.utils.root_glob import glob
+
+    def import_analyzer(analyzer_name):
+        module = None
+        try:
+            module = import_module("cmsl1t.analyzers."+str(analyzer_name))
+        except ImportError:
+            msg = "Cannot find module, '{}', from the analyzers directory"
+            ArgumentParser.error(msg.format(analyzer_name))
+        return module
+
+    parser = ArgumentParser()
+    parser.add_argument("-o", "--out-dir")
+    parser.add_argument(
+            "-c", "--config", type=str,  # required=True,
+            help="YAML style config file")
+    parser.add_argument(
+            "-a", "--analysis", type=import_analyzer, required=True,
+            help="""Specify which analysis module to use. Must be relative
+                 to the analyzers directory""")
+    parser.add_argument(
+            "-n", "--n-events", type=int, default=1000,
+            help="Set how many events to run over")
+    parser.add_argument(
+            "-r", "--reload-histograms", action="store_true", default=False,
+            help="Reload histograms from a file and skip the input tuples")
+
+    # Temporarily add an option to handle the input data specification
+    # Soon we expect this to be moved to the YAML config file
+    parser.add_argument(
+            "-i", "--inputs", required=True, type=glob,
+            help="""DEPRECATED: Specify the input files to run over.
+                    Globbing is possible, but remember to escape things
+                    properly so it is handled by python and not BASH's
+                    command-line expansion""")
+    return parser
+
+
+def get_unique_out_dir(outdir=None, revision=1):
+    if not outdir:
+        outdir = os.path.join(
+                "workspace",
+                '{y}{m:02d}{d:02d}'.format(
+                    y=TODAY.tm_year, m=TODAY.tm_mon, d=TODAY.tm_mday)
+                )
+    full_outdir = outdir+"-rev_{rev}".format(rev=revision)
+    if os.path.isdir(full_outdir):
+        return get_unique_out_dir(outdir, revision+1)
+    print("Will write output to: ", full_outdir)
+    return full_outdir
+
+
+def clean_args(args):
+    print(section.format("Starting CMS L1T Analsysis"))
+    args.out_dir = get_unique_out_dir(args.out_dir)
+    return args
+
+
+@timerfunc(logger.info)
+def process_tuples(args, analyzer):
+    # Open the data files
+    print(section.format("Loading data"))
+    print("Input files:")
+    if len(args.inputs) > 10:
+        print(args.inputs[:10], "... and", len(args.inputs)-10, "more files")
+    else:
+        print(args.inputs)
+
+    from cmsl1t.playground.eventreader import EventReader
+    reader = EventReader(args.inputs, events=args.n_events)
+    is_ok = analyzer.prepare_for_events(reader)
+    if is_ok is not True:
+        return "Problem during prepare_for_events() with analyzer: "\
+                + str(args.analysis)
+
+    print(section.format("Processing events"))
+    # Fill the histograms from the tuples
+    counter_rate = args.n_events/10 if args.n_events <= 10000 else 1000
+    for entry, event in enumerate(reader):
+        if entry % counter_rate == 0:
+            print(entry, "of", args.n_events)
+        is_ok = analyzer.process_event(entry, event)
+        if is_ok is not True:
+            break
+    print(args.n_events, "of", args.n_events)
+
+
+def run(args):
+    # Fetch the analyzer
+    analyzer = args.analysis.Analyzer(args)
+
+    if not args.reload_histograms:
+        process_tuples(args, analyzer)
+    else:
+        # TODO: Support multiple input root histogram files
+        is_ok = analyzer.reload_histograms(args.inputs[0])
+        if is_ok is not True:
+            return "Problem in reload_histograms() with analyzer: " \
+                    + str(args.analysis)
+    # Write out the histograms
+    analyzer.write_histograms()
+
+    # Turn the histograms to plots
+    print(section.format("Making plots"))
+    is_ok = analyzer.make_plots()
+    if is_ok is not True:
+        return "Problem during make_plots() with analyzer: "+str(args.analysis)
+
+    # Finalize
+    print(section.format("Finalizing things"))
+    is_ok = analyzer.finalize()
+    if is_ok is not True:
+        return "Problem during finalize() with analyzer: "+str(args.analysis)
+
+    return is_ok
+
+
+if __name__ == '__main__':
+    parser = create_cli_parser()
+    args = parser.parse_args()
+
+    # Begin the main analysis
+    args = clean_args(args)
+    isok = run(args)
+
+    print('\n'+separator+'\n')
+    if isok is not True:
+        print("There were errors during running:")
+        print(isok)
+        print('\n'+separator+'\n')

--- a/cmsl1t/analyzers/BaseAnalyzer.py
+++ b/cmsl1t/analyzers/BaseAnalyzer.py
@@ -1,0 +1,85 @@
+import os
+
+
+class BaseAnalyzer(object):
+    """
+    A Base class to be used by the various analyzers
+    """
+    def __init__(self, name, config):
+        self.name = name
+        self.output_folder = config.out_dir
+        os.makedirs(self.output_folder)
+
+    def prepare_for_events(self, reader):
+        """
+        Can be overloaded in the derived class.
+        Called once, after the input trees have been prepared.
+
+        returns:
+          Should return True if everything was prepared ok.
+          If anything else is returned, processing will stop
+        """
+        return True
+
+    def process_event(self, entry, event):
+        """Should not really be overloaded in the derived class"""
+        return self.fill_histograms(entry, event)
+
+    def fill_histograms(self, entry, event):
+        """
+        Has to be overloaded by users code.
+
+        Called once per input event in the tuples.
+
+        parameters:
+         - entry -- the index of the entry being read in
+         - event -- the event data read in from the tuples
+
+        returns:
+          Should return True if histograms were filled without problem.
+          If anything else is returned, processing of the trees will stop
+        """
+        raise NotImplementedError("fill_histograms needs to be implemented")
+        return True
+
+    def write_histograms(self):
+        """
+        Has to be overloaded by users code.
+
+        Called after all events have been read, so that histograms can be
+        written to file).  Note that plots should not be drawn here, since this
+        method will not be called if we are running off previously filled
+        histograms.
+
+        returns:
+          Should return True if histograms were written without problem.
+          If anything else is returned, processing of the trees will stop
+        """
+        raise NotImplementedError("write_histograms() needs to be implemented")
+        return True
+
+    def make_plots(self):
+        """
+        Has to be overloaded by users code.
+
+        Called after all events have been read to convert histograms to actual
+        plots Might be called on existing files of histograms (ie. without
+        reading tuples in again)
+
+        returns:
+          Should return True if plots were produced without problem.
+          If anything else is returned, processing of the trees will stop
+        """
+        raise NotImplementedError("make_plots needs to be implemented")
+
+    def finalize(self):
+        """
+        Can be overloaded in the derived class if needed.
+
+        Called at the very end of the code to tidy things up before the
+        programs quits
+        """
+        return True
+
+    def get_histogram_filename(self):
+        return os.path.join(self.output_folder, "histograms.root")

--- a/cmsl1t/analyzers/demo_analyzer.py
+++ b/cmsl1t/analyzers/demo_analyzer.py
@@ -1,0 +1,62 @@
+"""
+Study the MET distibutions and various PUS schemes
+"""
+
+from BaseAnalyzer import BaseAnalyzer
+from cmsl1t.collections import EfficiencyCollection
+from functools import partial
+import cmsl1t.recalc.met as recalc
+import numpy as np
+
+
+class Analyzer(BaseAnalyzer):
+    def __init__(self, config):
+        super(Analyzer, self).__init__("demo_analyzer", config)
+
+        self.met_calcs = dict(
+            RecalcL1EmuMETNot28=dict(
+                title="Emulated MET, |ieta|<28",
+                calculate=recalc.l1MetNot28),
+            RecalcL1EmuMETNot28HF=dict(
+                title="Emulated MET, |ieta|!=28",
+                calculate=recalc.l1MetNot28HF),
+        )
+
+    def prepare_for_events(self, reader):
+        bins = np.arange(0, 200, 25)
+        thresholds = [70, 90, 110]
+        puBins = range(0, 50, 10)+[999]
+
+        self.efficiencies = EfficiencyCollection(pileupBins=puBins)
+        add_met_variable = partial(
+            self.efficiencies.add_variable,
+            bins=bins, thresholds=thresholds)
+        map(add_met_variable, self.met_calcs)
+        return True
+
+    def reload_histograms(self, input_file):
+        # Something like this needs to be implemented still
+        # self.efficiencies = EfficiencyCollection.from_root(input_file)
+        return True
+
+    def fill_histograms(self, entry, event):
+        pileup = event.nVertex
+        if pileup < 5 or not event.passesMETFilter():
+            return True
+        self.efficiencies.set_pileup(pileup)
+
+        offlineMetBE = event.sums.caloMetBE
+        for name, config in self.met_calcs.items():
+            onlineMet = config['calculate'](event.caloTowers)
+            onlineMet = np.linalg.norm(onlineMet)
+            self.efficiencies.fill(name, offlineMetBE, onlineMet)
+        return True
+
+    def write_histograms(self):
+        self.efficiencies.to_root(self.get_histogram_filename())
+        return True
+
+    def make_plots(self):
+        # Something like this needs to be implemented still
+        # self.efficiencies.draw_plots(self.output_folder, "png")
+        return True

--- a/cmsl1t/analyzers/demo_analyzer.py
+++ b/cmsl1t/analyzers/demo_analyzer.py
@@ -25,7 +25,7 @@ class Analyzer(BaseAnalyzer):
     def prepare_for_events(self, reader):
         bins = np.arange(0, 200, 25)
         thresholds = [70, 90, 110]
-        puBins = range(0, 50, 10)+[999]
+        puBins = range(0, 50, 10) + [999]
 
         self.efficiencies = EfficiencyCollection(pileupBins=puBins)
         add_met_variable = partial(


### PR DESCRIPTION
This adds several additional files, with the aim of being a first step towards the sort of interface a new student might want to work with to analyze things. 

This PR adds:
 - An overall `analyze` file, which in general would not need to be changed.
 - A `BaseAnalyzer` module which provides the generic interface for an analyzer.  
 - A demo of how a user would implement an analyzer (`demo_analyzer`).

To run analysis using a specific custom analyzer, the command line (for now) would be:
```bash
python bin/analyze -a demo_analyzer -i 'data/L1Ntuple_*.root' -n 1000
```
I've set up the minimal set of command line options that one would need to use this for now:
```
$ python bin/analyze -h 
usage: analyze [-h] [-o OUT_DIR] [-c CONFIG] -a ANALYSIS [-n N_EVENTS] [-r] -i INPUTS

optional arguments:
  -h, --help            show this help message and exit
  -o OUT_DIR, --out-dir OUT_DIR
  -c CONFIG, --config CONFIG
                        YAML style config file
  -a ANALYSIS, --analysis ANALYSIS
                        Specify which analysis module to use. Must be relative
                        to the analyzers directory
  -n N_EVENTS, --n-events N_EVENTS
                        Set how many events to run over
  -r, --reload-histograms
                        Reload histograms from a file and skip the input
                        tuples
  -i INPUTS, --inputs INPUTS
                        DEPRECATED: Specify the input files to run over.
                        Globbing is possible, but remember to escape things
                        properly so it is handled by python and not BASH's
                        command-line expansion
```
 Some of these should move (in the long-term) into the YAML config file, at which point the only remaining ones I imagine would be `-c`, `-o`, and possibly `-r`.

@kreczko, I realise the implementation of this is slightly different to what you had in mind, but I'd be happy to adapt this into that and I don't think it's far off. I think `BaseAnalyzer` could be easily turned into a context manager, in which case `prepare_histograms` would become `__enter__`, and `finalize` would become `__exit__` I think.  The code in `bin/analyzer` would also need changing a little, but mainly that would be splitting up the `run` and `process_tuples` functions differently.  

 I don't think I can spend too much time on re-working this just yet, and want to push on trying it for actual analysis, and playing with the histogram classes more, but I'd be grateful to hear any thoughts!