### PR TITLE
Recalc method to match jets

### DIFF
--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -264,6 +264,9 @@ class ConfigParser(object):
             if key in modules:
                 modules = modules[key]
             else:
+                msg = "Cannot find required config section: " 
+                msg += "::".join(config_keys)
+                self.config_errors.append(msg)
                 return False
         msg = []
         results = []

--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -264,7 +264,7 @@ class ConfigParser(object):
             if key in modules:
                 modules = modules[key]
             else:
-                msg = "Cannot find required config section: " 
+                msg = "Cannot find required config section: "
                 msg += "::".join(config_keys)
                 self.config_errors.append(msg)
                 return False

--- a/cmsl1t/playground/eventreader.py
+++ b/cmsl1t/playground/eventreader.py
@@ -8,6 +8,7 @@ from jetfilters import defaultJetFilter
 from cmsl1t.playground.cache import CachedIndexedTree
 import ROOT
 from collections import namedtuple
+from exceptions import RuntimeError
 
 if 'L1TAnalysisDataformats.so' not in ROOT.gSystem.GetLibraries():
     ROOT.gSystem.Load('build/L1TAnalysisDataformats.so')
@@ -20,17 +21,16 @@ Met = namedtuple('Met', ['et', 'phi'])
 Mex = namedtuple('Mex', ['ex'])
 Mey = namedtuple('Mey', ['ey'])
 
-TREE_NAMES = [
-    'l1CaloTowerTree/L1CaloTowerTree',
-    'l1CaloTowerEmuTree/L1CaloTowerTree',
-    'l1JetRecoTree/JetRecoTree',
-    'l1MetFilterRecoTree/MetFilterRecoTree',
-    'l1MuonRecoTree/Muon2RecoTree',
-    'l1RecoTree/RecoTree',
-    'l1UpgradeTree/L1UpgradeTree',
-    'l1UpgradeEmuTree/L1UpgradeTree',
-]
-
+ALL_TREE = {
+    "caloTowers" : 'l1CaloTowerTree/L1CaloTowerTree',
+    "emuCaloTower" : 'l1CaloTowerEmuTree/L1CaloTowerTree',
+    "jetReco" : 'l1JetRecoTree/JetRecoTree',
+    "metFilterReco" : 'l1MetFilterRecoTree/MetFilterRecoTree',
+    "muonReco" : 'l1MuonRecoTree/Muon2RecoTree',
+    "recoTree" : 'l1RecoTree/RecoTree',
+    "upgrade" : 'l1UpgradeTree/L1UpgradeTree',
+    "emuUpgrade" : 'l1UpgradeEmuTree/L1UpgradeTree',
+}
 
 class Event(object):
 
@@ -46,37 +46,41 @@ class Event(object):
         sumTypes.kTotalEty: {'name': 'Mey', 'type': Mey},
     }
 
-    def __init__(self, trees):
+    def __init__(self, tree_names, trees):
         self._trees = trees
-        # add names, aliases?
-        # lets assume fixed for now:
-        self._caloTowers, self._emuCaloTower, self._jetReco,\
-            self._metFilterReco, self._muonReco, self._recoTree,\
-            self._upgrade, self._emuUpgrade = self._trees
-
-        self._caloTowers = CachedIndexedTree(
-            self._caloTowers.L1CaloTower, 'nTower')
-        self._emuCaloTower = CachedIndexedTree(
-            self._emuCaloTower.L1CaloTower, 'nTower')
-        self.muons = CachedIndexedTree(
-            self._muonReco.Muon, 'nMuons'
-        )
-        self._upgrade = self._upgrade.L1Upgrade
-        self._emuUpgrade = self._emuUpgrade.L1Upgrade
-
-        self._jets = []
-        for i in range(self._jetReco.Jet.nJets):
-            self._jets.append(Jet(self._jetReco.Jet, i))
-
-        self._l1Jets = [L1Jet(self._upgrade, i)
-                        for i in range(self._upgrade.nJets)]
-
-        self._l1EmuJets = [L1Jet(self._emuUpgrade, i)
-                           for i in range(self._emuUpgrade.nJets)]
-
+        for name, tree in zip(tree_names, trees):
+            setattr(self, "_"+name, tree)
         self._l1Sums = {}
