### PR TITLE
Config validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ run-benchmark:
 
 test: test-code flake8
 
+test-all: test-code-full flake8
+
 test-code:
 	@$(NOSETESTS) -v -A "not slow and not grid_access" -s test
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,10 @@ run-benchmark:
 test: test-code flake8
 
 test-code:
-	@$(NOSETESTS) -v -a '!slow' -s test
+	@$(NOSETESTS) -v -A "not slow and not grid_access" -s test
+
+test-code-full:
+	@$(NOSETESTS) -v -s test
 
 changelog:
 	@github_changelog_generator -u cms-l1t-offline -p cms-l1t-analysis --base docs/initial_changelog.md

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ voms-proxy-init --voms cms
 make setup
 ```
 
+### running tests
+Tests can be run either on an SL 6 machine or in the Vagrant box:
+```
+make test
+# if a grid proxy is provided (e.g. via voms-proxy-init --voms cms)
+# you can also run tests that require grid access:
+make test-all
+```
+
 ### running benchmark
 ```
 # install python requirements

--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -16,6 +16,16 @@ def get_unique_out_dir(outdir=None, revision=1):
         return get_unique_out_dir(outdir, revision + 1)
     return full_outdir
 
+def resolve_input_files(input_files):
+    from cmsl1t.utils.root_glob import glob
+    all_files = []
+    for f in input_files:
+        if '*' in f:
+            all_files.extend(glob(f))
+        else:
+            all_files.append(f)
+    return all_files
+
 
 class ConfigParser(object):
     SECTIONS = ['general', 'input', 'analysis', 'output']
@@ -25,6 +35,9 @@ class ConfigParser(object):
 
     def read(self, input_file):
         cfg = yaml.load(input_file)
+        self._read_config(cfg)
+
+    def _read_config(self, cfg):
         cfg['general'] = dict(version=cfg['version'], name=cfg['name'])
         del cfg['version'], cfg['name']
 
@@ -32,6 +45,7 @@ class ConfigParser(object):
             # TODO: improve
             raise IOError('Invalid config')
 
+        cfg['input']['files']=resolve_input_files(cfg['input']['files'])
         self.config = cfg
         self.__fill_output_template()
 

--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -29,6 +29,8 @@ while the title is meant to be used in string representations
 
 .. code-block:: yaml
 
+   input:
+     ...
      sample:
        name: Data
        title: 2016 Data
@@ -40,6 +42,8 @@ As the sample name and title, the trigger counterparts play a similar role.
 
 .. code-block:: yaml
 
+   input:
+     ...
      trigger:
        name: SingleMu
        title: Single Muon
@@ -62,6 +66,8 @@ These analyzers have to satisfy the same API as
 
 .. code-block:: yaml
 
+   analysis:
+     ...
      analyzers:
        - cmsl1t.analyzers.demo_analyzer
 
@@ -72,6 +78,8 @@ then be accessed by all analyzers.
 
 .. code-block:: yaml
 
+   analysis:
+     ...
      modifiers:
        - cmsl1t.recalc.met.l1MetNot28:
            in: event.caloTowers
@@ -86,6 +94,8 @@ events).
 
 .. code-block:: yaml
 
+   analysis:
+     ...
      progress_bar:
        report_every: 1000
      # or to switch it off
@@ -123,6 +133,7 @@ import logging
 from cmsl1t.utils import module
 from copy import deepcopy
 
+
 logger = logging.getLogger(__name__)
 TODAY = datetime.now().timetuple()
 
@@ -158,13 +169,24 @@ class ConfigParser(object):
         del cfg['version'], cfg['name']
 
         input_files = cfg['input']['files']
-        input_files = resolve_file_paths(input_files)
+        try:
+            input_files = resolve_file_paths(input_files)
+        except Exception, e:
+            msg = 'Could not resolve file paths:' + str(e)
+            logger.exception(msg)
+            raise IOError(msg)
         cfg['input']['files'] = input_files
         self.config = cfg
-        self.__fill_output_template()
 
         if not self.is_valid():
             msg = '\n'.join(self.config_errors)
+            logger.exception(msg)
+            raise IOError(msg)
+
+        try:
+            self.__fill_output_template()
+        except Exception, e:
+            msg = 'Could fill out output template:' + str(e)
             logger.exception(msg)
             raise IOError(msg)
 

