### PR TITLE
Add users' site packages directory to PYTHONPATH

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -73,6 +73,11 @@ else
   source activate cms
 fi
 
+# Capture the user's site-packages directory:
+USER_SITE_PACKAGES="$(python -c "import site; print site.USER_SITE")"
+# add project to PYTHONPATH
+PYTHONPATH="${USER_SITE_PACKAGES}:$PYTHONPATH"
+
 git submodule init
 git submodule update
 


### PR DESCRIPTION
We need to guarantee certain package versions are used, and for this we use `pip install --user` however, we don't currently force that the directory used to install these packages is added to the PYTHONPATH variable. This PR fixes this.

Targeting weekly-checks, but should be ported to Master shortly as well.