-        self._readUpgradeSums()
-        self._readEmuUpgradeSums()
+
+        if "caloTowers" in tree_names:
+            self._caloTowers = CachedIndexedTree(
+                self._caloTowers.L1CaloTower, 'nTower')
+
+        if "emuCaloTowers" in tree_names:
+            self._emuCaloTower = CachedIndexedTree(
+                self._emuCaloTower.L1CaloTower, 'nTower')
+
+        if "muonReco" in tree_names:
+            self.muons = CachedIndexedTree(
+                self._muonReco.Muon, 'nMuons'
+            )
+
+        if "upgrade" in tree_names:
+            self._upgrade = self._upgrade.L1Upgrade
+            self._l1Jets = [L1Jet(self._upgrade, i)
+                            for i in range(self._upgrade.nJets)]
+            self._readUpgradeSums()
+
+        if "emuUpgrade" in tree_names:
+            self._emuUpgrade = self._emuUpgrade.L1Upgrade
+            self._l1EmuJets = [L1Jet(self._emuUpgrade, i)
+                               for i in range(self._emuUpgrade.nJets)]
+            self._readEmuUpgradeSums()
+
+        if "jetReco" in tree_names:
+            self._jets = []
+            for i in range(self._jetReco.Jet.nJets):
+                self._jets.append(Jet(self._jetReco.Jet, i))
 
     def _readUpgradeSums(self):
         self._readSums(self._upgrade, prefix='L1')
@@ -246,12 +250,19 @@ class EventReader(object):
             else:
                 input_files.append(f)
         # this is not efficient
-        self._trees = [TreeChain(name, input_files, cache=True, events=events)
-                       for name in TREE_NAMES]
+        self._trees = []
+        self._names = []
+        for name, path in ALL_TREE.iteritems():
+            try:
+                chain = TreeChain(path, input_files, cache=True, events=events)
+            except RuntimeError as e:
+                continue
+            self._names.append(name)
+            self._trees.append(chain)
 
     def __iter__(self):
-        for trees in six.moves.zip(*self._trees):
-            yield Event(trees)
+        for i, trees in enumerate(six.moves.zip(*self._trees)):
+            yield Event(self._names, trees)
 
 
 if __name__ == '__main__':

--- a/cmsl1t/playground/eventreader.py
+++ b/cmsl1t/playground/eventreader.py
@@ -9,6 +9,8 @@ from cmsl1t.playground.cache import CachedIndexedTree
 import ROOT
 from collections import namedtuple
 from exceptions import RuntimeError
+import logging
+logger = logging.getLogger(__name__)
 
 if 'L1TAnalysisDataformats.so' not in ROOT.gSystem.GetLibraries():
     ROOT.gSystem.Load('build/L1TAnalysisDataformats.so')
@@ -22,15 +24,16 @@ Mex = namedtuple('Mex', ['ex'])
 Mey = namedtuple('Mey', ['ey'])
 
 ALL_TREE = {
-    "caloTowers" : 'l1CaloTowerTree/L1CaloTowerTree',
-    "emuCaloTower" : 'l1CaloTowerEmuTree/L1CaloTowerTree',
-    "jetReco" : 'l1JetRecoTree/JetRecoTree',
-    "metFilterReco" : 'l1MetFilterRecoTree/MetFilterRecoTree',
-    "muonReco" : 'l1MuonRecoTree/Muon2RecoTree',
-    "recoTree" : 'l1RecoTree/RecoTree',
-    "upgrade" : 'l1UpgradeTree/L1UpgradeTree',
-    "emuUpgrade" : 'l1UpgradeEmuTree/L1UpgradeTree',
+    "caloTowers": 'l1CaloTowerTree/L1CaloTowerTree',
+    "emuCaloTower": 'l1CaloTowerEmuTree/L1CaloTowerTree',
+    "jetReco": 'l1JetRecoTree/JetRecoTree',
+    "metFilterReco": 'l1MetFilterRecoTree/MetFilterRecoTree',
+    "muonReco": 'l1MuonRecoTree/Muon2RecoTree',
+    "recoTree": 'l1RecoTree/RecoTree',
+    "upgrade": 'l1UpgradeTree/L1UpgradeTree',
+    "emuUpgrade": 'l1UpgradeEmuTree/L1UpgradeTree',
 }
