### PR TITLE
Fixes for documentation on readthedocs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # cms-l1t-analysis
 Software package to analyse L1TNtuples
 
- - [![Build Status](https://travis-ci.org/cms-l1t-offline/cms-l1t-analysis.svg?branch=master)](https://travis-ci.org/cms-l1t-offline/cms-l1t-analysis)
- - [![DOI](https://zenodo.org/badge/80877637.svg)](https://zenodo.org/badge/latestdoi/80877637)
- - [![Code Health](https://landscape.io/github/cms-l1t-offline/cms-l1t-analysis/master/landscape.svg?style=flat)](https://landscape.io/github/cms-l1t-offline/cms-l1t-analysis/master)
+[![Build Status](https://travis-ci.org/cms-l1t-offline/cms-l1t-analysis.svg?branch=master)](https://travis-ci.org/cms-l1t-offline/cms-l1t-analysis) [![DOI](https://zenodo.org/badge/80877637.svg)](https://zenodo.org/badge/latestdoi/80877637) [![Code Health](https://landscape.io/github/cms-l1t-offline/cms-l1t-analysis/master/landscape.svg?style=flat)](https://landscape.io/github/cms-l1t-offline/cms-l1t-analysis/master) [![docs](https://readthedocs.org/projects/cms-l1t-analysis/badge/?version=latest)](http://cms-l1t-analysis.readthedocs.io/en/latest/)
 
 
 ## DEV

--- a/cmsl1t/__init__.py
+++ b/cmsl1t/__init__.py
@@ -1,16 +1,10 @@
 from __future__ import absolute_import
 import os
+from os import path
 import sys
 import logging
 
 __version__ = '0.1.1'
-
-
-if 'PROJECT_ROOT' not in os.environ:
-    print("Could not find environmental variable 'PROJECT_ROOT'")
-    print("You need to run 'source bin/env.sh' first!")
-    sys.exit(-1)
-PROJECT_ROOT = os.environ['PROJECT_ROOT']
 
 # logging
 logger = logging.getLogger(__name__)
@@ -19,7 +13,7 @@ logger.setLevel(logging.DEBUG)
 # add loggers
 ch = logging.StreamHandler()
 if not os.environ.get("DEBUG", False):
-    ch.setLevel(logging.ERROR)
+    ch.setLevel(logging.WARNING)
 else:
     ch.setLevel(logging.DEBUG)
 # log format
@@ -27,3 +21,11 @@ formatter = logging.Formatter(
     '%(asctime)s [%(name)s]  %(levelname)s: %(message)s')
 ch.setFormatter(formatter)
 logger.addHandler(ch)
+
+if 'PROJECT_ROOT' not in os.environ:
+    logger.warn("Could not find environmental variable 'PROJECT_ROOT'")
+    logger.warn("You should to run 'source bin/env.sh' first!")
+    HERE = path.dirname(path.abspath(__file__))
+    PROJECT_ROOT = path.abspath(path.join(HERE, path.pardir))
+else:
+    PROJECT_ROOT = os.environ['PROJECT_ROOT']

--- a/cmsl1t/collections/by_pileup.py
+++ b/cmsl1t/collections/by_pileup.py
@@ -1,7 +1,6 @@
 import numpy as np
 import logging
 from collections import defaultdict
-from rootpy.plotting import Hist
 
 from cmsl1t.utils.iterators import pairwise
 from cmsl1t.io import to_root
@@ -23,11 +22,13 @@ class HistogramsByPileUpCollection(BaseHistCollection):
     '''
 
     def __init__(self, pileupBins, dimensions=1, initialValue=0):
+        from rootpy.plotting import Hist
         BaseHistCollection.__init__(self, dimensions, initialValue)
         self._pileupBins = pileupBins
         self._pileupHist = Hist(100, 0, 100, name='nVertex')
 
     def add(self, hist_name, bins=[]):
+        from rootpy.plotting import Hist
         '''
             Specialisation for 2 dimensions
             TODO: generalise

--- a/cmsl1t/collections/efficiency.py
+++ b/cmsl1t/collections/efficiency.py
@@ -1,14 +1,10 @@
 """
     .. module:: collections.efficiency
-        :synopsis: Module for creating efficiency(turnon)-curves
-
-    .. moduleauthor:: Luke Kreczko
+       :synopsis: Module for creating efficiency(turnon)-curves
 """
 from collections import defaultdict
 from . import HistogramsByPileUpCollection
-from rootpy.plotting import Hist
-from rootpy import asrootpy
-from ROOT import TEfficiency
+
 from cmsl1t.utils.iterators import pairwise
 import logging
 
@@ -18,6 +14,7 @@ logger = logging.getLogger(__name__)
 class _EfficiencyCurve(object):
 
     def __init__(self, name, bins, threshold):
+        from rootpy.plotting import Hist
         self._pass = Hist(bins, name=name + '_pass')
         self._total = Hist(bins, name=name + '_total')
         self._dist = Hist(bins, name=name + '_dist')
@@ -39,6 +36,8 @@ class _EfficiencyCurve(object):
             self._pass.fill(recoValue, weight)
 
     def calculate_efficiency(self):
+        from rootpy import asrootpy
+        from ROOT import TEfficiency
         self._efficiency = asrootpy(TEfficiency(self._pass, self._total))
         self._efficiency.SetName(self._total.GetName() + '_eff')
 

--- a/cmsl1t/collections/resolution.py
+++ b/cmsl1t/collections/resolution.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 import six
 import logging
 import numpy as np
-from rootpy.plotting import Hist
 
 import cmsl1t.geometry as geo
 from cmsl1t.utils.iterators import pairwise
@@ -62,6 +61,7 @@ class ResolutionCollection(HistogramsByPileUpCollection):
             h[region].fill(x, w)
 
     def add_variable(self, variable, bins=[]):
+        from rootpy.plotting import Hist
         if variable in self.keys():
             logger.warn('Variable {0} already exists!')
             return

--- a/cmsl1t/io/__init__.py
+++ b/cmsl1t/io/__init__.py
@@ -1,10 +1,9 @@
-from rootpy.io.pickler import dump
-
 
 def to_root(obj, output_file):
     '''
         Saves the obj into a ROOT file
     '''
+    from rootpy.io.pickler import dump
     # no pickles without dill
     import dill
     if not output_file.endswith('.root'):

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -9,17 +9,24 @@
    :members:
    :no-inherited-members:
 
-:mod:`cmsl1t.filters`:  Filters
+:mod:`cmsl1t.collections`:  Collections
 ===============================================
-.. automodule:: cmsl1t.filters
-  :members:
-  :no-inherited-members:
+.. automodule:: cmsl1t.collections
+   :members:
+   :no-inherited-members:
 
-  :mod:`cmsl1t.io`:  IO
-  ===============================================
-  .. automodule:: cmsl1t.io
-    :members:
-    :no-inherited-members:
+:mod:`cmsl1t.hist`:  Hist
+===============================================
+.. automodule:: cmsl1t.hist
+   :members:
+   :no-inherited-members:
+
+
+:mod:`cmsl1t.io`:  IO
+===============================================
+.. automodule:: cmsl1t.io
+   :members:
+   :no-inherited-members:
 
 :mod:`cmsl1t.plotting`:  Plotting
 ===============================================
@@ -28,11 +35,6 @@
    :no-members:
    :no-inherited-members:
 
-:mod:`cmsl1t.collections`:  Collections
-===============================================
-.. automodule:: cmsl1t.collections
-   :members:
-   :no-inherited-members:
 
 :mod:`cmsl1t.playground`:  Playground
 ===============================================
@@ -40,10 +42,16 @@
   :members:
   :no-inherited-members:
 
-  :mod:`cmsl1t.utils`:  Utils
-  ===============================================
-  .. automodule:: cmsl1t.Utils
-    :members:
-    :no-inherited-members:
+:mod:`cmsl1t.recalc`:  Recalculations
+===============================================
+.. automodule:: cmsl1t.recalc
+   :members:
+   :no-inherited-members:
+
+:mod:`cmsl1t.utils`:  Utils
+===============================================
+.. automodule:: cmsl1t.utils
+  :members:
+  :no-inherited-members:
 
 .. currentmodule:: cmsl1t

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,17 @@
 
 import sys
 import os
-sys.path.insert(0, os.path.abspath("/vagrant"))
-# sys.path.append(os.path.abspath('.'))
+
+from os import path
+import datetime
+now = datetime.datetime.now()
+
+HERE = path.dirname(path.abspath(__file__))
+cmsl1t_root = path.abspath(path.join(HERE, path.pardir))
+
+# put cmsl1t at the front of sys.path
+sys.path.insert(0, cmsl1t_root)
+
 import cmsl1t
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,7 +1,7 @@
 CMS L1T Analysis Tutorial
 ********************************************
-
-.. include:: tutorial/getting_started.rst
-.. include:: tutorial/configuration.rst
-.. include:: tutorial/histograms.rst
-.. include:: tutorial/analyzers.rst
+.. toctree::
+   tutorial/getting_started.rst
+   tutorial/configuration.rst
+   tutorial/histograms.rst
+   tutorial/analyzers.rst


### PR DESCRIPTION
Currently, http://cms-l1t-analysis.readthedocs.io/en/latest/ is not building correctly as it fails to include `cmsl1t`.
This PR fixes the import, sorts the API docs and moves ROOT dependencies from import to run-time.