### PR TITLE
Add two more plotters for resolution

### DIFF
--- a/cmsl1t/plotting/efficiency.py
+++ b/cmsl1t/plotting/efficiency.py
@@ -159,10 +159,11 @@ class EfficiencyPlot(BasePlotter):
         """
         Check the two plotters are the consistent, so same binning and same axis names
         """
-        return (self.pileup_bins.bins == new.pileup_bins.bins) and \
-               (self.thresholds.bins == new.thresholds.bins) and \
-               (self.online_name == new.online_name) and \
-               (self.offline_name == new.offline_name)
+        return all([self.pileup_bins.bins == new.pileup_bins.bins,
+                    self.thresholds.bins == new.thresholds.bins,
+                    self.online_name == new.online_name,
+                    self.offline_name == new.offline_name,
+                    ])
 
     def _merge(self, other):
         """

--- a/cmsl1t/plotting/onlineVsOffline.py
+++ b/cmsl1t/plotting/onlineVsOffline.py
@@ -30,7 +30,7 @@ class OnlineVsOffline(BasePlotter):
         name = ["onlineVsOffline", self.online_name, self.offline_name, "pu_{pileup}"]
         name = "__".join(name)
         title = " ".join([self.online_name, "vs.", self.offline_name, "in PU bin: {pileup}"])
-        title = ";".join([title, self.offline_title, self.online_name])
+        title = ";".join([title, self.offline_title, self.online_title])
         self.plots = HistogramCollection([self.pileup_bins],
                                          "Hist2D", n_bins, low, high, n_bins, low, high,
                                          name=name, title=title)

--- a/cmsl1t/plotting/onlineVsOffline.py
+++ b/cmsl1t/plotting/onlineVsOffline.py
@@ -60,9 +60,10 @@ class OnlineVsOffline(BasePlotter):
         """
         Check the two plotters are the consistent, so same binning and same axis names
         """
-        return (self.pileup_bins.bins == new.pileup_bins.bins) and \
-               (self.online_name == new.online_name) and \
-               (self.offline_name == new.offline_name)
+        return all([self.pileup_bins.bins == new.pileup_bins.bins,
+                    self.online_name == new.online_name,
+                    self.offline_name == new.offline_name,
+                    ])
 
     def _merge(self, other):
         """

--- a/cmsl1t/plotting/onlineVsOffline.py
+++ b/cmsl1t/plotting/onlineVsOffline.py
@@ -27,7 +27,7 @@ class OnlineVsOffline(BasePlotter):
         self.pileup_bins = bn.Sorted(pileup_bins, "pileup",
                                      use_everything_bin=True)
 
-        name = [self.online_name, self.offline_name, "pu_{pileup}"]
+        name = ["onlineVsOffline", self.online_name, self.offline_name, "pu_{pileup}"]
         name = "__".join(name)
         title = " ".join([self.online_name, "vs.", self.offline_name, "in PU bin: {pileup}"])
         title = ";".join([title, self.offline_title, self.online_name])

--- a/cmsl1t/plotting/resolution.py
+++ b/cmsl1t/plotting/resolution.py
@@ -91,10 +91,11 @@ class ResolutionPlot(BasePlotter):
         """
         Check the two plotters are the consistent, so same binning and same axis names
         """
