### PR TITLE
Make proper use of TEfficiency

### DIFF
--- a/cmsl1t/hist/hist_collection.py
+++ b/cmsl1t/hist/hist_collection.py
@@ -14,8 +14,9 @@ logger = logging.getLogger(__name__)
 
 
 class HistCollectionView(object):
-    def __init__(self, hist_list):
+    def __init__(self, bin_indices, hist_list):
         self.histograms = hist_list
+        self.bin_indices = bin_indices
 
     def __getattr__(self, attr):
         return [getattr(hist, attr) for hist in self.histograms]
@@ -33,6 +34,10 @@ class HistCollectionView(object):
 
     def __len__(self):
         return len(self.histograms)
+
+    def items(self):
+        for bin_hist_pair in zip(self.bin_indices, self.histograms):
+            yield bin_hist_pair
 
 
 class HistogramCollection(object):
@@ -131,7 +136,7 @@ class HistogramCollection(object):
         '''
         bin_indices = self._find_bins(keys)
         objects = [self.get_bin_contents(bins) for bins in bin_indices]
-        return HistCollectionView(objects)
+        return HistCollectionView(bin_indices, objects)
 
     def shape(self):
         return self.shape


### PR DESCRIPTION
There was an issue before that the errors produced in the efficiency plotter were rubbish.  This fixes that by making proper use of TEfficiency.  

Previously I'd been nervous that there would be an issue when we try to combine the turn-ons produced in separate jobs eg. when running on the batch system.  Having looked into it though, this is taken care of by TEfficiency::Merge, so there should be no problem there.

I've also made sure the `fit_efficiency()` and `draw()` utilities can cope ok with this, before they were somewhat limited to the inputs that they could take.