### PR TITLE
Fix reporting of errors when merging histograms together 

### DIFF
--- a/cmsl1t/analyzers/BaseAnalyzer.py
+++ b/cmsl1t/analyzers/BaseAnalyzer.py
@@ -69,7 +69,6 @@ class BaseAnalyzer(object):
         ok = all(results)
         return ok
 
-
     def write_histograms(self):
         """
         Called after all events have been read, so that histograms can be

--- a/cmsl1t/analyzers/BaseAnalyzer.py
+++ b/cmsl1t/analyzers/BaseAnalyzer.py
@@ -66,7 +66,9 @@ class BaseAnalyzer(object):
             for hist in self.all_plots:
                 indir = input_file.GetDirectory(hist.directory_name)
                 results.append(hist.from_root(indir))
-        return all(results)
+        ok = all(results)
+        return ok
+
 
     def write_histograms(self):
         """

--- a/cmsl1t/plotting/base.py
+++ b/cmsl1t/plotting/base.py
@@ -66,7 +66,7 @@ class BasePlotter(object):
         merged together with existing ones
         """
         reloaded = from_root(filename)
-        self.merge_in(reloaded)
+        return self.merge_in(reloaded)
 
     def merge_in(self, reloaded):
         # Have already been initialised, so merge this in

--- a/cmsl1t/plotting/efficiency.py
+++ b/cmsl1t/plotting/efficiency.py
@@ -168,3 +168,4 @@ class EfficiencyPlot(BasePlotter):
         Merge another plotter into this one
         """
         self.efficiencies += other.efficiencies
+        return self.efficiencies

--- a/cmsl1t/plotting/onlineVsOffline.py
+++ b/cmsl1t/plotting/onlineVsOffline.py
@@ -69,3 +69,4 @@ class OnlineVsOffline(BasePlotter):
         Merge another plotter into this one
         """
         self.plots += other.plots
+        return self.plots


### PR DESCRIPTION
A lack of returned objects in several of the methods involved with merging histograms together was causing an error message to be printed inappropriately.