-        return (self.pileup_bins.bins == new.pileup_bins.bins) and \
-               (self.resolution_method == new.resolution_method) and \
-               (self.online_name == new.online_name) and \
-               (self.offline_name == new.offline_name)
+        return all([self.pileup_bins.bins == new.pileup_bins.bins,
+                    self.resolution_method == new.resolution_method,
+                    self.online_name == new.online_name,
+                    self.offline_name == new.offline_name,
+                    ])
 
     def _merge(self, other):
         """

--- a/cmsl1t/plotting/resolution.py
+++ b/cmsl1t/plotting/resolution.py
@@ -1,0 +1,105 @@
+from __future__ import print_function
+from cmsl1t.plotting.base import BasePlotter
+from cmsl1t.hist.hist_collection import HistogramCollection
+from cmsl1t.hist.factory import HistFactory
+import cmsl1t.hist.binning as bn
+from cmsl1t.utils.draw import draw, label_canvas
+from cmsl1t.recalc.resolution import get_resolution_function
+
+from rootpy.context import preserve_current_style
+from rootpy.plotting import Legend
+
+
+class ResolutionPlot(BasePlotter):
+    def __init__(self, resolution_type, online_name, offline_name):
+        name = ["resolution", online_name, offline_name]
+        super(ResolutionPlot, self).__init__("__".join(name))
+        self.online_name = online_name
+        self.offline_name = offline_name
+        self.resolution_method = get_resolution_function(resolution_type)
+
+
+    def create_histograms(self,
+                          online_title, offline_title,
+                          pileup_bins, n_bins, low, high):
+        """ This is not in an init function so that we can by-pass this in the
+        case where we reload things from disk """
+        self.online_title = online_title
+        self.offline_title = offline_title
+        self.pileup_bins = bn.Sorted(pileup_bins, "pileup",
+                                     use_everything_bin=True)
+
+        name = ["resolution", self.online_name, self.offline_name, "pu_{pileup}"]
+        name = "__".join(name)
+        title = " ".join([self.online_name, "vs.", self.offline_name, "in PU bin: {pileup}"])
+        title = ";".join([title, self.offline_title, self.online_name])
+        self.plots = HistogramCollection([self.pileup_bins],
+                                         "Hist1D", n_bins, low, high,
+                                         name=name, title=title)
+        self.filename_format = name
+
+    def fill(self, pileup, offline, online):
+        difference = self.resolution_method(online, offline)
+        self.plots[pileup].fill(difference)
+
+    def draw(self, with_fits=False):
+        hists = []
+        labels = []
+        fits = []
+        for (pile_up, ), hist  in self.plots.flat_items_all():
+            if pile_up == bn.Base.everything:
+                hist.linestyle = "dashed"
+                label = "Everything"
+            elif isinstance(pile_up, int):
+                hist.drawstyle = "EP"
+                label = "~ {:.0f}".format(self.pileup_bins.get_bin_center(pile_up))
+            else:
+                continue
+            hists.append(hist)
+            labels.append(label)
+            # if with_fits:
+            #     fits.append(self.fits.get_bin_contents([pile_up]))
+        self.__make_overlay(hists, fits, labels, "Number of events")
+
+        normed_hists = [ hist / hist.integral()  if hist.integral() != 0 else hist.Clone() for hist in hists]
+        self.__make_overlay(normed_hists, fits, labels, "Fraction of events", "__shapes")
+
+    def __make_overlay(self, hists, fits, labels, ytitle, suffix = ""):
+        with preserve_current_style():
+            # Draw each resolution (with fit)
+            xtitle = self.resolution_method.label.format(on=self.online_title, off=self.offline_title)
+            canvas = draw(hists, draw_args={"xtitle": xtitle, "ytitle": ytitle})
+            if fits:
+                for fit, hist in zip(fits, hists):
+                    fit["asymmetric"].linecolor = hist.GetLineColor()
+                    fit["asymmetric"].Draw("same")
+
+            # Add labels
+            label_canvas()
+
+            # Add a legend
+            legend = Legend(len(hists), header="Pile-up bin",
+                            topmargin=0.35, entryheight=0.035)
+            for hist, label in zip(hists, labels):
+                legend.AddEntry(hist, label)
+            legend.Draw()
+
+            # Save canvas to file
+            name = self.filename_format.format(pileup="all")
+            self.save_canvas(canvas, name + suffix)
+
+    def _is_consistent(self, new):
+        """
+        Check the two plotters are the consistent, so same binning and same axis names
+        """
+        return (self.pileup_bins.bins == new.pileup_bins.bins) and \
+               (self.resolution_method == new.resolution_method) and \
+               (self.online_name == new.online_name) and \
+               (self.offline_name == new.offline_name)
+
+    def _merge(self, other):
+        """
+        Merge another plotter into this one
+        """
+        self.plots += other.plots
+        return self.plots

--- a/cmsl1t/plotting/resolution.py
+++ b/cmsl1t/plotting/resolution.py
@@ -18,7 +18,6 @@ class ResolutionPlot(BasePlotter):
         self.offline_name = offline_name
         self.resolution_method = get_resolution_function(resolution_type)
 
-
     def create_histograms(self,
                           online_title, offline_title,
                           pileup_bins, n_bins, low, high):
@@ -46,7 +45,7 @@ class ResolutionPlot(BasePlotter):
         hists = []
         labels = []
         fits = []
-        for (pile_up, ), hist  in self.plots.flat_items_all():
+        for (pile_up, ), hist in self.plots.flat_items_all():
             if pile_up == bn.Base.everything:
                 hist.linestyle = "dashed"
                 label = "Everything"
@@ -61,10 +60,10 @@ class ResolutionPlot(BasePlotter):
             #     fits.append(self.fits.get_bin_contents([pile_up]))
         self.__make_overlay(hists, fits, labels, "Number of events")
 
-        normed_hists = [ hist / hist.integral()  if hist.integral() != 0 else hist.Clone() for hist in hists]
+        normed_hists = [hist / hist.integral() if hist.integral() != 0 else hist.Clone() for hist in hists]
         self.__make_overlay(normed_hists, fits, labels, "Fraction of events", "__shapes")
 
-    def __make_overlay(self, hists, fits, labels, ytitle, suffix = ""):
+    def __make_overlay(self, hists, fits, labels, ytitle, suffix=""):
         with preserve_current_style():
             # Draw each resolution (with fit)
             xtitle = self.resolution_method.label.format(on=self.online_title, off=self.offline_title)

--- a/cmsl1t/plotting/resolution.py
+++ b/cmsl1t/plotting/resolution.py
@@ -32,7 +32,7 @@ class ResolutionPlot(BasePlotter):
         name = ["resolution", self.online_name, self.offline_name, "pu_{pileup}"]
         name = "__".join(name)
         title = " ".join([self.online_name, "vs.", self.offline_name, "in PU bin: {pileup}"])
-        title = ";".join([title, self.offline_title, self.online_name])
+        title = ";".join([title, self.offline_title, self.online_title])
         self.plots = HistogramCollection([self.pileup_bins],
                                          "Hist1D", n_bins, low, high,
                                          name=name, title=title)

--- a/cmsl1t/plotting/resolution_vs_X.py
+++ b/cmsl1t/plotting/resolution_vs_X.py
@@ -70,11 +70,12 @@ class ResolutionVsXPlot(BasePlotter):
         """
         Check the two plotters are the consistent, so same binning and same axis names
         """
-        return (self.pileup_bins.bins == new.pileup_bins.bins) and \
-               (self.resolution_method == new.resolution_method) and \
-               (self.versus_name == new.versus_name) and \
-               (self.online_name == new.online_name) and \
-               (self.offline_name == new.offline_name)
+        return all([self.pileup_bins.bins == new.pileup_bins.bins,
+                    self.resolution_method == new.resolution_method,
+                    self.versus_name == new.versus_name,
+                    self.online_name == new.online_name,
+                    self.offline_name == new.offline_name,
+                    ])
 
     def _merge(self, other):
         """

