### PR TITLE
Allow multiple wildcards with root_glob

### DIFF
--- a/test/utils/test_root_glob.py
+++ b/test/utils/test_root_glob.py
@@ -37,6 +37,13 @@ def test_glob_local_wildcard():
         assert_equal(root_glob(filename), py_glob(filename))
 
 
+def test_glob_local_multiple_wildcards():
+    with patch('glob.glob', glob.glob):
+        filename = "/tmp/l*/*.root"
+        from glob import glob as py_glob
+        assert_equal(root_glob(filename), py_glob(filename))
+
+
 @attr('grid_access')
 def test_glob_xrootd_single():
     filename = "root://lcgse01.phy.bris.ac.uk///cms/store/PhEDEx_LoadTest07/"\


### PR DESCRIPTION
I've back-ported the version of root_glob I added to central rootpy (and added our extra fixes, which should be pushed back to the rootpy version now as well...) so that we can put multiple globs in the filename paths.

Targeting this to weekly-checks branch but this should also be put onto master soon.