+
 
 class Event(object):
 
@@ -49,7 +52,7 @@ class Event(object):
     def __init__(self, tree_names, trees):
         self._trees = trees
         for name, tree in zip(tree_names, trees):
-            setattr(self, "_"+name, tree)
+            setattr(self, "_" + name, tree)
         self._l1Sums = {}
 
         if "caloTowers" in tree_names:
@@ -255,7 +258,8 @@ class EventReader(object):
         for name, path in ALL_TREE.iteritems():
             try:
                 chain = TreeChain(path, input_files, cache=True, events=events)
-            except RuntimeError as e:
+            except RuntimeError:
+                logger.warn("Cannot find tree: {0} in input file".format(path))
                 continue
             self._names.append(name)
             self._trees.append(chain)

--- a/cmsl1t/recalc/jet_matching.py
+++ b/cmsl1t/recalc/jet_matching.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pprint
+
+def jet_match(jetlist1, jetlist2, max_R_to_match=0.5):
+
+    delta_R = _build_dR(jetlist1, jetlist2)
+    matched_jets = _run_jet_matching(delta_R, max_R_to_match)
+    return matched_jets
+
+def _build_dR(jetlist1, jetlist2):
+    n_jet1 = len(jetlist1)
+    n_jet2 = len(jetlist2)
+    jet1_eta = np.array([jet.eta for jet in jetlist1])
+    jet1_phi = np.array([jet.phi for jet in jetlist1])
+    jet2_eta = np.array([jet.eta for jet in jetlist2])
+    jet2_phi = np.array([jet.phi for jet in jetlist2])
+
+    jet1_eta = np.tile(jet1_eta,(n_jet2, 1))
+    jet1_phi = np.tile(jet1_phi,(n_jet2, 1))
+    jet2_eta = np.tile(jet2_eta,(n_jet1, 1)).T
+    jet2_phi = np.tile(jet2_phi,(n_jet1, 1)).T
+
+    delta_eta = jet1_eta - jet2_eta
+    delta_phi = jet1_phi - jet2_phi
+
+    return np.sqrt(delta_eta**2 + delta_phi**2)
+
+def _run_jet_matching(delta_R, max_R_to_match):
+    matched_jets = []
+    while True:
+        index = np.argmin(delta_R)
+        index = np.unravel_index(index, delta_R.shape)
+        min_dR = delta_R[index[0], index[1]]
+        if min_dR > max_R_to_match:
+            break
+        matched_jets.append(index)
+        delta_R[index[0], :] = np.inf
+        delta_R[:, index[1]] = np.inf
+        # Are there more pairings to test in the matrix?
+        if not np.any(np.isfinite(delta_R)):
+            break
+
+    return matched_jets

--- a/cmsl1t/recalc/jet_matching.py
+++ b/cmsl1t/recalc/jet_matching.py
@@ -1,11 +1,13 @@
 import numpy as np
 import pprint
 
+
 def jet_match(jetlist1, jetlist2, max_R_to_match=0.5):
 
     delta_R = _build_dR(jetlist1, jetlist2)
     matched_jets = _run_jet_matching(delta_R, max_R_to_match)
     return matched_jets
+
 
 def _build_dR(jetlist1, jetlist2):
     n_jet1 = len(jetlist1)
@@ -15,15 +17,16 @@ def _build_dR(jetlist1, jetlist2):
     jet2_eta = np.array([jet.eta for jet in jetlist2])
     jet2_phi = np.array([jet.phi for jet in jetlist2])
 