--- a/cmsl1t/plotting/resolution_vs_X.py
+++ b/cmsl1t/plotting/resolution_vs_X.py
@@ -1,0 +1,84 @@
+from __future__ import print_function
+from cmsl1t.plotting.base import BasePlotter
+from cmsl1t.hist.hist_collection import HistogramCollection
+from cmsl1t.hist.factory import HistFactory
+import cmsl1t.hist.binning as bn
+from cmsl1t.utils.draw import draw2D, label_canvas
+from cmsl1t.recalc.resolution import get_resolution_function
+
+from rootpy.context import preserve_current_style
+from rootpy.plotting import Legend
+from rootpy import asrootpy
+
+
+class ResolutionVsXPlot(BasePlotter):
+    def __init__(self, resolution_type, online_name, offline_name, versus_name):
+        name = ["resolution_vs_" + versus_name, online_name, offline_name]
+        super(ResolutionVsXPlot, self).__init__("__".join(name))
+        self.online_name = online_name
+        self.offline_name = offline_name
+        self.versus_name = versus_name
+        self.resolution_method = get_resolution_function(resolution_type)
+
+    def create_histograms(self,
+                          online_title, offline_title, versus_title,
+                          pileup_bins, res_n_bins, res_low, res_high,
+                          vs_n_bins, vs_low, vs_high,
+                          ):
+        """ This is not in an init function so that we can by-pass this in the
+        case where we reload things from disk """
+        self.online_title = online_title
+        self.offline_title = offline_title
+        self.versus_title = versus_title
+        self.pileup_bins = bn.Sorted(pileup_bins, "pileup",
+                                     use_everything_bin=True)
+
+        name = ["resolution_vs", self.versus_name, self.online_name, self.offline_name, "pu_{pileup}"]
+        name = "__".join(name)
+        title = " ".join(["Resolution (", self.online_name, "vs.", self.offline_name,
+                          ") against", self.versus_name, "in PU bin: {pileup}"])
+        title = ";".join([title, self.offline_title, self.online_title])
+        self.plots = HistogramCollection([self.pileup_bins],
+                                         "Hist2D", vs_n_bins, vs_low, vs_high,
+                                         res_n_bins, res_low, res_high,
+                                         name=name, title=title)
+        self.filename_format = name
+
+    def fill(self, pileup, versus, offline, online):
+        difference = self.resolution_method(online, offline)
+        self.plots[pileup].fill(versus, difference)
+
+    def draw(self, with_fits=True):
+        for (pileup, ), hist in self.plots.flat_items_all():
+            self.__do_draw(pileup, hist)
+            self.__do_draw(pileup, asrootpy(hist.ProfileX()), "_profile")
+
+    def __do_draw(self, pileup, hist, suffix=""):
+        with preserve_current_style():
+            # Draw each efficiency (with fit)
+            ytitle = self.resolution_method.label.format(on=self.online_title, off=self.offline_title)
+            canvas = draw2D(hist, draw_args={"xtitle": self.versus_title, "ytitle": ytitle})
+
+            # Add labels
+            label_canvas()
+
+            # Save canvas to file
+            name = self.filename_format.format(pileup=pileup)
+            self.save_canvas(canvas, name + suffix)
+
+    def _is_consistent(self, new):
+        """
+        Check the two plotters are the consistent, so same binning and same axis names
+        """
+        return (self.pileup_bins.bins == new.pileup_bins.bins) and \
+               (self.resolution_method == new.resolution_method) and \
+               (self.versus_name == new.versus_name) and \
+               (self.online_name == new.online_name) and \
+               (self.offline_name == new.offline_name)
+
+    def _merge(self, other):
+        """
+        Merge another plotter into this one
+        """
+        self.plots += other.plots
+        return self.plots

