### PR TITLE
Say something when validation fails due to missing section

### DIFF
--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -264,6 +264,9 @@ class ConfigParser(object):
             if key in modules:
                 modules = modules[key]
             else:
+                msg = "Cannot find required config section: " 
+                msg += "::".join(config_keys)
+                self.config_errors.append(msg)
                 return False
         msg = []
         results = []

--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -264,7 +264,7 @@ class ConfigParser(object):
             if key in modules:
                 modules = modules[key]
             else:
-                msg = "Cannot find required config section: " 
+                msg = "Cannot find required config section: "
                 msg += "::".join(config_keys)
                 self.config_errors.append(msg)
                 return False


### PR DESCRIPTION
At the moment, if a required section is missing in a config file, the validation seems to die without any explanation.  This should solve the issue.