### PR TITLE
WIP: Add a dirty batch submission script, for issue #58

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ pep8:
 	@pep8 --exclude=.git,external examples cmsl1t
 
 flake8:
-	@flake8 cmsl1t test --ignore=F401 --max-line-length=120
+	@flake8 cmsl1t test bin/cmsl1t{,_dirty_batch} --ignore=F401 --max-line-length=120
 
 # benchmarks
 NTUPLE_CFG := "legacy/Config/ntuple_cfg.h"

--- a/bin/cmsl1t
+++ b/bin/cmsl1t
@@ -61,6 +61,7 @@ def process_tuples(config, nevents, analyzers):
         if all(results) is not True:
             break
 
+
 @timerfunc_log_to(logger.info)
 def process_histogram_files(config, analyzers):
     # Open the histogram files
@@ -145,7 +146,7 @@ def check(results, analyzers, method):
 @click.option('-n', '--nevents', default=-1, help='Number of events to process.')
 @click.option('-r', '--reload-histograms', is_flag=True,
               help="Reload histograms from a file and skip the input tuples")
-@click.option('--hist-files',  default=None,
+@click.option('--hist-files', default=None,
               help="Provide a list of files to reload histograms from")
 @click_log.simple_verbosity_option()
 @click_log.init(__name__)
@@ -173,6 +174,7 @@ def load_analyzer(analyzer, config):
     module = import_module(name)
     logger.info("Successfully loaded analyzer:" + name)
     return module.Analyzer(config, **params)
+
 
 if __name__ == '__main__':
     analyze()

--- a/bin/cmsl1t_dirty_batch
+++ b/bin/cmsl1t_dirty_batch
@@ -1,0 +1,124 @@
+#! /usr/bin/env python
+
+from __future__ import print_function
+import click
+import click_log
+import yaml
+import os
+from cmsl1t.config import ConfigParser, get_unique_out_dir
+import htcondor
+import sys
+import math
+from textwrap import dedent
+
+class cmsl1t_batch_job(object):
+    def __init__(self, batch_directory):
+        setup_script = os.path.join(os.environ["PROJECT_ROOT"], "bin", "env.sh")
+
+        run_script_contents = dedent("""\
+        #! /bin/bash
+        source {setup_script}
+        cmsl1t $@
+        """).format(setup_script=setup_script)
+
+        self.run_script = os.path.realpath(os.path.join(batch_directory, "run_script.sh"))
+        with open(self.run_script, "w") as run_script:
+            run_script.write(run_script_contents)
+
+    def submit(self, config_files):
+        print("Will submit", len(config_files), "jobs")
+        schedd = htcondor.Schedd()
+        results = []
+        for cfg in config_files:
+            with schedd.transaction() as txn:
+                cfg = os.path.realpath(cfg)
+                job_cfg = dict(
+                        executable=self.run_script, 
+                        arguments="-c {}".format(cfg),
+                        )
+                sub = htcondor.Submit(job_cfg)
+                out = sub.queue(txn)
+                print(out)
+                results.append(out)
+        return results
+                
+
+@click.command()
+@click.option('-c', '--config_file', help='YAML style config file', type=click.File(), required=True)
+@click_log.simple_verbosity_option()
+@click_log.init(__name__)
+def run(config_file):
+    # Read the config file
+    config = ConfigParser()
+    config.read(config_file)
+
+    # Get the list of input files (we're going to run one of these per job)
+    input_ntuples = config.get('input', 'files')
+
+    # Get the output directory
+    output_directory = config.get('output', 'folder')
+    batch_dir = os.path.join(output_directory, "batch")
+    batch_dir = get_unique_out_dir(batch_dir)
+    batch_config_dir = os.path.join(batch_dir, "_configs")
+    print("Batch config files will be placed under:", batch_config_dir)
+    os.makedirs(batch_config_dir)
+
+    # Sort out a name for the batch config files
+    n_jobs = len(input_ntuples)
+    n_jobs_pad_width = int(math.log10(n_jobs)) + 1
+    batch_filename = os.path.basename(config_file.name)
+    batch_filename = list(os.path.splitext(batch_filename))
+    batch_filename.insert(1, "_{index}")
+    batch_filename = "".join(batch_filename)
+    batch_filename = os.path.join(batch_config_dir, batch_filename)
+
+    out_dir = "job_{index}"
+    out_dir = os.path.join(batch_dir, out_dir)
+
+    padding = "{{:0{}}}".format(n_jobs_pad_width)
+
+    # Prepare input jobs
+    job_configs = []
+    for i, ntuple in enumerate(input_ntuples):
+        padded_index = padding.format(i)
+
+        # Reset the input file list
+        config.config['input']['files'] = [os.path.realpath(ntuple)]
+
+        # Reset the output directory
+        config.config['output']['folder'] = out_dir.format(index=padded_index)
+
+        # Dump the config file
+        batch_file = batch_filename.format(index=padded_index)
+        config.dump(batch_file)
+
+        job_configs.append(batch_file)
+
+    # Now actually submit the jobs
+    submitter = cmsl1t_batch_job(batch_dir)
+    result = submitter.submit(job_configs)
+
+    if not all(result):
+        print("Error: submitting jobs failed...")
+        return False
+
+    # Finally dump the commands needed to run the next steps to screen:
+    next_steps = """
+    Jobs should be running on htcondor now.  To monitor their progress use:
+        
+        condor_q $USER
+
+    when all jobs are done, you can combine all results together with:
+
+        cmsl1t -c {cfg} -r --hist-files '{out_dir}/*.root'
+
+    ie. use the same config file given here, but reload hists from the intermediate root files.
+    """
+
+    print(next_steps.format(cfg=config_file.name,
+                            out_dir=out_dir.format(index="*")))
+
+    return True
+
+if __name__ == '__main__':
+    run()

--- a/bin/cmsl1t_dirty_batch
+++ b/bin/cmsl1t_dirty_batch
@@ -10,6 +10,9 @@ import htcondor
 import sys
 import math
 from textwrap import dedent
+import logging
+logger = logging.getLogger(__name__)
+
 
 class cmsl1t_batch_job(object):
     def __init__(self, batch_directory):
@@ -26,22 +29,19 @@ class cmsl1t_batch_job(object):
             run_script.write(run_script_contents)
 
     def submit(self, config_files):
-        print("Will submit", len(config_files), "jobs")
+        logger.info("Will submit", len(config_files), "jobs")
         schedd = htcondor.Schedd()
         results = []
         for cfg in config_files:
             with schedd.transaction() as txn:
                 cfg = os.path.realpath(cfg)
-                job_cfg = dict(
-                        executable=self.run_script, 
-                        arguments="-c {}".format(cfg),
-                        )
+                job_cfg = dict(executable=self.run_script,
+                               arguments="-c {}".format(cfg))
                 sub = htcondor.Submit(job_cfg)
                 out = sub.queue(txn)
-                print(out)
                 results.append(out)
         return results
-                
+
 
 @click.command()
 @click.option('-c', '--config_file', help='YAML style config file', type=click.File(), required=True)
@@ -60,7 +60,7 @@ def run(config_file):
     batch_dir = os.path.join(output_directory, "batch")
     batch_dir = get_unique_out_dir(batch_dir)
     batch_config_dir = os.path.join(batch_dir, "_configs")
-    print("Batch config files will be placed under:", batch_config_dir)
+    logger.info("Batch config files will be placed under:", batch_config_dir)
     os.makedirs(batch_config_dir)
 
     # Sort out a name for the batch config files
@@ -99,13 +99,13 @@ def run(config_file):
     result = submitter.submit(job_configs)
 
     if not all(result):
-        print("Error: submitting jobs failed...")
+        logger.error("Error: submitting jobs failed...")
         return False
 
     # Finally dump the commands needed to run the next steps to screen:
     next_steps = """
     Jobs should be running on htcondor now.  To monitor their progress use:
-        
+
         condor_q $USER
 
     when all jobs are done, you can combine all results together with:
@@ -115,10 +115,11 @@ def run(config_file):
     ie. use the same config file given here, but reload hists from the intermediate root files.
     """
 
-    print(next_steps.format(cfg=config_file.name,
-                            out_dir=out_dir.format(index="*")))
+    logger.info(next_steps.format(cfg=config_file.name,
+                                  out_dir=out_dir.format(index="*")))
 
     return True
+
 
 if __name__ == '__main__':
     run()

--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -235,7 +235,6 @@ class ConfigParser(object):
     def describe(self):
         return __doc__
 
-
     def dump(self, out_filename):
         # Remove contents that weren't in the actual input config file
         config = deepcopy(self.config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ click
 click-log
 sphinx
 pyfakefs
+htcondor


### PR DESCRIPTION
Needs some modifications to the config parser.

To run it, simply give the config file you wish to use:
```
cmsl1t_dirty_batch -c <config_file>
```
The same config parser used for the `cmsl1t` command then parses the config, and then for each input file, a new config file is made with only that input file.  Intermediate scripts and histograms are stored under a sub-directory of the requested output directory, eg:
```
<output_dir>
└── batch-v1
    ├── _configs
    │   ├── demo_0.yaml
    │   ├── demo_1.yaml
    │   └── demo_2.yaml
    ├── job_1
    │   └── hist_file.root
    ├── job_2
    │   └── hist_file.root
    └── run_script.sh
```

Finally, once everything has been submitted the command needed to produce histograms is displayed (future improvements might optionally make this script wait and then automatically run the next steps).