--- a/cmsl1t/recalc/resolution.py
+++ b/cmsl1t/recalc/resolution.py
@@ -31,14 +31,14 @@ def resolution_energy(online, offline):
 
 def resolution_phi(online, offline):
     """
-    delta_phi = phi_on - phi_off 
-    but then wrap delta_phi, so abs(delta_phi) < pi 
+    delta_phi = phi_on - phi_off
+    but then wrap delta_phi, so abs(delta_phi) < pi
     and make sure the sign implies the same direction (anti-clockwise from on to off is positive)
     """
     delta_phi = _resolution_no_div(online, offline)
-    if delta_phi > pi: 
+    if delta_phi > pi:
         delta_phi -= twopi
-    delta_phi_other = delta_phi % twopi 
+    delta_phi_other = delta_phi % twopi
     delta_phi_ret = delta_phi if delta_phi_other > pi else delta_phi_other
     return delta_phi_ret
 

--- a/cmsl1t/recalc/resolution.py
+++ b/cmsl1t/recalc/resolution.py
@@ -1,0 +1,61 @@
+import numpy as np
+from exceptions import RuntimeError
+from math import pi, degrees
+twopi = 2 * pi
+
+
+def get_resolution_function(resolution_type):
+    if resolution_type.lower() == "energy":
+        return resolution_energy
+    elif resolution_type.lower() == "phi":
+        return resolution_phi
+    elif resolution_type.lower() == "eta":
+        return resolution_eta
+    elif resolution_type.lower() == "position_1d":
+        return resolution_position_1D
+    elif resolution_type.lower() == "position_2d":
+        return resolution_position_2D
+    msg = "Cannot find method for requested resolution_type, " + resolution_type
+    raise RuntimeError(msg)
+
+
+def resolution_energy(online, offline):
+    return _resolution_div_offline(online, offline)
+
+
+def resolution_phi(online, offline):
+    """
+    delta_phi = phi_on - phi_off 
+    but then wrap delta_phi, so abs(delta_phi) < pi 
+    and make sure the sign implies the same direction (anti-clockwise from on to off is positive)
+    """
+    delta_phi = _resolution_no_div(online, offline)
+    if delta_phi > pi: 
+        delta_phi -= twopi
+    delta_phi_other = delta_phi % twopi 
+    delta_phi_ret = delta_phi if delta_phi_other > pi else delta_phi_other
+    return delta_phi_ret
+
+
+def resolution_eta(online, offline):
+    return _resolution_no_div(online, offline)
+
+
+def resolution_position_1D(online, offline):
+    return _resolution_no_div(online, offline)
+
+
+def resolution_position_2D(online, offline):
+    return np.linalg.norm(np.array(online) - np.array(offline))
+
+
+def _resolution_div_offline(online, offline):
+    return (online - offline) / float(offline) if offline != 0 else float("NaN")
+
+
+def _resolution_div_online(online, offline):
+    return (online - offline) / float(online) if online != 0 else float("NaN")
+
+
+def _resolution_no_div(online, offline):
+    return online - offline

