### PR TITLE
Add a generic 2D online vs offline quantity plotter

### DIFF
--- a/cmsl1t/hist/binning.py
+++ b/cmsl1t/hist/binning.py
@@ -1,5 +1,5 @@
 import bisect
-from exceptions import KeyError
+from exceptions import KeyError, IndexError
 from copy import deepcopy
 import logging
 
@@ -100,7 +100,7 @@ class Sorted(Base):
     import bisect
 
     def __init__(self, bin_edges, label, use_everything_bin=False):
-        Base.__init__(self, len(bin_edges), label,
+        Base.__init__(self, len(bin_edges) - 1, label,
                       use_everything_bin=use_everything_bin)
         self.bins = sorted(bin_edges)
 
@@ -114,7 +114,11 @@ class Sorted(Base):
         return [found_bin]
 
     def _bin_center(self, bin_index):
-        return (self.bins[bin_index + 1] + self.bins[bin_index]) * 0.5
+        try:
+            return (self.bins[bin_index + 1] + self.bins[bin_index]) * 0.5
+        except IndexError as e:
+            logger.error("Cannot get bin center for index " + str(bin_index))
+            raise e
 
 
 class GreaterThan(Base):

--- a/cmsl1t/plotting/onlineVsOffline.py
+++ b/cmsl1t/plotting/onlineVsOffline.py
@@ -18,7 +18,7 @@ class OnlineVsOffline(BasePlotter):
         self.offline_name = offline_name
 
     def create_histograms(self,
-                          online_title, offline_title, 
+                          online_title, offline_title,
                           pileup_bins, n_bins, low, high):
         """ This is not in an init function so that we can by-pass this in the
         case where we reload things from disk """
@@ -30,6 +30,7 @@ class OnlineVsOffline(BasePlotter):
         name = [self.online_name, self.offline_name, "pu_{pileup}"]
         name = "__".join(name)
         title = " ".join([self.online_name, "vs.", self.offline_name, "in PU bin: {pileup}"])
+        title = ";".join([title, self.offline_title, self.online_name])
         self.plots = HistogramCollection([self.pileup_bins],
                                          "Hist2D", n_bins, low, high, n_bins, low, high,
                                          name=name, title=title)

--- a/cmsl1t/plotting/onlineVsOffline.py
+++ b/cmsl1t/plotting/onlineVsOffline.py
@@ -1,0 +1,70 @@
+from __future__ import print_function
+from cmsl1t.plotting.base import BasePlotter
+from cmsl1t.hist.hist_collection import HistogramCollection
+from cmsl1t.hist.factory import HistFactory
+import cmsl1t.hist.binning as bn
+from cmsl1t.utils.draw import draw2D, label_canvas
+from cmsl1t.io import to_root
+
+from rootpy.plotting import Legend, HistStack
+from rootpy.context import preserve_current_style
+
+
+class OnlineVsOffline(BasePlotter):
+    def __init__(self, online_name, offline_name):
+        name = ["online_vs_offline", online_name, offline_name]
+        super(OnlineVsOffline, self).__init__("__".join(name))
+        self.online_name = online_name
+        self.offline_name = offline_name
+
+    def create_histograms(self,
+                          online_title, offline_title, 
+                          pileup_bins, n_bins, low, high):
+        """ This is not in an init function so that we can by-pass this in the
+        case where we reload things from disk """
+        self.online_title = online_title
+        self.offline_title = offline_title
+        self.pileup_bins = bn.Sorted(pileup_bins, "pileup",
+                                     use_everything_bin=True)
+
+        name = [self.online_name, self.offline_name, "pu_{pileup}"]
+        name = "__".join(name)
+        title = " ".join([self.online_name, "vs.", self.offline_name, "in PU bin: {pileup}"])
+        self.plots = HistogramCollection([self.pileup_bins],
+                                         "Hist2D", n_bins, low, high, n_bins, low, high,
+                                         name=name, title=title)
+        self.filename_format = name
+
+    def fill(self, pileup, offline, online):
+        self.plots[pileup].fill(offline, online)
+
+    def draw(self, with_fits=True):
+        for pileup in self.pileup_bins.iter_all():
+            plot = self.plots.get_bin_contents([pileup])
+            self.__do_draw(self.pileup_bins.get_bin_center(pileup), plot)
+
+    def __do_draw(self, pileup, hist):
+        with preserve_current_style():
+            # Draw each efficiency (with fit)
+            canvas = draw2D(hist, draw_args={"xtitle": self.offline_title,
+                                             "ytitle": self.online_title})
+            # Add labels
+            label_canvas()
+
+            # Save canvas to file
+            name = self.filename_format.format(pileup=pileup)
+            self.save_canvas(canvas, name)
+
+    def _is_consistent(self, new):
+        """
+        Check the two plotters are the consistent, so same binning and same axis names
+        """
+        return (self.pileup_bins.bins == new.pileup_bins.bins) and \
+               (self.online_name == new.online_name) and \
+               (self.offline_name == new.offline_name)
+
+    def _merge(self, other):
+        """
+        Merge another plotter into this one
+        """
+        self.plots += other.plots

--- a/cmsl1t/utils/draw.py
+++ b/cmsl1t/utils/draw.py
@@ -59,6 +59,15 @@ def root_palette(value, max, min=0):
     return gStyle.GetColorPalette(int(colour_index))
 
 
+def set_palette(palette):
+    if palette in __known_root_pallettes:
+        gStyle.SetPalette(getattr(ROOT, "k" + palette))
+        palette = root_palette
+    else:
+        raise RuntimeError("Unknown palette requested: " + palette)
+    return palette
+
+
 def __prepare_canvas(canvas_args):
     style = gStyle
     style.SetOptStat(0)
@@ -93,11 +102,7 @@ def __apply_colour_map(hists, colourmap, colour_values, change_colour):
     with preserve_current_style():
         # Resolve the requested palette if it's not a function
         if isinstance(colourmap, str):
-            if colourmap in __known_root_pallettes:
-                gStyle.SetPalette(getattr(ROOT, "k" + colourmap))
-                colourmap = root_palette
-            else:
-                raise RuntimeError("Unknown palette requested: " + colourmap)
+            colourmap = set_palette(colourmap)
 
         # Set the colour of each hist
         max = len(hists)
@@ -137,6 +142,19 @@ def draw(hists, colourmap="RainBow", colour_values=None,
     axis_hist.title = ""
 
     r_draw(hists, canvas, xaxis=xaxis, yaxis=yaxis, **draw_args)
+    return canvas
+
+
+def draw2D(hist2d, colourmap="RainBow", canvas_args={}, draw_args={}):
+    canvas, style = __prepare_canvas(canvas_args)
+    if isinstance(colourmap, str):
+        colourmap = set_palette(colourmap)
+    hist2d.title = ""
+    hist2d.Draw(draw_args.get("opts", "colz"))
+    if "xtitle" in draw_args:
+        hist2d.GetXaxis().SetTitle(draw_args["xtitle"])
+    if "ytitle" in draw_args:
+        hist2d.GetYaxis().SetTitle(draw_args["ytitle"])
     return canvas
 
 


### PR DESCRIPTION
This adds the sort of generic plotter needed to complete the weekly-checks described on issue #65.  I've tested this on only a few events and it looks ok, and plots reasonable.  
This PR also fixes a small bug in the `Sorted` binning class, that impacted iterating over all bins.

To do before this is merged:
* [ ] Display the titles on the actual plots
* [ ] Run on more events