### PR TITLE
Handle L1NTuples without certain trees

### DIFF
--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -264,6 +264,9 @@ class ConfigParser(object):
             if key in modules:
                 modules = modules[key]
             else:
+                msg = "Cannot find required config section: " 
+                msg += "::".join(config_keys)
+                self.config_errors.append(msg)
                 return False
         msg = []
         results = []

--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -264,7 +264,7 @@ class ConfigParser(object):
             if key in modules:
                 modules = modules[key]
             else:
-                msg = "Cannot find required config section: " 
+                msg = "Cannot find required config section: "
                 msg += "::".join(config_keys)
                 self.config_errors.append(msg)
                 return False

--- a/cmsl1t/playground/eventreader.py
+++ b/cmsl1t/playground/eventreader.py
@@ -265,7 +265,7 @@ class EventReader(object):
             self._trees.append(chain)
 
     def __iter__(self):
-        for i, trees in enumerate(six.moves.zip(*self._trees)):
+        for trees in six.moves.zip(*self._trees):
             yield Event(self._names, trees)
 
 

--- a/cmsl1t/playground/eventreader.py
+++ b/cmsl1t/playground/eventreader.py
@@ -8,6 +8,7 @@ from jetfilters import defaultJetFilter
 from cmsl1t.playground.cache import CachedIndexedTree
 import ROOT
 from collections import namedtuple
+from exceptions import RuntimeError
 
 if 'L1TAnalysisDataformats.so' not in ROOT.gSystem.GetLibraries():
     ROOT.gSystem.Load('build/L1TAnalysisDataformats.so')
@@ -20,17 +21,16 @@ Met = namedtuple('Met', ['et', 'phi'])
 Mex = namedtuple('Mex', ['ex'])
 Mey = namedtuple('Mey', ['ey'])
 
-TREE_NAMES = [
-    'l1CaloTowerTree/L1CaloTowerTree',
-    'l1CaloTowerEmuTree/L1CaloTowerTree',
-    'l1JetRecoTree/JetRecoTree',
-    'l1MetFilterRecoTree/MetFilterRecoTree',
-    'l1MuonRecoTree/Muon2RecoTree',
-    'l1RecoTree/RecoTree',
-    'l1UpgradeTree/L1UpgradeTree',
-    'l1UpgradeEmuTree/L1UpgradeTree',
-]
-
+ALL_TREE = {
+    "caloTowers" : 'l1CaloTowerTree/L1CaloTowerTree',
+    "emuCaloTower" : 'l1CaloTowerEmuTree/L1CaloTowerTree',
+    "jetReco" : 'l1JetRecoTree/JetRecoTree',
+    "metFilterReco" : 'l1MetFilterRecoTree/MetFilterRecoTree',
+    "muonReco" : 'l1MuonRecoTree/Muon2RecoTree',
+    "recoTree" : 'l1RecoTree/RecoTree',
+    "upgrade" : 'l1UpgradeTree/L1UpgradeTree',
+    "emuUpgrade" : 'l1UpgradeEmuTree/L1UpgradeTree',
+}
 
 class Event(object):
 
@@ -46,37 +46,41 @@ class Event(object):
         sumTypes.kTotalEty: {'name': 'Mey', 'type': Mey},
     }
 
-    def __init__(self, trees):
+    def __init__(self, tree_names, trees):
         self._trees = trees
-        # add names, aliases?
-        # lets assume fixed for now:
-        self._caloTowers, self._emuCaloTower, self._jetReco,\
-            self._metFilterReco, self._muonReco, self._recoTree,\
-            self._upgrade, self._emuUpgrade = self._trees
-
-        self._caloTowers = CachedIndexedTree(
-            self._caloTowers.L1CaloTower, 'nTower')
-        self._emuCaloTower = CachedIndexedTree(
-            self._emuCaloTower.L1CaloTower, 'nTower')
-        self.muons = CachedIndexedTree(
-            self._muonReco.Muon, 'nMuons'
-        )
-        self._upgrade = self._upgrade.L1Upgrade
-        self._emuUpgrade = self._emuUpgrade.L1Upgrade
-
-        self._jets = []
-        for i in range(self._jetReco.Jet.nJets):
-            self._jets.append(Jet(self._jetReco.Jet, i))
-
-        self._l1Jets = [L1Jet(self._upgrade, i)
-                        for i in range(self._upgrade.nJets)]
-
-        self._l1EmuJets = [L1Jet(self._emuUpgrade, i)
-                           for i in range(self._emuUpgrade.nJets)]
-
+        for name, tree in zip(tree_names, trees):
+            setattr(self, "_"+name, tree)
         self._l1Sums = {}
