### PR TITLE
Fix issue 71 and other aspects of the bin/cmsl1t* commands

### DIFF
--- a/bin/cmsl1t
+++ b/bin/cmsl1t
@@ -71,8 +71,8 @@ def process_histogram_files(config, analyzers):
     inputs = config.get('input', 'hist_files')
     logger.info("Inputs:")
     if len(inputs) > 10:
-        logger.info(inputs[:10], "... and",
-                    len(inputs) - 10, "more")
+        msg = inputs[:10], "... and " + str(len(inputs) - 10) + " more"
+        logger.info(msg)
     else:
         logger.info(inputs)
 

--- a/bin/cmsl1t_dirty_batch
+++ b/bin/cmsl1t_dirty_batch
@@ -116,20 +116,41 @@ class cmsl1t_batch_job_bsub(object):
         return True
 
 
+def prepare_input_file_groups(input_ntuples, files_per_job):
+    file_lists = []
+    current_list = []
+    for infile in input_ntuples:
+        if not infile.startswith("root:"):
+            infile = os.path.realpath(infile)
+        current_list.append(infile)
+
+        # Is the current list full?
+        if len(current_list) >= files_per_job:
+            file_lists.append(current_list)
+            current_list = []
+
+    # Even if the last list had fewer files than needed, make sure to use this too
+    if current_list:
+        file_lists.append(current_list)
+
+    return file_lists
+
+
 @click.command()
 @click.option('-c', '--config_file', help='YAML style config file', type=click.File(), required=True)
+@click.option('-f', '--files-per-job', help='Give each job this many files', type=int, default=1)
 @click.option('--debug/--no-debug', help='Debug mode for the job submission', default=False)
 @click.option('--batch', default="bsub", type=click.Choice(["bsub", "htcondor"]),
               help='Select the job submission system to use')
-@click_log.simple_verbosity_option()
-@click_log.init(__name__)
-def run(config_file, debug, batch):
+@click_log.simple_verbosity_option(logger)
+def run(config_file, debug, batch, files_per_job):
     # Read the config file
     config = ConfigParser()
     config.read(config_file)
 
-    # Get the list of input files (we're going to run one of these per job)
+    # Get the list of input files
     input_ntuples = config.get('input', 'files')
+    input_ntuples = prepare_input_file_groups(input_ntuples, files_per_job)
 
     # Get the output directory
     output_directory = config.get('output', 'folder')
@@ -155,11 +176,11 @@ def run(config_file, debug, batch):
 
     # Prepare input jobs
     job_configs = []
-    for i, ntuple in enumerate(input_ntuples):
+    for i, in_files in enumerate(input_ntuples):
         padded_index = padding.format(i)
 
         # Reset the input file list
-        config.config['input']['files'] = [os.path.realpath(ntuple)]
+        config.config['input']['files'] = in_files
 
         # Reset the output directory
         config.config['output']['folder'] = out_dir.format(index=padded_index)


### PR DESCRIPTION
This PR fixes the issue with click-log for cmsl1t_dirty_batch as documented on #71. 
In addition it fixes the cmsl1t command which had problems with the logging when more than 10 input files were given in the config.  It also adds the ability to send batch jobs with more than one input file per job, by providing an additional command line option to control this.