### PR TITLE
[WIP] General histogram collection

### DIFF
--- a/cmsl1t/collections/__init__.py
+++ b/cmsl1t/collections/__init__.py
@@ -5,10 +5,12 @@ from .base import BaseHistCollection
 from .by_pileup import HistogramsByPileUpCollection
 from .resolution import ResolutionCollection
 from .efficiency import EfficiencyCollection
+from .hist import HistogramCollection
 
 __all__ = [
     'BaseHistCollection',
     'HistogramsByPileUpCollection',
     'ResolutionCollection',
     'EfficiencyCollection',
+    'HistogramCollection',
 ]

--- a/cmsl1t/collections/hist.py
+++ b/cmsl1t/collections/hist.py
@@ -1,0 +1,95 @@
+import collections
+
+
+class HistogramCollection(object):
+    '''
+    The histogram collection needs a few things:
+     - it needs to be able to essentially have binned maps of histograms
+     - needs to know how to create new histograms
+
+    e.g.
+    def getter_pileup(value, bins)
+            if pileup > max(bins):
+                return -1
+            bins = pairwise(bins)
+            for i, (lowerEdge, upperEdge) in enumerate(bins):
+                if pileup >= lowerEdge and pileup < upperEdge:
+                    return i
+            return 0
+
+    def getter_region(eta, bins):
+        for region in regions:
+            if is_in_region(region, eta, regions=regions):
+                return region
+
+
+    def hist1D_factory(name, bins):
+        pass
+
+
+    hists = HistogramCollection(dimensions=2) #dimension 0 == histogram names?
+    hists.register_dim(1, getter_pileup, bins=[0, 10, 20, 30, 999])
+    hists.register_dim(2, getter_region, ['B', 'BE', 'E', 'HF'])
+    '''
+
+    def __init__(self, dimensions):
+        '''
+            Should dimensions include or exclude histogram names?
+        '''
+        self._dimensions = dimensions
+
+    def register_dim(self, dim_index, segmentation_func, bins):
+        '''
+            Does it make sense to include bins here or is it better to use
+            functools.partial and expect the segmentation_func to only handle 1
+            parameter? Unless we pass a setter, we need the bins to add histograms
+        '''
+        pass
+
+    def __getitem__(self, key):
+        '''
+            Supposed to handle
+                coll[x]
+            and
+                coll[x, y, z]
+        '''
+        if isinstance(key, collections.Sequence) and not isinstance(obj, basestring):
+            pass
+        else:
+            '''
+                This bit also needs to support
+                    coll[x][y][z]
+            '''
+            pass
+
+    def __setitem__(self, key, value):
+        '''
+            Same requirements as __getitem__
+        '''
+        pass
+
+    def add(self, name, bins):
+        '''
+            coll.add('1Dhistogram', bins=[1,2,3])
+            coll.add('2Dhistogram', bins=[[1,2,3], [1,2,3]])
+            coll.add('3Dhistogram', bins=[[1,2,3], [1,2,3], [1,2,3]])
+        '''
+        # get the segmentation of the current dimensions
+        # create a histogram for each segment
+        pass
+
+    def fill(self, x, weight):
+        '''
+            Do we want this? It could only work if we have setters for each
+            dimension:
+                coll.set_dim(1, pileup)
+                coll.set_dim(2, region)
+
+
+                coll.fill('1Dhistogram', x=42, w=1)
+                coll.fill('2Dhistogram', x=[42, 1], w=1)
+
+            alternative is
+                coll[pileup][eta][histname].fill(...)
+        '''
+        pass

--- a/cmsl1t/collections/hist.py
+++ b/cmsl1t/collections/hist.py
@@ -93,3 +93,6 @@ class HistogramCollection(object):
                 coll[pileup][eta][histname].fill(...)
         '''
         pass
+
+    def __len__(self):
+        return 0

--- a/test/collections/test_histogramCollection.py
+++ b/test/collections/test_histogramCollection.py
@@ -1,0 +1,45 @@
+from nose.tools import assert_equal
+from cmsl1t.collections import HistogramCollection
+from cmsl1t.geometry import is_in_region, eta_regions
+from functools import partial
+
+
+def getter_pileup(value, bins):
+    if pileup > max(bins):
+        return -1
+    bins = pairwise(bins)
+    for i, (lowerEdge, upperEdge) in enumerate(bins):
+        if pileup >= lowerEdge and pileup < upperEdge:
+            return i
+    return 0
+
+
+def getter_region(eta, bins):
+    for region in regions:
+        if is_in_region(region, eta, regions=regions):
+            return region
+
+pileupBins = [0, 10, 15, 20, 30, 999]
+regions = eta_regions.keys()
+
+
+def test_pileup_binning():
+    coll = HistogramCollection(dimensions=1)
+    coll.register_dim(1, segmentation_func=partial(
+        getter_pileup, bins=pileupBins), bins=pileupBins)
+    coll[11] = 2
+    coll[42] = 42
+    assert_equal(coll[13], 2)
+    assert_equal(coll[9999], 42)
+
+
+def test_region_binning():
+    coll = HistogramCollection(dimensions=1)
+    coll.register_dim(1, segmentation_func=partial(
+        getter_region, bins=regions), bins=regions)
+    coll[0] = 2
+    coll[2.1] = 42
+    coll[5] = 234
+    assert_equal(coll[-1.0], 2)
+    assert_equal(coll[2.99], 42)
+    assert_equal(coll[-999], 5)

--- a/test/collections/test_histogramCollection.py
+++ b/test/collections/test_histogramCollection.py
@@ -43,3 +43,21 @@ def test_region_binning():
     assert_equal(coll[-1.0], 2)
     assert_equal(coll[2.99], 42)
     assert_equal(coll[-999], 5)
+
+
+def test_collection_size_1D():
+    coll = HistogramCollection(dimensions=1)
+    coll.register_dim(1, segmentation_func=partial(
+        getter_region, bins=regions), bins=regions)
+    coll.add('histName', bins=[0, 10, 20, 30])
+    assert_equal(len(coll), len(regions))
+
+
+def test_collection_size_2D():
+    coll = HistogramCollection(dimensions=1)
+    coll.register_dim(1, segmentation_func=partial(
+        getter_pileup, bins=pileupBins), bins=pileupBins)
+    coll.register_dim(2, segmentation_func=partial(
+        getter_region, bins=regions), bins=regions)
+    coll.add('histName', bins=[0, 10, 20, 30])
+    assert_equal(len(coll), len(regions) * len(pileupBins))


### PR DESCRIPTION
added first tests for new histogram collection.

Some of the functionality is still unclear, e.g. how to introduce generators for different dimensions and how they work together.
E.g. a pileup bins generator would create one histogram (with different names) for each pileup bin when
```python
hists.add('myHist', bins=[0,100,200,450])
```
is called.

However, when you bin in both detector regions AND pileup, then only one of the generators should actually create the histogram object, while the other one would only add the binning to the histogram name.