-        self._readUpgradeSums()
-        self._readEmuUpgradeSums()
+
+        if "caloTowers" in tree_names:
+            self._caloTowers = CachedIndexedTree(
+                self._caloTowers.L1CaloTower, 'nTower')
+
+        if "emuCaloTowers" in tree_names:
+            self._emuCaloTower = CachedIndexedTree(
+                self._emuCaloTower.L1CaloTower, 'nTower')
+
+        if "muonReco" in tree_names:
+            self.muons = CachedIndexedTree(
+                self._muonReco.Muon, 'nMuons'
+            )
+
+        if "upgrade" in tree_names:
+            self._upgrade = self._upgrade.L1Upgrade
+            self._l1Jets = [L1Jet(self._upgrade, i)
+                            for i in range(self._upgrade.nJets)]
+            self._readUpgradeSums()
+
+        if "emuUpgrade" in tree_names:
+            self._emuUpgrade = self._emuUpgrade.L1Upgrade
+            self._l1EmuJets = [L1Jet(self._emuUpgrade, i)
+                               for i in range(self._emuUpgrade.nJets)]
+            self._readEmuUpgradeSums()
+
+        if "jetReco" in tree_names:
+            self._jets = []
+            for i in range(self._jetReco.Jet.nJets):
+                self._jets.append(Jet(self._jetReco.Jet, i))
 
     def _readUpgradeSums(self):
         self._readSums(self._upgrade, prefix='L1')
@@ -246,12 +250,19 @@ class EventReader(object):
             else:
                 input_files.append(f)
         # this is not efficient
-        self._trees = [TreeChain(name, input_files, cache=True, events=events)
-                       for name in TREE_NAMES]
+        self._trees = []
+        self._names = []
+        for name, path in ALL_TREE.iteritems():
+            try:
+                chain = TreeChain(path, input_files, cache=True, events=events)
+            except RuntimeError as e:
+                continue
+            self._names.append(name)
+            self._trees.append(chain)
 
     def __iter__(self):
-        for trees in six.moves.zip(*self._trees):
-            yield Event(trees)
+        for i, trees in enumerate(six.moves.zip(*self._trees)):
+            yield Event(self._names, trees)
 
 
 if __name__ == '__main__':

--- a/cmsl1t/playground/eventreader.py
+++ b/cmsl1t/playground/eventreader.py
@@ -9,6 +9,8 @@ from cmsl1t.playground.cache import CachedIndexedTree
 import ROOT
 from collections import namedtuple
 from exceptions import RuntimeError
+import logging
+logger = logging.getLogger(__name__)
 
 if 'L1TAnalysisDataformats.so' not in ROOT.gSystem.GetLibraries():
     ROOT.gSystem.Load('build/L1TAnalysisDataformats.so')
@@ -22,15 +24,16 @@ Mex = namedtuple('Mex', ['ex'])
 Mey = namedtuple('Mey', ['ey'])
 
 ALL_TREE = {
-    "caloTowers" : 'l1CaloTowerTree/L1CaloTowerTree',
-    "emuCaloTower" : 'l1CaloTowerEmuTree/L1CaloTowerTree',
-    "jetReco" : 'l1JetRecoTree/JetRecoTree',
-    "metFilterReco" : 'l1MetFilterRecoTree/MetFilterRecoTree',
-    "muonReco" : 'l1MuonRecoTree/Muon2RecoTree',
-    "recoTree" : 'l1RecoTree/RecoTree',
-    "upgrade" : 'l1UpgradeTree/L1UpgradeTree',
-    "emuUpgrade" : 'l1UpgradeEmuTree/L1UpgradeTree',
+    "caloTowers": 'l1CaloTowerTree/L1CaloTowerTree',
+    "emuCaloTower": 'l1CaloTowerEmuTree/L1CaloTowerTree',
+    "jetReco": 'l1JetRecoTree/JetRecoTree',
+    "metFilterReco": 'l1MetFilterRecoTree/MetFilterRecoTree',
+    "muonReco": 'l1MuonRecoTree/Muon2RecoTree',
+    "recoTree": 'l1RecoTree/RecoTree',
+    "upgrade": 'l1UpgradeTree/L1UpgradeTree',
+    "emuUpgrade": 'l1UpgradeEmuTree/L1UpgradeTree',
 }
+
 
 class Event(object):
 
@@ -49,7 +52,7 @@ class Event(object):
     def __init__(self, tree_names, trees):
         self._trees = trees
         for name, tree in zip(tree_names, trees):
-            setattr(self, "_"+name, tree)
+            setattr(self, "_" + name, tree)
         self._l1Sums = {}
 
         if "caloTowers" in tree_names:
@@ -255,7 +258,8 @@ class EventReader(object):
         for name, path in ALL_TREE.iteritems():
             try:
                 chain = TreeChain(path, input_files, cache=True, events=events)
-            except RuntimeError as e:
+            except RuntimeError:
+                logger.warn("Cannot find tree: {0} in input file".format(path))
                 continue
             self._names.append(name)
             self._trees.append(chain)


### PR DESCRIPTION
Sometimes we produce L1NTuples without specific trees, eg emulated objects which may or may not be included.  The current implementation expects all trees to be there.  This change will allow, at least in the event-reader, trees not to be in the files but the program continue.  

Should only be merged after PR #42.