--- a/cmsl1t/recalc/resolution.py
+++ b/cmsl1t/recalc/resolution.py
@@ -6,17 +6,23 @@ twopi = 2 * pi
 
 def get_resolution_function(resolution_type):
     if resolution_type.lower() == "energy":
-        return resolution_energy
+        function = resolution_energy
+        function.label = "({on} - {off})/ {off}"
     elif resolution_type.lower() == "phi":
-        return resolution_phi
+        function = resolution_phi
     elif resolution_type.lower() == "eta":
-        return resolution_eta
+        function = resolution_eta
     elif resolution_type.lower() == "position_1d":
-        return resolution_position_1D
+        function = resolution_position_1D
     elif resolution_type.lower() == "position_2d":
-        return resolution_position_2D
-    msg = "Cannot find method for requested resolution_type, " + resolution_type
-    raise RuntimeError(msg)
+        function = resolution_position_2D
+        function.label = "|{on} - {off}|"
+    else:
+        msg = "Cannot find method for requested resolution_type, " + resolution_type
+        raise RuntimeError(msg)
+    if not hasattr(function, "label"):
+        function.label = "{on} - {off}"
+    return function
 
 
 def resolution_energy(online, offline):

--- a/test/recalc/test_resolution.py
+++ b/test/recalc/test_resolution.py
@@ -12,7 +12,7 @@ def test_get_resolution_function():
     assert_equal(funcs.get_resolution_function("eta"), funcs.resolution_eta)
     assert_equal(funcs.get_resolution_function("position_1D"), funcs.resolution_position_1D)
     assert_equal(funcs.get_resolution_function("position_2D"), funcs.resolution_position_2D)
-    assert_raises(RuntimeError, funcs.get_resolution_function,"gobbledygoop")
+    assert_raises(RuntimeError, funcs.get_resolution_function, "gobbledygoop")
 
 
 def test_resolution_energy():