--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -1,3 +1,119 @@
+'''
+YAML Config parser for cmsl1t
+A config file consists of muliple sections. The ``general`` section describes
+the version and name of the config.
+
+.. code-block:: yaml
+
+   general:
+     version: 0.0.1
+     name: Benchmark
+
+
+The input section describes the data that is to be processed and might be
+changed in the near future. The first
+subsection, ``files``, is a list of files that can be either relative paths,
+absolute paths or global paths (e.g. xrootd) and can include wildcards.
+
+.. code-block:: yaml
+
+   input:
+     files:
+       - data/L1Ntuple_*.root
+
+The second subsection, ``sample`` is used to describe the data: The name of the
+dataset, the title and the run number. The name is likely used in file and histogram names,
+while the title is meant to be used in string representations
+(e.g titles/legends of histograms). If pileup reweighting is required, the
+``pileup_file`` parameter needs to be set.
+
+.. code-block:: yaml
+
+     sample:
+       name: Data
+       title: 2016 Data
+       pileup_file: ""
+       run_number: 276243
+
+The trigger subsection describes which trigger is to be used for this dataset.
+As the sample name and title, the trigger counterparts play a similar role.
+
+.. code-block:: yaml
+
+     trigger:
+       name: SingleMu
+       title: Single Muon
+
+
+The ``analysis`` section describes which analyzers are to be run.
+Global parameters include flags and binning for the analyzers (``do_fit``,
+``pu_bins``). These can also be specified later separately for each analyzer if
+required.
+
+.. code-block:: yaml
+
+   analysis:
+     do_fit: False
+     pu_bins: 0,13,20,999
+
+The analyzers subsection of ``analysis`` is a list of all analyzers to be run.
+These analyzers have to satisfy the same API as
+``cmsl1t.analyzers.BaseAnalyzer`` and be visible in the `PYTHONPATH`.
+
+.. code-block:: yaml
+
+     analyzers:
+       - cmsl1t.analyzers.demo_analyzer
+
+Modifiers are a way to enrich the event content by attaching objects to the
+event itself. E.g. ``cmsl1t.recalc.l1MetNot28`` reads in ``event.caloTowers``
+and creates a new object, ``event.l1MetNot28``, that can be accessed by all
+analyzers.
+
+.. code-block:: yaml
+
+     modifiers:
+       - cmsl1t.recalc.l1MetNot28:
+           in: event.caloTowers
+           out: event.l1MetNot28
+       - cmsl1t.recalc.l1MetNot28HF:
+           in: event.caloTowers
+           out: event.l1MetNot28HF
+
+Next, you can specify if you want progress information (e.g. a progress bar)
+and how often this information is updated (``report_every`` in units of
+events).
+
+.. code-block:: yaml
+
+     progress_bar:
+       report_every: 1000
+     # or to switch it off
+     # progress_bar:
+     #   enable: False
+
+
+And finally the output section describes where the output, usually ROOT files,
+is stored. The ```template`` entry is composed of a list of paths that are
+joined to create the full output file. The template expects the following named
+parameters:
+
+* ``date``
+* ``sample_name``
+* ``run_number``
+* ``trigger_name``
+
+which are automatically filled by the config parser
+
+
+.. code-block:: yaml
+
+   output:
+     # template is a list here that is joined (os.path.join) in the config parser
+     template:
+        - benchmark/new
+        - "{date}_{sample_name}_run-{run_number}_{trigger_name}"
+'''
 from __future__ import print_function
 import yaml
 import os
@@ -69,7 +185,8 @@ class ConfigParser(object):
         hasValidSections = expectedSections == sections
         if hasValidSections is not True:
             msg = 'Configuration has missing or invalid sections.\n'
-            msg += self.__section_format(self.__compare_sections(expectedSections, sections))
+            msg += self.__section_format(
+                self.__compare_sections(expectedSections, sections))
             self.config_errors += [msg]
         return hasValidSections
 
@@ -119,6 +236,9 @@ class ConfigParser(object):
             date=date, sample_name=sample_name, trigger_name=trigger_name,
             run_number=run_number)
         cfg['output']['folder'] = get_unique_out_dir(ouput_folder)
+
+    def describe(self):
+        return __doc__
 
 
 if __name__ == '__main__':

--- a/cmsl1t/utils/module.py
+++ b/cmsl1t/utils/module.py
@@ -1,5 +1,6 @@
 from importlib import import_module
 
+
 def exists(module_name):
     try:
         import_module(module_name)

--- a/cmsl1t/utils/module.py
+++ b/cmsl1t/utils/module.py
@@ -1,0 +1,18 @@
+from importlib import import_module
+
+def exists(module_name):
+    try:
+        import_module(module_name)
+    except ImportError:
+        if '.' not in module_name:
+            return False
+        # check if it is a member of a module instead
+        tokens = module_name.split('.')
+        module_name = '.'.join(tokens[:-1])
+        try:
+            m = import_module(module_name)
+        except ImportError:
+            return False
+        return hasattr(m, tokens[-1])
+    else:
+        return True

