### PR TITLE
Get bsub batch submission working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ data/L1Ntuple_test_3.root:
 pep8:
 	@pep8 --exclude=.git,external examples cmsl1t
 
-flake8:
-	@flake8 cmsl1t test bin/cmsl1t{,_dirty_batch} --ignore=F401 --max-line-length=120
+flake8: 
+	flake8 $(shell file -p bin/* |awk -F: '/python.*text/{print $$1}') cmsl1t test --ignore=F401 --max-line-length=120
 
 # benchmarks
 NTUPLE_CFG := "legacy/Config/ntuple_cfg.h"

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ pep8:
 	@pep8 --exclude=.git,external examples cmsl1t
 
 flake8: 
-	flake8 $(shell file -p bin/* |awk -F: '/python.*text/{print $$1}') cmsl1t test --ignore=F401 --max-line-length=120
+	@flake8 $(shell file -p bin/* |awk -F: '/python.*text/{print $$1}') cmsl1t test --ignore=F401 --max-line-length=120
 
 # benchmarks
 NTUPLE_CFG := "legacy/Config/ntuple_cfg.h"

--- a/bin/cmsl1t
+++ b/bin/cmsl1t
@@ -76,14 +76,16 @@ def process_histogram_files(config, analyzers):
         logger.info(inputs)
 
     # Open the histogram file
-    results = []
+    results = {}
     for filename in inputs:
         for analyzer in analyzers:
+            if analyzer not in results:
+                results[analyzer] = True
             if analyzer.might_contain_histograms(filename):
-                results.append(analyzer.reload_histograms(filename))
+                results[analyzer] &= bool(analyzer.reload_histograms(filename))
 
     # Check for errors
-    return check(results, analyzers, 'process_histogram_files')
+    return check(results.values(), results.keys(), 'process_histogram_files')
 
 
 @timerfunc_log_to(logger.info)

--- a/bin/cmsl1t_dirty_batch
+++ b/bin/cmsl1t_dirty_batch
@@ -11,11 +11,15 @@ import sys
 import math
 from textwrap import dedent
 import logging
+import subprocess
 logger = logging.getLogger(__name__)
 
 
-class cmsl1t_batch_job(object):
-    def __init__(self, batch_directory):
+class cmsl1t_batch_job_htcondor(object):
+    run_script_name = "run_script.sh"
+
+    def __init__(self, batch_directory, debug):
+        self.debug = debug
         setup_script = os.path.join(os.environ["PROJECT_ROOT"], "bin", "env.sh")
 
         run_script_contents = dedent("""\
@@ -24,30 +28,102 @@ class cmsl1t_batch_job(object):
         cmsl1t $@
         """).format(setup_script=setup_script)
 
-        self.run_script = os.path.realpath(os.path.join(batch_directory, "run_script.sh"))
+        self.run_script = os.path.realpath(os.path.join(batch_directory, self.run_script_name))
         with open(self.run_script, "w") as run_script:
             run_script.write(run_script_contents)
+        os.chmod(self.run_script, 0777)
 
     def submit(self, config_files):
-        logger.info("Will submit", len(config_files), "jobs")
+        logger.info("Will submit %d jobs" % len(config_files))
         schedd = htcondor.Schedd()
         results = []
         for cfg in config_files:
             with schedd.transaction() as txn:
                 cfg = os.path.realpath(cfg)
-                job_cfg = dict(executable=self.run_script,
-                               arguments="-c {}".format(cfg))
+                job_cfg = dict(executable=self.run_script_name,
+                               arguments="-c {}".format(cfg),
+                               )
                 sub = htcondor.Submit(job_cfg)
                 out = sub.queue(txn)
                 results.append(out)
+        logger.info(dedent("""\
+        Jobs should be running on htcondor now.  To monitor their progress use:
+
+            condor_q $USER """))
+
         return results
+
+
+class cmsl1t_batch_job_bsub(object):
+    run_script_name = "run_script.sh"
+
+    def __init__(self, batch_directory, debug):
+        self.batch_directory = batch_directory
+        self.debug = debug
+        setup_script = os.path.join(os.environ["PROJECT_ROOT"], "bin", "env.sh")
+
+        run_script_contents = dedent("""\
+        #! /bin/bash
+        pushd {project_root}
+        source {setup_script}
+        popd
+        cmsl1t -c "$1"
+        """).format(project_root=os.environ["PROJECT_ROOT"], setup_script=setup_script)
+
+        self.run_script = os.path.realpath(os.path.join(batch_directory, self.run_script_name))
+        with open(self.run_script, "w") as run_script:
+            run_script.write(run_script_contents)
+        os.chmod(self.run_script, 0777)
+
+    def submit(self, config_files):
+        n_cfgs = str(len(config_files))
+        logger.info("Will submit %s jobs using bsub" % n_cfgs)
+
+        job_group = "/CMS-L1T--"
+        directory_name = os.path.basename(os.path.dirname(self.batch_directory))
+        job_group += directory_name.replace("/", "--")
+
+        results = []
+        for i, cfg in enumerate(config_files):
+            logger.info("submitting: " + cfg)
+            results.append(self._submit_one(cfg, job_group))
+
+        logger.info("    Check job status using:\n\n         bjobs -g {group}".format(group=job_group))
+        return results
+
+    def _submit_one(self, config, group=None):
+        # Prepare the args
+        args = ["bsub", "-q", "8nm"]
+        if group:
+            args += ["-g", group]
+        if not self.debug:
+            args += ["-eo", os.devnull, "-oo", os.devnull]
+        command = ' '.join([self.run_script, config])
+        args += [command]
+
+        try:
+            subprocess.check_output(args)
+        except subprocess.CalledProcessError as e:
+            msg = dedent("""\
+                    Error submitting to bsub.
+                    Output was:
+                       {e.output}
+
+                    Return code was:
+                       {e.returncode}""")
+            logger.error(msg.format(e=e))
+            return False
+        return True
 
 
 @click.command()
 @click.option('-c', '--config_file', help='YAML style config file', type=click.File(), required=True)
+@click.option('--debug/--no-debug', help='Debug mode for the job submission', default=False)
+@click.option('--batch', default="bsub", type=click.Choice(["bsub", "htcondor"]),
+              help='Select the job submission system to use')
 @click_log.simple_verbosity_option()
 @click_log.init(__name__)
-def run(config_file):
+def run(config_file, debug, batch):
     # Read the config file
     config = ConfigParser()
     config.read(config_file)
@@ -60,7 +136,7 @@ def run(config_file):
     batch_dir = os.path.join(output_directory, "batch")
     batch_dir = get_unique_out_dir(batch_dir)
     batch_config_dir = os.path.join(batch_dir, "_configs")
-    logger.info("Batch config files will be placed under:", batch_config_dir)
+    logger.info("Batch config files will be placed under: " + batch_config_dir)
     os.makedirs(batch_config_dir)
 
     # Sort out a name for the batch config files
@@ -95,7 +171,10 @@ def run(config_file):
         job_configs.append(batch_file)
 
     # Now actually submit the jobs
-    submitter = cmsl1t_batch_job(batch_dir)
+    if batch == "bsub":
+        submitter = cmsl1t_batch_job_bsub(batch_dir, debug)
+    elif batch == "htcondor":
+        submitter = cmsl1t_batch_job_htcondor(batch_dir, debug)
     result = submitter.submit(job_configs)
 
     if not all(result):
@@ -104,10 +183,6 @@ def run(config_file):
 
     # Finally dump the commands needed to run the next steps to screen:
     next_steps = """
-    Jobs should be running on htcondor now.  To monitor their progress use:
-
-        condor_q $USER
-
     when all jobs are done, you can combine all results together with:
 
         cmsl1t -c {cfg} -r --hist-files '{out_dir}/*.root'

--- a/bin/get_l1Analysis
+++ b/bin/get_l1Analysis
@@ -106,8 +106,8 @@ namespace l1t {
 
 
 # additional header needed by legacy for the enum EtSumType
-additional_header_url = 'https://raw.githubusercontent.com/cms-sw/cmssw/{0}/DataFormats/L1Trigger/interface/EtSum.h'.format(
-    CMSSW_BRANCH)
+additional_header_url = 'https://raw.githubusercontent.com/cms-sw/cmssw/{0}/DataFormats/L1Trigger/interface/EtSum.h'
+additional_header_url = additional_header_url.format(CMSSW_BRANCH)
 additional_header = 'EtSum.h'
 destination = 'external/DataFormats/L1Trigger/interface/'
 if not os.path.exists(destination):

--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -244,6 +244,9 @@ class ConfigParser(object):
         if 'hist_files' in config['input']:
             del config['input']['hist_files']
 
+        # copy the "general" section back to the top-level
+        config.update(config.get('general', {}))
+
         with open(out_filename, "w") as out_file:
             out_file.write(yaml.dump(config))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ click-log
 sphinx
 pyfakefs
 htcondor
+pyaml
+rootpy


### PR DESCRIPTION
This builds off the work from PR #60 (which was merged prematurely :p ) to get batch system running.
Since I've had issues using the htcondor python bindings and testing things, I've implemented things using LSF and the bsub command for now.  I'm hoping @kreczko can implement the htcondor aspects in a later date.

With this PR, the full chain using the batch system feels in place.  We probably want to revisit the way we identify the output directory, since at the moment there is no knowledge of the batch system with cmsl1t itself (all batch system code is for the moment inside the new `cmsl1t_dirty_batch` command, hopefully this will be farmed out to better locations of the codebase in the near future).

See #60 for more details on how this works.  In addition, two new command line options have been added:
 * `--batch` to specify which batch system to use (bsub or htcondor, when implemented)
 * `--debug` to enable debugging of the batch submission stages.

I've also fixed the flake8 tests in the makefile to pick up all bin/ python files, and test them for pep8 compliance, naturally this means some of those files have changes too to make them compliant.