-    jet1_eta = np.tile(jet1_eta,(n_jet2, 1))
-    jet1_phi = np.tile(jet1_phi,(n_jet2, 1))
-    jet2_eta = np.tile(jet2_eta,(n_jet1, 1)).T
-    jet2_phi = np.tile(jet2_phi,(n_jet1, 1)).T
+    jet1_eta = np.tile(jet1_eta, (n_jet2, 1))
+    jet1_phi = np.tile(jet1_phi, (n_jet2, 1))
+    jet2_eta = np.tile(jet2_eta, (n_jet1, 1)).T
+    jet2_phi = np.tile(jet2_phi, (n_jet1, 1)).T
 
     delta_eta = jet1_eta - jet2_eta
     delta_phi = jet1_phi - jet2_phi
 
     return np.sqrt(delta_eta**2 + delta_phi**2)
+
 
 def _run_jet_matching(delta_R, max_R_to_match):
     matched_jets = []

--- a/test/recalc/test_jet_match.py
+++ b/test/recalc/test_jet_match.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+from nose.tools import assert_equal
+import numpy as np
+from cmsl1t.recalc.jet_matching import jet_match
+
+class Jet():
+    def __init__(self, eta, phi):
+        self.eta = eta
+        self.phi = phi
+
+jetlist_1 = [Jet(0, 0), Jet(2, 1.3)]
+jetlist_2 = [Jet(2.3, 1.3), Jet(0.1, 0)]
+jetlist_3 = jetlist_1 + [Jet(4, 3)]
+
+def test_jet_match_self():
+    matches = jet_match(jetlist_1, jetlist_1)
+    assert_equal(np.array(matches).shape, (len(jetlist_1), len(jetlist_1)))
+    assert_equal(set(matches), set([(i, i) for i in range(len(jetlist_1))]))
+
+def test_jet_match_similar():
+    matches = jet_match(jetlist_1, jetlist_2)
+    assert_equal(set(matches), set([(0, 1), (1, 0)]))
+
+def test_jet_match_different():
+    matches = jet_match(jetlist_1, jetlist_3)
+    assert_equal(len(matches), len(jetlist_1))

--- a/test/recalc/test_jet_match.py
+++ b/test/recalc/test_jet_match.py
@@ -3,23 +3,28 @@ from nose.tools import assert_equal
 import numpy as np
 from cmsl1t.recalc.jet_matching import jet_match
 
+
 class Jet():
     def __init__(self, eta, phi):
         self.eta = eta
         self.phi = phi
 
+
 jetlist_1 = [Jet(0, 0), Jet(2, 1.3)]
 jetlist_2 = [Jet(2.3, 1.3), Jet(0.1, 0)]
 jetlist_3 = jetlist_1 + [Jet(4, 3)]
+
 
 def test_jet_match_self():
     matches = jet_match(jetlist_1, jetlist_1)
     assert_equal(np.array(matches).shape, (len(jetlist_1), len(jetlist_1)))
     assert_equal(set(matches), set([(i, i) for i in range(len(jetlist_1))]))
 
+
 def test_jet_match_similar():
     matches = jet_match(jetlist_1, jetlist_2)
     assert_equal(set(matches), set([(0, 1), (1, 0)]))
+
 
 def test_jet_match_different():
     matches = jet_match(jetlist_1, jetlist_3)


### PR DESCRIPTION
Adds a simple method to match between two lists of jets, eg. online vs reconstructed.  
The algorithm works by pairing the closest jets in eta and phi (using a euclidean metric) until no jets remain in either list, or until the only jets that do remain are further apart than some limit, which defaults to dR < 0.5,

Code is in the cmsl1t/recalc sub-package, since I thought this was physics related, rather than in the utils subpackage which I thought was more for software-related functionality.  I'm happy to move it if recalc doesn't seem like an appropriate place.  

Unit tests are in place for the new code.

Should only be merged after #43; the diff here looks longer than it really is because this builds on that work.