--- a/cmsl1t/utils/root_glob.py
+++ b/cmsl1t/utils/root_glob.py
@@ -3,10 +3,10 @@ Reproduce the standard glob package behaviour but use TSystem to be able to
 query remote file systems, like xrootd
 """
 from __future__ import print_function
-from rootpy.ROOT import gSystem
 import glob as gl
 import os.path
 import fnmatch
+from rootpy.ROOT import gSystem
 
 
 def __directory_iter(directory):
@@ -25,9 +25,15 @@ def glob(pathname):
         return try_glob
 
     # If pathname does not contain a wildcard:
-    if not gl.has_magic(pathname):
-        return [pathname]
+    if not gl.has_magic(pathname) and not '://':
+        if os.path.exists(pathname):
+            return [pathname]
 
+    # otherwise try root
+    return glob_r(pathname)
+
+
+def glob_r(pathname):
     # Split the pathname into a directory and basename
     # (which should include the wild-card)
     dirname, basename = os.path.split(pathname)
@@ -58,16 +64,16 @@ if __name__ == "__main__":
     test_paths = [
         "data/*root",
         "data/L1Ntuple_test_3.root",
-        """root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/"""
-        """comm_trigger/L1Trigger/L1Menu2016/Stage2/"""
-        """l1t-integration-v88p1-CMSSW-8021/SingleMuon/"""
-        """crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"""
-        """161031_120512/0000/L1Ntuple_999.root""",
-        """root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/"""
-        """comm_trigger/L1Trigger/L1Menu2016/Stage2/"""
-        """l1t-integration-v88p1-CMSSW-8021/SingleMuon/"""
-        """crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"""
-        """161031_120512/0000/L1Ntuple_99*.root""",
+        "root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/"
+        "comm_trigger/L1Trigger/L1Menu2016/Stage2/"
+        "l1t-integration-v88p1-CMSSW-8021/SingleMuon/"
+        "crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"
+        "161031_120512/0000/L1Ntuple_999.root",
+        "root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/"
+        "comm_trigger/L1Trigger/L1Menu2016/Stage2/"
+        "l1t-integration-v88p1-CMSSW-8021/SingleMuon/"
+        "crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"
+        "161031_120512/0000/L1Ntuple_99*.root",
     ]
     for i, path in enumerate(test_paths):
         expanded = glob(path)

--- a/config/demo.yaml
+++ b/config/demo.yaml
@@ -44,10 +44,10 @@ analysis:
   analyzers:
     - cmsl1t.analyzers.demo_analyzer
   modifiers:
-    - cmsl1t.recalc.l1MetNot28:
+    - cmsl1t.recalc.met.l1MetNot28:
         in: event.caloTowers
         out: event.l1MetNot28
-    - cmsl1t.recalc.l1MetNot28HF:
+    - cmsl1t.recalc.met.l1MetNot28HF:
         in: event.caloTowers
         out: event.l1MetNot28HF
   progress_bar:

--- a/config/study_tower28_met.yaml
+++ b/config/study_tower28_met.yaml
@@ -44,10 +44,10 @@ analysis:
   analyzers:
     - cmsl1t.analyzers.study_tower28_met
   modifiers:
-    - cmsl1t.recalc.l1MetNot28:
+    - cmsl1t.recalc.met.l1MetNot28:
         in: event.caloTowers
         out: event.l1MetNot28
-    - cmsl1t.recalc.l1MetNot28HF:
+    - cmsl1t.recalc.met.l1MetNot28HF:
         in: event.caloTowers
         out: event.l1MetNot28HF
   progress_bar:

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -15,6 +15,13 @@
    :members:
    :no-inherited-members:
 
+:mod:`cmsl1t.config`:  ConfigParser
+===============================================
+.. automodule:: cmsl1t.config
+   :members:
+   :no-inherited-members:
+
+
 :mod:`cmsl1t.hist`:  Hist
 ===============================================
 .. automodule:: cmsl1t.hist

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pep8
 nose
 click
 click-log
+sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ nose
 click
 click-log
 sphinx
+pyfakefs

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -35,10 +35,10 @@ analysis:
   analyzers:
     - cmsl1t.analyzers.demo_analyzer
   modifiers:
-    - cmsl1t.recalc.l1MetNot28:
+    - cmsl1t.recalc.met.l1MetNot28:
         in: event.caloTowers
         out: event.l1MetNot28
-    - cmsl1t.recalc.l1MetNot28HF:
+    - cmsl1t.recalc.met.l1MetNot28HF:
         in: event.caloTowers
         out: event.l1MetNot28HF
   progress_bar:
@@ -93,6 +93,24 @@ def test_invalid_section():
             TEST_CONFIG.replace('analysis:', 'ryan:'))
         assert_raises(IOError, parser._read_config,
                       config_with_invalid_section)
+
+
+def test_invalid_analyzer():
+    with patch('glob.glob', glob.glob):
+        parser = ConfigParser()
+        config_with_invalid_analyzer = yaml.load(
+            TEST_CONFIG.replace('cmsl1t.analyzers.demo_analyzer', 'ben'))
+        assert_raises(IOError, parser._read_config,
+                      config_with_invalid_analyzer)
+
+
+def test_invalid_modifier():
+    with patch('glob.glob', glob.glob):
+        parser = ConfigParser()
+        config_with_invalid_analyzer = yaml.load(
+            TEST_CONFIG.replace('cmsl1t.recalc.met.l1MetNot28', 'olivier'))
+        assert_raises(IOError, parser._read_config,
+                      config_with_invalid_analyzer)
 
 
 def test_resolve_file_paths():

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,98 @@
+from cmsl1t.config import (ConfigParser, resolve_input_files)
+import yaml
+
+from nose.tools import (raises, assert_equal, assert_almost_equal,
+                        assert_raises, assert_true, assert_false)
+from nose import with_setup
+import pyfakefs.fake_filesystem as fake_fs
+import pyfakefs.fake_filesystem_glob as fake_glob
+
+try:
+    from unittest.mock import patch  # In Python 3, mock is built-in
+except ImportError:
+    from mock import patch
+
+TEST_CONFIG = """
+version: 0.0.1
+name: Benchmark
+
+input:
+  files:
+    - /tmp/l1t/L1Ntuple_*.root
+  sample:
+    name: Data
+    title: 2016 Data
+  trigger:
+    name: SingleMu
+    title: Single Muon
+  pileup_file: ""
+  run_number: 276243
+
+analysis:
+  do_fit: False
+  pu_type: 0PU12,13PU19,20PU
+  pu_bins: 0,13,20,999
+  analyzers:
+    - cmsl1t.analyzers.demo_analyzer
+  modifiers:
+    - cmsl1t.recalc.l1MetNot28:
+        in: event.caloTowers
+        out: event.l1MetNot28
+    - cmsl1t.recalc.l1MetNot28HF:
+        in: event.caloTowers
+        out: event.l1MetNot28HF
+  progress_bar:
+    report_every: 1000
+  # or to switch it off
+  # progress_bar:
+  #   enable: False
+
+output:
+  # template is a list here that is joined (os.path.join) in the config parser
+  template:
+     - benchmark/new
+     - "{date}_{sample_name}_run-{run_number}_{trigger_name}"
+"""
+
+
+# Create a faked file system
+fs = fake_fs.FakeFilesystem()
+
+# Do some setup on the faked file system
+fs.CreateFile('/tmp/l1t/L1Ntuple_1.root')
+fs.CreateFile('/tmp/l1t/L1Ntuple_2.root')
+fs.CreateFile('/tmp/l1t/L1Ntuple_3.root')
+
+glob = fake_glob.FakeGlobModule(fs)
+
+
+def setup_func():
+    "set up test fixtures"
+
+
+def teardown_func():
+    "tear down test fixtures"
+
+
+def test_general_section():
+    parser = ConfigParser()
+    parser._read_config(yaml.load(TEST_CONFIG))
+    assert_equal(parser.get('general', 'version'), '0.0.1')
+    assert_equal(parser.get('general', 'name'), 'Benchmark')
+
+
+def test_resolve_input_files():
+    with patch('glob.glob', glob.glob):
+        input_files = resolve_input_files(['/tmp/l1t/L1Ntuple_*.root'])
+        assert_equal(input_files, [
+                 '/tmp/l1t/L1Ntuple_1.root', '/tmp/l1t/L1Ntuple_2.root', '/tmp/l1t/L1Ntuple_3.root'])
+
+
+def test_input_section():
+    with patch('glob.glob', glob.glob):
+        parser = ConfigParser()
+        parser._read_config(yaml.load(TEST_CONFIG))
+        assert_equal(parser.get('input', 'files'), [
+                     '/tmp/l1t/L1Ntuple_1.root', '/tmp/l1t/L1Ntuple_2.root', '/tmp/l1t/L1Ntuple_3.root'])
+        assert_equal(parser.get('input', 'sample'), {
+                     'name': 'Data', 'title': '2016 Data'})

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -86,6 +86,15 @@ def test_general_section():
         assert_equal(parser.get('general', 'name'), 'Benchmark')
 
 
+def test_invalid_section():
+    with patch('glob.glob', glob.glob):
+        parser = ConfigParser()
+        config_with_invalid_section = yaml.load(
+            TEST_CONFIG.replace('analysis:', 'ryan:'))
+        assert_raises(IOError, parser._read_config,
+                      config_with_invalid_section)
+
+
 def test_resolve_file_paths():
     with patch('glob.glob', glob.glob):
         input_files = resolve_file_paths(['/tmp/l1t/L1Ntuple_*.root'])

--- a/test/utils/test_root_glob.py
+++ b/test/utils/test_root_glob.py
@@ -1,28 +1,51 @@
-import unittest
+from nose.tools import (raises, assert_equal, assert_almost_equal,
+                        assert_raises, assert_true, assert_false)
+from nose.plugins.attrib import attr
+
+
+import pyfakefs.fake_filesystem as fake_fs
+import pyfakefs.fake_filesystem_glob as fake_glob
+
+try:
+    from unittest.mock import patch  # In Python 3, mock is built-in
+except ImportError:
+    from mock import patch
+
 from cmsl1t.utils.root_glob import glob as root_glob
-from glob import glob as py_glob
+
+# Create a faked file system
+fs = fake_fs.FakeFilesystem()
+
+# Do some setup on the faked file system
+fs.CreateFile('/tmp/l1t/L1Ntuple_1.root')
+fs.CreateFile('/tmp/l1t/L1Ntuple_2.root')
+fs.CreateFile('/tmp/l1t/L1Ntuple_3.root')
+
+glob = fake_glob.FakeGlobModule(fs)
 
 
-class TestRootGlob(unittest.TestCase):
+def test_glob_local_single():
+    with patch('glob.glob', glob.glob):
+        filename = "/tmp/l1t/L1Ntuple_3.root"
+        assert_equal(root_glob(filename), [filename])
 
-    def test_glob_local_single(self):
-        filename = "data/L1Ntuple_test_3.root"
-        self.assertEqual([filename], root_glob(filename))
 
-    def test_glob_local_wildcard(self):
-        filename = "data/*root"
-        self.assertEqual(root_glob(filename), py_glob(filename))
+def test_glob_local_wildcard():
+    with patch('glob.glob', glob.glob):
+        filename = "/tmp/l1t/*.root"
+        from glob import glob as py_glob
+        assert_equal(root_glob(filename), py_glob(filename))
 
-#    def test_glob_xrootd_single(self):
-#       filename = """root://eoscms.cern.ch//eos/cms/store/group/"""
-#       """dpg_trigger/comm_trigger/L1Trigger/L1Menu2016/Stage2/"""
-#       """l1t-integration-v88p1-CMSSW-8021/SingleMuon/"""
-#       """crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"""
-#       """161031_120512/0000/L1Ntuple_999.root""",
 