@@ -53,4 +53,3 @@ def test_resolution_position_2D():
     assert_equal(funcs.resolution_position_2D([1, 1], [1, 1]), 0)
     assert_equal(funcs.resolution_position_2D([1, 1], [-1, -1]), 2 * sqrt(2))
     assert_equal(funcs.resolution_position_2D([1, 1], [1, -1]), 2)
-

--- a/test/recalc/test_resolution.py
+++ b/test/recalc/test_resolution.py
@@ -1,0 +1,56 @@
+from __future__ import print_function
+from nose.tools import assert_equal, assert_raises, assert_almost_equal
+import numpy as np
+from math import radians, sqrt
+import cmsl1t.recalc.resolution as funcs
+from exceptions import RuntimeError
+
+
+def test_get_resolution_function():
+    assert_equal(funcs.get_resolution_function("energy"), funcs.resolution_energy)
+    assert_equal(funcs.get_resolution_function("phi"), funcs.resolution_phi)
+    assert_equal(funcs.get_resolution_function("eta"), funcs.resolution_eta)
+    assert_equal(funcs.get_resolution_function("position_1D"), funcs.resolution_position_1D)
+    assert_equal(funcs.get_resolution_function("position_2D"), funcs.resolution_position_2D)
+    assert_raises(RuntimeError, funcs.get_resolution_function,"gobbledygoop")
+
+
+def test_resolution_energy():
+    assert_equal(funcs.resolution_energy(10, 100), -0.9)
+    assert_equal(funcs.resolution_energy(100, 10), 9.)
+    assert_equal(funcs.resolution_energy(100, 100), 0)
+    assert_equal(funcs.resolution_energy(0, 100), -1)
+    assert_equal(str(funcs.resolution_energy(0, 0)).lower(), "nan")
+
+
+def test_resolution_phi():
+    assert_almost_equal(funcs.resolution_phi(radians(10), radians(100)), radians(-90))
+    assert_almost_equal(funcs.resolution_phi(radians(100), radians(10)), radians(90))
+    assert_almost_equal(funcs.resolution_phi(radians(15), radians(340)), radians(35))
+    assert_almost_equal(funcs.resolution_phi(radians(340), radians(15)), radians(-35))
+    assert_almost_equal(funcs.resolution_phi(radians(300), radians(333)), radians(-33))
+
+
+def test_resolution_eta():
+    assert_equal(funcs.resolution_eta(radians(10), radians(90)), radians(-80))
+    assert_equal(funcs.resolution_eta(radians(-90), radians(10)), radians(-100))
+    assert_equal(funcs.resolution_eta(radians(0), radians(-90)), radians(90))
+    assert_equal(funcs.resolution_eta(radians(-90), radians(90)), radians(-180))
+    assert_equal(funcs.resolution_eta(radians(0), radians(0)), 0)
+
+
+def test_resolution_position_1D():
+    assert_equal(funcs.resolution_position_1D(10, 11), -1)
+    assert_equal(funcs.resolution_position_1D(100, -11), 111)
+    assert_equal(funcs.resolution_position_1D(0, -11), 11)
+    assert_equal(funcs.resolution_position_1D(0, 0), 0)
+
+
+def test_resolution_position_2D():
+    assert_equal(funcs.resolution_position_2D([1, 0], [0, 1]), sqrt(2))
+    assert_equal(funcs.resolution_position_2D([-1, 0], [0, 1]), sqrt(2))
+    assert_equal(funcs.resolution_position_2D([-1, 1], [0, 0]), sqrt(2))
+    assert_equal(funcs.resolution_position_2D([1, 1], [1, 1]), 0)
+    assert_equal(funcs.resolution_position_2D([1, 1], [-1, -1]), 2 * sqrt(2))
+    assert_equal(funcs.resolution_position_2D([1, 1], [1, -1]), 2)
+


### PR DESCRIPTION
This PR adds:
 * Recalc methods to deduce the resolution (difference between online and offline) for different quantities.
 * A plotter to plot the resolution distribution vs pile-up
 * A plotter to plot the resolution distributions against another variable (eg. eta or phi) in pile-up bins