### PR TITLE
Split timerfunc decorator for different call-signatures

### DIFF
--- a/bin/analyze
+++ b/bin/analyze
@@ -3,7 +3,7 @@ from __future__ import print_function
 import ROOT
 import os
 from datetime import datetime
-from cmsl1t.utils.timers import timerfunc
+from cmsl1t.utils.timers import timerfunc_log_to
 
 import logging
 logger = logging.getLogger(__name__)
@@ -79,7 +79,7 @@ def clean_args(args):
     return args
 
 
-@timerfunc(logger.info)
+@timerfunc_log_to(logger.info)
 def process_tuples(args, analyzer):
     # Open the data files
     print(section.format("Loading data"))

--- a/cmsl1t/utils/timers.py
+++ b/cmsl1t/utils/timers.py
@@ -3,14 +3,11 @@ import time
 import functools
 
 
-def timerfunc(func, printer=print):
-    """
-    A timer decorator
-    """
+def __timerfunc(func, printer=None):
     @functools.wraps(func)
-    def function_timer(*args, **kwargs):
+    def wrapper(*args, **kwargs):
         """
-        A nested function for timing other functions
+        A function for timing other functions
         """
         start = time.time()
         value = func(*args, **kwargs)
@@ -20,5 +17,21 @@ def timerfunc(func, printer=print):
         printer(msg.format(func=func.__name__,
                            time=runtime))
         return value
-    function_timer.__wrapped__ = func
+    wrapper.__wrapped__ = func
+    return wrapper
+
+
+def timerfunc(func):
+    """
+    A timer decorator that prints to stdout
+    """
+    function_timer = functools.partial(__timerfunc, printer=print)(func)
+    return function_timer
+
+
+def timerfunc_log_to(printer):
+    """
+    A timer decorator that prints to a specific print function or logger
+    """
+    function_timer = functools.partial(__timerfunc, printer=printer)
     return function_timer

--- a/test/utils/test_timers.py
+++ b/test/utils/test_timers.py
@@ -1,14 +1,28 @@
+from __future__ import print_function
 import unittest
-from cmsl1t.utils.timers import timerfunc
+from cmsl1t.utils.timers import timerfunc, timerfunc_log_to
+
+
+def simple_logger(*args):
+    print(args)
 
 
 @timerfunc
-def test_wrapping_method():
+def wrapping_method():
+    pass
+
+
+@timerfunc_log_to(simple_logger)
+def wrapping_method_with_logger():
     pass
 
 
 class TestTimerfunc(unittest.TestCase):
 
     def test_wrapping(self):
-        wrapped = getattr(test_wrapping_method, "__wrapped__")
-        self.assertEqual(wrapped.__name__, 'test_wrapping_method')
+        wrapped = getattr(wrapping_method, "__wrapped__")
+        self.assertEqual(wrapped.__name__, 'wrapping_method')
+
+    def test_wrapping_withlogger(self):
+        wrapped = getattr(wrapping_method_with_logger, "__wrapped__")
+        self.assertEqual(wrapped.__name__, 'wrapping_method_with_logger')


### PR DESCRIPTION
The timerfunc decorator was supposed to be able to be used with no arguments, or provided a single argument being a print_function to specify a log output.  Since such behaviour is hard to achieve in python, and since this was giving us grief elsewhere I have split this decorator into two, one which takes no arguments, and just uses python's `print` method, and one called `timerfunc_log_to` which receives on argument for the printer method to use.

This allows a fix for issue #24.  

I've also extended the unit tests to check this is working.