-#    def test_glob_xrootd_wildcard(self):
-#       filename = """root://eoscms.cern.ch//eos/cms/store/group/"""
-#       """dpg_trigger/comm_trigger/L1Trigger/L1Menu2016/Stage2/"""
-#       """l1t-integration-v88p1-CMSSW-8021/SingleMuon/"""
-#       """crab_l1t-integration-v88p1-CMSSW-8021__SingleMuon_2016H_v2/"""
-#       """161031_120512/0000/L1Ntuple_99*.root"""
+@attr('grid_access')
+def test_glob_xrootd_single():
+    filename = "root://lcgse01.phy.bris.ac.uk///cms/store/PhEDEx_LoadTest07/"\
+        "LoadTest07_Debug_T2_UK_SGrid_Bristol/LoadTest07_SouthGrid_Bristol_3B"
+    assert_equal(root_glob(filename), [filename])
+
+
+@attr('grid_access')
+def test_glob_xrootd_wildcard():
+    filename = "root://lcgse01.phy.bris.ac.uk///cms/store/PhEDEx_LoadTest07/"\
+        "LoadTest07_Debug_T2_UK_SGrid_Bristol/*"
+    assert_equal(len(root_glob(filename)), 256)


### PR DESCRIPTION
In this PR I am adding validation functionality to the `cmsl1t.config.ConfigParser`.
This includes:
 - unit tests for the config parser
 - changes in the existing configs (2 had errors!)
 - documentation describing the configuration

On the side I've also added `sphinx` and `pyfakefs` to the project requirements and added `grid_access` attribute to the unit tests. It is now possible to test remote file systems if grid access is available (e.g. a valid grid proxy exists) with `make test-all`.