### PR TITLE
[DO NOT MERGE] New EventReader and Producers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -103,3 +103,5 @@ external
 workspace
 data
 benchmark
+legacy
+output

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ external
 workspace
 data
 benchmark
+output

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ before_install:
   - docker pull hepsw/cvmfs-cms
 
 install:
- - sudo docker build -t cms-l1t-offline/cms-l1t-analysis -f ci/Dockerfile .
+ - cd ci
+ - sudo docker build -t cms-l1t-offline/cms-l1t-analysis .
+ - cd -
 
 script:
-  - sudo docker run -t -v $PWD:/analysis --privileged=true cms-l1t-offline/cms-l1t-analysis
+  - sudo docker run -t -v $PWD:/analysis --privileged cms-l1t-offline/cms-l1t-analysis
 cache: apt

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 PYTHON := $(shell which python)
 NOSETESTS := $(shell which nosetests)
+NOSE2 := $(shell which nose2)
 
 all: clean setup
 
@@ -76,6 +77,9 @@ test-all: test-code-full flake8
 
 test-code:
 	@$(NOSETESTS) -v -A "not slow and not grid_access" -s test
+	@echo ">> Running new-style tests"
+	@$(NOSE2) -v
+
 
 test-code-full:
 	@$(NOSETESTS) -v -s test

--- a/bin/cmsl1t
+++ b/bin/cmsl1t
@@ -202,5 +202,6 @@ def load_producer(producer, config):
     logger.info("Successfully loaded producer:" + name)
     return module.Producer(**params)
 
+
 if __name__ == '__main__':
     analyze()

--- a/bin/cmsl1t
+++ b/bin/cmsl1t
@@ -8,6 +8,7 @@ from cmsl1t.config import ConfigParser
 import click
 import click_log
 from importlib import import_module
+import yaml
 import logging
 logger = logging.getLogger(__name__)
 logging.getLogger("rootpy.tree.chain").setLevel(logging.WARNING)
@@ -23,7 +24,7 @@ section = '\n'.join(section)
 
 
 @timerfunc_log_to(logger.info)
-def process_tuples(config, nevents, analyzers):
+def process_tuples(config, nevents, analyzers, producers):
     # Open the data files
     logger.info(section.format("Loading data"))
 
@@ -39,8 +40,13 @@ def process_tuples(config, nevents, analyzers):
     else:
         logger.info(input_files)
 
-    from cmsl1t.playground.eventreader import EventReader
-    reader = EventReader(input_files, events=nevents)
+    ntuple_map_file = 'config/ntuple_content.yaml'
+    with open(ntuple_map_file) as f:
+        ntuple_map = yaml.load(f)
+    from cmsl1t.io.eventreader import EventReader
+    from cmsl1t.utils.module import load_L1TNTupleLibrary
+    load_L1TNTupleLibrary()
+    reader = EventReader(input_files, ntuple_map, nevents=nevents)
 
     results = [analyzer.prepare_for_events(reader) for analyzer in analyzers]
     check(results, analyzers, 'prepare_for_events')
@@ -56,6 +62,8 @@ def process_tuples(config, nevents, analyzers):
                 logger.info("{} of {}".format(entry, nevents))
             else:
                 logger.info("{} of <all>".format(entry))
+        results = [p.produce(event) for p in producers]
+        check(results, producers, 'produce')
         results = [analyzer.process_event(entry, event)
                    for analyzer in analyzers]
         check(results, analyzers, 'process_event')
@@ -108,12 +116,15 @@ def run(config, nevents, reload_histograms):
     analyzers = config.get('analysis', 'analyzers')
     analyzers = [load_analyzer(analyzer, config) for analyzer in analyzers]
 
+    producers = config.get('analysis', 'producers')
+    producers = [load_producer(producer, config) for producer in producers]
+
     if not reload_histograms:
         analysis_mode = config.try_get('analysis', 'mode', default='new')
         if analysis_mode == 'legacy':
             process_legacy(config, nevents, analyzers)
         else:
-            process_tuples(config, nevents, analyzers)
+            process_tuples(config, nevents, analyzers, producers)
     else:
         process_histogram_files(config, analyzers)
 
@@ -177,6 +188,19 @@ def load_analyzer(analyzer, config):
     logger.info("Successfully loaded analyzer:" + name)
     return module.Analyzer(config, **params)
 
+
+def load_producer(producer, config):
+    name = producer
+    params = {}
+    if isinstance(producer, dict):
+        name = producer.keys()[0]
+        params = producer[name]
+    if 'params' not in params:
+        params['params'] = None
+    logger.info("Try loading producer:" + name)
+    module = import_module(name)
+    logger.info("Successfully loaded producer:" + name)
+    return module.Producer(**params)
 
 if __name__ == '__main__':
     analyze()

--- a/bin/cmsl1t_dirty_batch
+++ b/bin/cmsl1t_dirty_batch
@@ -64,7 +64,7 @@ class cmsl1t_batch_job_bsub(object):
         setup_script = os.path.join(os.environ["PROJECT_ROOT"], "bin", "env.sh")
 
         run_script_contents = dedent("""\
-        #! /bin/bash
+        #!/bin/bash
         pushd {project_root}
         source {setup_script}
         popd

--- a/bin/create-map-file
+++ b/bin/create-map-file
@@ -68,13 +68,10 @@ def convert_to_dict(trees):
 
 
 def getDefaultAliases(path, treeName, objName):
-    # full_path_alias = _full_path_alias(path, objName)
-    # default_alias = _default_alias(path, treeName, objName)
-    shorthand_alias = _shorthand_alias(path, treeName, objName)
     return [
-        # full_path_alias,
-        # default_alias,
-        shorthand_alias,
+        # full_path_alias(path, objName),
+        # default_alias(path, treeName, objName),
+        shorthand_alias(path, treeName, objName),
     ]
 
 

--- a/bin/create-map-file
+++ b/bin/create-map-file
@@ -9,6 +9,8 @@ import ROOT
 from rootpy.io import root_open
 from rootpy.tree import Tree
 from cmsl1t.utils.module import load_L1TNTupleLibrary
+from cmsl1t.io.mapfile import \
+    default_alias, full_path_alias, shorthand_alias
 import cmsl1t
 
 import yaml
@@ -63,38 +65,6 @@ def convert_to_dict(trees):
             branches={b: {} for b in tree['branches']},
         )
     return trees_dict
-
-
-def _full_path_alias(path, objName):
-    # path includes treeName
-    tokens = path.split('/')
-    tokens += objName.split('.')
-    return 'event.' + '_'.join(tokens)
-
-
-def _default_alias(path, treeName, objName):
-    tokens = []
-    if 'emu' in path.lower():
-        tokens.append('emu')
-    tokens.append(treeName)
-    tokens += objName.split('.')
-    return 'event.' + '_'.join(tokens)
-
-
-def _shorthand_alias(path, treeName, objName):
-    tokens = []
-    path_lower = path.lower()
-    obj_lower = objName.lower()
-    search_for = ['emu', 'bmt', 'emt', 'omt']
-    for s in search_for:
-        if s in path_lower or s in obj_lower:
-            tokens.append(s)
-    if 'event' in obj_lower:
-        tokens.append(objName.split('.')[-1])
-    else:
-        tokens += objName.split('.')[-2:]
-
-    return 'event.' + '_'.join(tokens)
 
 
 def getDefaultAliases(path, treeName, objName):

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,13 +1,13 @@
 FROM hepsw/cvmfs-cms
 
-MAINTAINER kreczko@cern.ch
+LABEL maintainer="kreczko@cern.ch"
 
 # mount /cvmfs/grid.cern.ch & /cvmfs/sft.cern.ch
 RUN mkdir -p /cvmfs/grid.cern.ch && mkdir -p /cvmfs/sft.cern.ch && \
     echo "grid.cern.ch /cvmfs/grid.cern.ch cvmfs defaults 0 0" >> /etc/fstab && \
     echo "sft.cern.ch /cvmfs/sft.cern.ch cvmfs defaults 0 0" >> /etc/fstab
 
-RUN yum install -y -q wget git
+RUN yum install -y -q wget git glibc-devel.i686 glibc-devel
 #RUN yum install -y -q glibc gcc && yum clean all
 RUN useradd cmsl1t
 RUN mkdir /analysis && chown -R cmsl1t /analysis
@@ -17,4 +17,4 @@ WORKDIR /analysis
 # need to execute env.sh and ntp setup in CMD
 # as CVMFS needs 'privileged' rights,
 # but cannot do that when building the container
-CMD ["/bin/bash", "-c", "source bin/env.sh;export PATH=~/.local/bin:$PATH;make setup;make test"]
+CMD ["/bin/bash", "-c", "ci/run_tests.sh"]

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -17,4 +17,4 @@ WORKDIR /analysis
 # need to execute env.sh and ntp setup in CMD
 # as CVMFS needs 'privileged' rights,
 # but cannot do that when building the container
-CMD ["/bin/bash", "-c", "source bin/env.sh;export PATH=~/.local/bin:$PATH;make test"]
+CMD ["/bin/bash", "-c", "source bin/env.sh;export PATH=~/.local/bin:$PATH;make setup;make test"]

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# set -x
+source bin/env.sh
+export PATH=~/.local/bin:$PATH
+make setup
+ls -l build
+make test

--- a/cmsl1t/__init__.py
+++ b/cmsl1t/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 import os
 from os import path
-import sys
 import logging
 
 __version__ = '0.1.1'

--- a/cmsl1t/analyzers/demo_analyzer.py
+++ b/cmsl1t/analyzers/demo_analyzer.py
@@ -1,25 +1,25 @@
 """
 Study the MET distibutions and various PUS schemes
 """
+from functools import partial
+import numpy as np
 
 from BaseAnalyzer import BaseAnalyzer
 from cmsl1t.collections import EfficiencyCollection
-from functools import partial
-import cmsl1t.recalc.met as recalc
-import numpy as np
 
 
 class Analyzer(BaseAnalyzer):
+
     def __init__(self, config, **kwargs):
         super(Analyzer, self).__init__("demo_analyzer", config)
 
         self.met_calcs = dict(
             RecalcL1EmuMETNot28=dict(
                 title="Emulated MET, |ieta|<28",
-                calculate=recalc.l1MetNot28),
+                attr='l1MetNot28'),
             RecalcL1EmuMETNot28HF=dict(
                 title="Emulated MET, |ieta|!=28",
-                calculate=recalc.l1MetNot28HF),
+                attr='l1MetNot28HF'),
         )
 
     def prepare_for_events(self, reader):
@@ -40,14 +40,14 @@ class Analyzer(BaseAnalyzer):
         return True
 
     def fill_histograms(self, entry, event):
-        pileup = event.nVertex
-        if pileup < 5 or not event.passesMETFilter():
+        pileup = event['Vertex_nVtx']
+        if pileup < 5 or not event.MetFilters_hbheNoiseFilter:
             return True
         self.efficiencies.set_pileup(pileup)
 
-        offlineMetBE = event.sums.caloMetBE
+        offlineMetBE = event.Sums_caloMetBE
         for name, config in self.met_calcs.items():
-            onlineMet = config['calculate'](event.caloTowers)
+            onlineMet = event[config['attr']]
             onlineMet = onlineMet.mag
             self.efficiencies.fill(name, offlineMetBE, onlineMet)
         return True

--- a/cmsl1t/analyzers/energy_sums_efficiencies.py
+++ b/cmsl1t/analyzers/energy_sums_efficiencies.py
@@ -3,16 +3,16 @@ Study the efficiencies of L1 energy sums
 """
 
 import math
-import ROOT
 import os
 import numpy as np
 from functools import partial
+
+import ROOT
 
 from cmsl1t.analyzers.BaseAnalyzer import BaseAnalyzer
 from cmsl1t.collections import EfficiencyCollection
 from cmsl1t.filters import muonfilter
 from cmsl1t.geometry import is_in_region
-from cmsl1t.recalc.met import recalcMET
 
 
 class Analyzer(BaseAnalyzer):
@@ -68,29 +68,32 @@ class Analyzer(BaseAnalyzer):
 
     def fill_histograms(self, entry, event):
         if self.triggerName == 'SingleMu':
-            if not muonfilter(event.muons):
+            if not muonfilter(event):
                 return True
-        if not event.passesMETFilter():
+        if not event['MetFilters_hbheNoiseFilter']:
             return True
 
-        pileup = event.nVertex
+        pileup = event['Vertex_nVtx']
         self.efficiencies.set_pileup(pileup)
 
-        l1MetBE = event.l1Sums['L1Met'].et
-        l1MetBERecalc = recalcMET(event.caloTowers).mag
+        l1MetBE = event.L1Upgrade_sumEt[event.energySumTypes['Met']]
+        l1MetBERecalc = event['l1MetBERecalc']
+        l1MetBERecalc = l1MetBERecalc.mag
 
-        l1MetBEEmu = event.l1Sums['L1EmuMet'].et
-        l1MetBERecalcEmu = recalcMET(event.emuCaloTowers).mag
+        l1MetBEEmu = event.emu_L1Upgrade_sumEt[event.energySumTypes['Met']]
+        l1MetBERecalcEmu =  event['l1MetBERecalcEmu']
+        l1MetBERecalcEmu = l1MetBERecalcEmu.mag
 
-        l1Htt = event.l1Sums['L1Htt'].et
+        l1Htt = event.L1Upgrade_sumEt[event.energySumTypes['Htt']]
 
-        offlineMetBE = event.sums.caloMetBE
-        recoHtt = event.sums.Ht
+        offlineMetBE = event.Sums_caloMetBE
+        recoHtt = event.Sums_Ht
 
         self.efficiencies.fill('metBE', offlineMetBE, l1MetBE)
         self.efficiencies.fill('metBERecalc', offlineMetBE, l1MetBERecalc)
         self.efficiencies.fill('metBEEmu', offlineMetBE, l1MetBEEmu)
-        self.efficiencies.fill('metBERecalcEmu', offlineMetBE, l1MetBERecalcEmu)
+        self.efficiencies.fill(
+            'metBERecalcEmu', offlineMetBE, l1MetBERecalcEmu)
 
         self.efficiencies.fill('htt', recoHtt, l1Htt)
 

--- a/cmsl1t/analyzers/energy_sums_efficiencies.py
+++ b/cmsl1t/analyzers/energy_sums_efficiencies.py
@@ -81,7 +81,7 @@ class Analyzer(BaseAnalyzer):
         l1MetBERecalc = l1MetBERecalc.mag
 
         l1MetBEEmu = event.emu_L1Upgrade_sumEt[event.energySumTypes['Met']]
-        l1MetBERecalcEmu =  event['l1MetBERecalcEmu']
+        l1MetBERecalcEmu = event['l1MetBERecalcEmu']
         l1MetBERecalcEmu = l1MetBERecalcEmu.mag
 
         l1Htt = event.L1Upgrade_sumEt[event.energySumTypes['Htt']]

--- a/cmsl1t/analyzers/jet_rates.py
+++ b/cmsl1t/analyzers/jet_rates.py
@@ -35,10 +35,10 @@ class Analyzer(BaseAnalyzer):
         return True
 
     def fill_histograms(self, entry, event):
-        pileup = event.nVertex
+        pileup = event['Vertex_nVtx']
         self.rates.set_pileup(pileup)
 
-        l1JetEts = [jet.et for jet in event._l1Jets]
+        l1JetEts = [jet['jetEt'] for jet in event.l1Jets]
         nJets = len(l1JetEts)
         if nJets == 0:
             return True

--- a/cmsl1t/analyzers/study_met.py
+++ b/cmsl1t/analyzers/study_met.py
@@ -5,11 +5,12 @@ Study the MET distibutions and various PUS schemes
 from BaseAnalyzer import BaseAnalyzer
 from cmsl1t.plotting.efficiency import EfficiencyPlot
 from functools import partial
-import cmsl1t.recalc.met as recalc
+import cmsl1t.producers.met as recalc
 import numpy as np
 
 
 class Analyzer(BaseAnalyzer):
+
     def __init__(self, config, **kwargs):
         super(Analyzer, self).__init__("study_met", config)
 
@@ -26,15 +27,17 @@ class Analyzer(BaseAnalyzer):
         return True
 
     def fill_histograms(self, entry, event):
-        pileup = event.nVertex
-        if pileup < 5 or not event.passesMETFilter():
+        pileup = event['Vertex_nVtx']
+        if pileup < 5 or not event.MetFilters_hbheNoiseFilter:
             return True
 
-        if len(event.caloTowers) <= 0:
-            return True
-
-        offlineMetBE = event.sums.caloMetBE
-        onlineMet = recalc.l1MetNot28(event.caloTowers).mag
+        offlineMetBE = event.Sums_caloMetBE
+        onlineMet = recalc.l1MetNot28(
+            event.L1CaloTower_iphi,
+            event.L1CaloTower_ieta,
+            event.L1CaloTower_iet,
+        )
+        onlineMet = onlineMet.mag
 
         self.eff_caloMET_BE.fill(pileup, offlineMetBE, onlineMet)
 

--- a/cmsl1t/analyzers/study_tower28_met.py
+++ b/cmsl1t/analyzers/study_tower28_met.py
@@ -5,7 +5,6 @@ Study the MET distibutions and various PUS schemes
 from BaseAnalyzer import BaseAnalyzer
 from cmsl1t.collections import EfficiencyCollection
 from functools import partial
-import cmsl1t.recalc.met as recalc
 from cmsl1t.filters import muonfilter
 import numpy as np
 
@@ -19,10 +18,10 @@ class Analyzer(BaseAnalyzer):
         self.met_calcs = dict(
             RecalcL1EmuMETNot28=dict(
                 title="Emulated MET, |ieta|<28",
-                calculate=recalc.l1MetNot28),
+                attr='l1MetNot28'),
             RecalcL1EmuMETNot28HF=dict(
                 title="Emulated MET, |ieta|!=28",
-                calculate=recalc.l1MetNot28HF),
+                attr='l1MetNot28HF'),
         )
 
     def prepare_for_events(self, reader):
@@ -45,17 +44,17 @@ class Analyzer(BaseAnalyzer):
 
     def fill_histograms(self, entry, event):
         if self.triggerName == 'SingleMu':
-            if not muonfilter(event.muons):
+            if not muonfilter(event):
                 return True
-        pileup = event.nVertex
-        if pileup < 5 or not event.passesMETFilter():
+        pileup = event['Vertex_nVtx']
+        if pileup < 5 or not event.MetFilters_hbheNoiseFilter:
             return True
 
         self.efficiencies.set_pileup(pileup)
 
-        offlineMetBE = event.sums.caloMetBE
+        offlineMetBE = event.Sums_caloMetBE
         for name, config in self.met_calcs.items():
-            onlineMet = config['calculate'](event.caloTowers)
+            onlineMet = event[config['attr']]
             onlineMet = onlineMet.mag
             self.efficiencies.fill(name, offlineMetBE, onlineMet)
         return True

--- a/cmsl1t/analyzers/weekly_analyzer.py
+++ b/cmsl1t/analyzers/weekly_analyzer.py
@@ -8,37 +8,53 @@ from cmsl1t.plotting.onlineVsOffline import OnlineVsOffline
 from cmsl1t.plotting.resolution import ResolutionPlot
 from cmsl1t.plotting.resolution_vs_X import ResolutionVsXPlot
 import cmsl1t.recalc.met as recalc
-from cmsl1t.playground.eventreader import Met, Sum
 from math import pi
 import pprint
 from collections import namedtuple
+from cmsl1t.producers.match import get_matched_l1_jet
 
 
 sum_types = ["HTT", "MHT", "MET_HF", "MET_noHF"]
 Sums = namedtuple("Sums", sum_types)
 
+Sum = namedtuple('Sum', ['et'])
+Met = namedtuple('Met', ['et', 'phi'])
+
 
 def ExtractSums(event):
-    offline = dict(HTT=Sum(event.sums.Ht),
-                   MHT=Met(event.sums.mHt, event.sums.mHtPhi),
-                   MET_HF=Met(event.sums.caloMet, event.sums.caloMetPhi),
-                   MET_noHF=Met(event.sums.caloMetBE, event.sums.caloMetPhiBE)
-                   )
-    online = dict(HTT=event.l1Sums["L1Htt"],
-                  MHT=event.l1Sums["L1Mht"],
-                  MET_HF=event.l1Sums["L1MetHF"],
-                  MET_noHF=event.l1Sums["L1Met"]
-                  )
+    offline = dict(
+        HTT=Sum(event.Sums_Ht),
+        MHT=Met(event.Sums_mHt, event.Sums_mHtPhi),
+        MET_HF=Met(event.Sums_caloMet, event.Sums_caloMetPhi),
+        MET_noHF=Met(event.Sums_caloMetBE, event.Sums_caloMetPhiBE),
+    )
+    online = dict(
+        HTT=Sum(event.L1Upgrade_sumEt[event.energySumTypes['Htt']]),
+        MHT=Met(
+            event.L1Upgrade_sumEt[event.energySumTypes['Mht']],
+            event.L1Upgrade_sumPhi[event.energySumTypes['Mht']],
+        ),
+        MET_HF=Met(
+            event.L1Upgrade_sumEt[event.energySumTypes['MetHF']],
+            event.L1Upgrade_sumPhi[event.energySumTypes['MetHF']],
+        ),
+        MET_noHF=Met(
+            event.L1Upgrade_sumEt[event.energySumTypes['Met']],
+            event.L1Upgrade_sumPhi[event.energySumTypes['Met']],
+        ),
+    )
     return online, offline
 
 
 class Analyzer(BaseAnalyzer):
+
     def __init__(self, config, **kwargs):
         super(Analyzer, self).__init__("study_met", config)
 
         for name in sum_types:
             eff_plot = EfficiencyPlot("online" + name, "offline" + name)
-            res_plot = ResolutionPlot("energy", "online" + name, "offline" + name)
+            res_plot = ResolutionPlot(
+                "energy", "online" + name, "offline" + name)
             twoD_plot = OnlineVsOffline("online" + name, "offline" + name)
             self.register_plotter(eff_plot)
             self.register_plotter(res_plot)
@@ -56,7 +72,8 @@ class Analyzer(BaseAnalyzer):
             setattr(self, name + "_res", res_plot)
             setattr(self, name + "_2D", twoD_plot)
 
-        self.res_vs_eta_CentralJets = ResolutionVsXPlot("energy", "onlineJet", "offlineJet", "offlineJet_eta")
+        self.res_vs_eta_CentralJets = ResolutionVsXPlot(
+            "energy", "onlineJet", "offlineJet", "offlineJet_eta")
         self.register_plotter(self.res_vs_eta_CentralJets)
 
     def prepare_for_events(self, reader):
@@ -67,8 +84,10 @@ class Analyzer(BaseAnalyzer):
         Config = namedtuple("Config", "name off_title on_title off_max on_max")
         HTT_cfg = Config("HTT", "Offline HTT", "Online HTT", 600, 600)
         MHT_cfg = Config("MHT", "Offline MHT", "Online MHT", 600, 600)
-        MET_HF_cfg = Config("MET_HF", "Offline MET with HF", "Calo MET with HF", 600, 600)
-        MET_noHF_cfg = Config("MET_noHF", "Offline MET no HF", "Calo MET no HF", 600, 600)
+        MET_HF_cfg = Config("MET_HF", "Offline MET with HF",
+                            "Calo MET with HF", 600, 600)
+        MET_noHF_cfg = Config(
+            "MET_noHF", "Offline MET no HF", "Calo MET no HF", 600, 600)
         cfgs = [HTT_cfg, MHT_cfg, MET_HF_cfg, MET_noHF_cfg]
         for cfg in cfgs:
             eff_plot = getattr(self, cfg.name + "_eff")
@@ -96,11 +115,11 @@ class Analyzer(BaseAnalyzer):
         return True
 
     def fill_histograms(self, entry, event):
-        if not event.passesMETFilter():
+        if not event['MetFilters_hbheNoiseFilter']:
             return True
 
         offline, online = ExtractSums(event)
-        pileup = event.nVertex
+        pileup = event['Vertex_nVtx']
 
         for name in sum_types:
             on = online[name]
@@ -114,10 +133,12 @@ class Analyzer(BaseAnalyzer):
                 getattr(self, name + "_phi_res").fill(pileup, off.phi, on.phi)
                 getattr(self, name + "_phi_2D").fill(pileup, off.phi, on.phi)
 
-        for recoJet in event.goodJets():
-            l1Jet = event.getMatchedL1Jet(recoJet)
+        l1Jets = event['l1Jets']
+        for recoJet in event.goodRecoJets:
+            l1Jet = get_matched_l1_jet(recoJet, l1Jets)
             if not l1Jet:
                 continue
-            self.res_vs_eta_CentralJets.fill(pileup, recoJet.eta, recoJet.etCorr, l1Jet.et)
+            self.res_vs_eta_CentralJets.fill(
+                pileup, recoJet.eta, recoJet.etCorr, l1Jet.jetEt)
 
         return True

--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -103,7 +103,7 @@ class ConfigParser(object):
         results = [self.validate_sections()]
         results += [self.validate_input_files()]
         results += [self.validate_analyzers()]
-        results += [self.validate_modifiers()]
+        results += [self.validate_producers()]
         return all(results)
 
     def validate_sections(self):
@@ -149,8 +149,8 @@ class ConfigParser(object):
     def validate_analyzers(self):
         return self.__validate_module_imports(['analysis', 'analyzers'])
 
-    def validate_modifiers(self):
-        return self.__validate_module_imports(['analysis', 'modifiers'])
+    def validate_producers(self):
+        return self.__validate_module_imports(['analysis', 'producers'])
 
     def __validate_module_imports(self, config_keys):
         modules = deepcopy(self.config)

--- a/cmsl1t/filters/__init__.py
+++ b/cmsl1t/filters/__init__.py
@@ -1,9 +1,12 @@
 
 
-def muonfilter(muons):
+def muonfilter(event, columns=['Muon_et', 'Muon_iso', 'Muon_isLooseMuon']):
     passes = False
-    for muon in muons:
-        if muon.pt > 20 and muon.iso <= 0.1 and bool(muon.isLooseMuon):
+    mPts = event[columns[0]]
+    mIsos = event[columns[1]]
+    mIDs = event[columns[2]]
+    for (pt, iso, mID) in zip(mPts, mIsos, mIDs):
+        if pt > 20 and iso <= 0.1 and bool(mID):
             passes = True
             break
     return passes

--- a/cmsl1t/filters/jets.py
+++ b/cmsl1t/filters/jets.py
@@ -1,0 +1,27 @@
+import cmsl1t.geometry as geo
+
+
+def jetFilterNoHF(jet):
+    '''
+        also a lot of potential for simplification
+    '''
+    isForwardJet = geo.is_in_region('HF', jet.eta)
+    innerJet = abs(jet.eta) <= 2.4
+    reject_if = [
+        jet.muMult != 0,
+        isForwardJet,
+        jet.nhef >= 0.9,
+        jet.pef >= 0.9,
+        jet.mef >= 0.8,
+        jet.allMult <= 1,
+        innerJet and jet.sumMult <= 0,
+        innerJet and jet.chef <= 0,
+        innerJet and jet.eef >= 0.9,
+    ]
+    if any(reject_if):
+        return False
+    return True
+
+
+def defaultJetFilter(jet):
+    return (abs(jet.eta) > 3.0 or jetFilterNoHF(jet)) and jet.etCorr > 30.

--- a/cmsl1t/io/eventreader.py
+++ b/cmsl1t/io/eventreader.py
@@ -1,11 +1,15 @@
 import logging
 import six
 
+import ROOT
 from rootpy.tree import TreeChain
 
 from cmsl1t.utils.root_glob import glob
+from cmsl1t.utils.module import load_L1TNTupleLibrary
 
+load_L1TNTupleLibrary()
 logger = logging.getLogger(__name__)
+sumTypes = ROOT.l1t.EtSum
 
 
 def _get_input_files(paths):
@@ -86,6 +90,18 @@ class EventReader(object):
 
 class Event(object):
 
+    energySumTypes = {
+        'Ett': sumTypes.kTotalEt,
+        'EttHF': sumTypes.kTotalEtHF,
+        'Htt': sumTypes.kTotalHt,
+        'HttHF': sumTypes.kTotalHtHF,
+        'Met': sumTypes.kMissingEt,
+        'MetHF': sumTypes.kMissingEtHF,
+        'Mht': sumTypes.kMissingHt,
+        'Mex': sumTypes.kTotalEtx,
+        'Mey': sumTypes.kTotalEty,
+    }
+
     def __init__(self, trees, mapping):
         self._map = mapping
         self._trees = trees
@@ -94,6 +110,9 @@ class Event(object):
     def __getattr__(self, name):
         if name in object.__getattribute__(self, '_cache'):
             return object.__getattribute__(self, '_cache')[name]
+
+        if not name in object.__getattribute__(self, '_map'):
+            return object.__getattribute__(self, name)
         treeName, treeAttr = object.__getattribute__(self, '_map')[name]
         tree = object.__getattribute__(self, '_trees')[treeName]
         obj = tree
@@ -104,3 +123,13 @@ class Event(object):
 
     def __getitem__(self, name):
         return object.__getattribute__(self, '__getattr__')(name)
+
+    def _map_energy_sums(self):
+        #TODO: use Event.energySumTypes to map
+        '''
+            event.L1Upgrade_sumEt[event.energySumTypes['Htt']]
+            to
+            event.L1Upgrade_sumEt_Htt
+            + EMU + phi
+        '''
+        pass

--- a/cmsl1t/io/eventreader.py
+++ b/cmsl1t/io/eventreader.py
@@ -125,7 +125,7 @@ class Event(object):
         return object.__getattribute__(self, '__getattr__')(name)
 
     def _map_energy_sums(self):
-        #TODO: use Event.energySumTypes to map
+        # TODO: use Event.energySumTypes to map
         '''
             event.L1Upgrade_sumEt[event.energySumTypes['Htt']]
             to

--- a/cmsl1t/io/eventreader.py
+++ b/cmsl1t/io/eventreader.py
@@ -111,7 +111,7 @@ class Event(object):
         if name in object.__getattribute__(self, '_cache'):
             return object.__getattribute__(self, '_cache')[name]
 
-        if not name in object.__getattribute__(self, '_map'):
+        if name not in object.__getattribute__(self, '_map'):
             return object.__getattribute__(self, name)
         treeName, treeAttr = object.__getattribute__(self, '_map')[name]
         tree = object.__getattribute__(self, '_trees')[treeName]

--- a/cmsl1t/io/eventreader.py
+++ b/cmsl1t/io/eventreader.py
@@ -1,0 +1,106 @@
+import logging
+import six
+
+from rootpy.tree import TreeChain
+
+from cmsl1t.utils.root_glob import glob
+
+logger = logging.getLogger(__name__)
+
+
+def _get_input_files(paths):
+    # TODO: move this replacement into cmsl1t.config
+    input_files = []
+    for p in paths:
+        if '*' in p:
+            input_files.extend(glob(p))
+        else:
+            input_files.append(p)
+    return input_files
+
+
+def _create_alias_map(ntuple_map):
+    '''
+        Translates the ntuple_map into a format that can more easily processed
+        for creating event attributes, e.g.
+        content:
+            <tree path>:
+                branches:
+                  <branchname>.<leafname>:
+                    aliases:
+                      - event.myAlias
+        to
+        {'myAlias': (<tree path>, <branchname>.<leafname>)}
+
+    '''
+    # TODO: move this replacement into cmsl1t.config
+    aliasMap = {}
+    trees = ntuple_map['content']
+    for treeName, content in trees.items():
+        for branchName, branchContent in content['branches'].items():
+            for alias in branchContent['aliases']:
+                tidyAlias = alias.replace('event.', '')
+                aliasMap[tidyAlias] = (treeName, branchName)
+    return aliasMap
+
+
+class EventReader(object):
+
+    def __init__(self, input_files, ntuple_map, nevents=-1):
+        '''
+            Reads ntuple_info as defined by bin/create-map-file
+        '''
+        self._treeNames = ntuple_map['content'].keys()
+        self._aliasMap = _create_alias_map(ntuple_map)
+        self.input_files = _get_input_files(input_files)
+        self.nevents = nevents
+        self._trees = {}
+        for alias in self._aliasMap:
+            if 'vertex' in alias.lower():
+                print(alias)
+
+        self._load_trees()
+
+    def _load_trees(self):
+        for treeName in self._treeNames:
+            try:
+                self._trees[treeName] = TreeChain(
+                    treeName,
+                    self.input_files,
+                    cache=True,
+                    events=self.nevents,
+                )
+            except RuntimeError:
+                logger.warn(
+                    "Cannot find tree: {0} in input file".format(treeName))
+                continue
+
+    def contains(self, name):
+        return name in self._aliasMap.keys()
+
+    def __iter__(self):
+        # event loop
+        for trees in six.moves.zip(*self._trees.itervalues()):
+            yield Event(self._trees, self._aliasMap)
+
+
+class Event(object):
+
+    def __init__(self, trees, mapping):
+        self._map = mapping
+        self._trees = trees
+        self._cache = {}
+
+    def __getattr__(self, name):
+        if name in object.__getattribute__(self, '_cache'):
+            return object.__getattribute__(self, '_cache')[name]
+        treeName, treeAttr = object.__getattribute__(self, '_map')[name]
+        tree = object.__getattribute__(self, '_trees')[treeName]
+        obj = tree
+        for attr in treeAttr.split('.'):
+            obj = getattr(obj, attr)
+        object.__getattribute__(self, '_cache')[name] = obj
+        return obj
+
+    def __getitem__(self, name):
+        return object.__getattribute__(self, '__getattr__')(name)

--- a/cmsl1t/io/mapfile.py
+++ b/cmsl1t/io/mapfile.py
@@ -1,0 +1,34 @@
+
+
+def full_path_alias(path, objName):
+    # path includes treeName
+    tokens = path.split('/')
+    tokens += objName.split('.')
+    return 'event.' + '_'.join(tokens)
+
+
+def default_alias(path, treeName, objName):
+    tokens = []
+    if 'emu' in path.lower():
+        tokens.append('emu')
+    tokens.append(treeName)
+    tokens += objName.split('.')
+    return 'event.' + '_'.join(tokens)
+
+
+def shorthand_alias(path, treeName, objName):
+    tokens = []
+    if 'emu' in path.lower():
+        tokens.append('emu')
+
+    search_for = ['bmt', 'emt', 'omt']
+    obj_lower = objName.lower()
+    for s in search_for:
+        if s in obj_lower:
+            tokens.append(s)
+    if 'event' in obj_lower:
+        tokens.append(objName.split('.')[-1])
+    else:
+        tokens += objName.split('.')[-2:]
+
+    return 'event.' + '_'.join(tokens)

--- a/cmsl1t/producers/jets.py
+++ b/cmsl1t/producers/jets.py
@@ -71,7 +71,7 @@ class Producer(object):
 
     def produce(self, event):
         if hasattr(event, self.outputCollection):
-            return
+            return True
         nJets = event[self.prefix + 'nJets']
         jets = []
         for i in range(nJets):
@@ -90,5 +90,4 @@ class Producer(object):
         )
 
         setattr(event, self.outputCollection, sorted_jets)
-        assert(hasattr(event, self.outputCollection))
         return True

--- a/cmsl1t/producers/jets.py
+++ b/cmsl1t/producers/jets.py
@@ -1,0 +1,94 @@
+from importlib import import_module
+
+DEFAULT_ATTRIBUTES = [
+    'etCorr', 'muMult', 'eta', 'phi', 'nhef', 'pef', 'mef', 'chMult',
+    'elMult', 'nhMult', 'phMult', 'chef', 'eef'
+]
+
+L1T_Jet_ATTRIBUTES = [
+    'jetEt', 'jetPhi', 'jetEta',
+]
+
+
+class Jet(object):
+    '''
+        Create a simple python wrapper for
+        L1Analysis::L1AnalysisRecoJetDataFormat
+    '''
+
+    def __init__(self, event, index, prefix='Jet_'):
+        global DEFAULT_ATTRIBUTES
+        # this could be simplified with a list of attributes
+        read_attributes = []
+        if not hasattr(event, prefix + DEFAULT_ATTRIBUTES[0]):
+            read_attributes[:] = L1T_Jet_ATTRIBUTES[:]
+            self.sortBy = 'jetEt'
+        else:
+            read_attributes[:] = DEFAULT_ATTRIBUTES[:]
+            self.sortBy = 'etCorr'
+        for attr in read_attributes:
+            setattr(self, attr, getattr(event, prefix + attr)[index])
+
+    @property
+    def sumMult(self):
+        return self.chMult + self.chMult + self.elMult
+        # not
+        # return self.chMult + self.muMult + self.elMult ?
+
+    @property
+    def allMult(self):
+        return self.sumMult + self.nhMult + self.phMult
+
+    def __getitem__(self, name):
+        return object.__getattribute__(self, name)
+
+# TODO:
+# 1. good reco jets (use jet filters)
+# 2. matched L1 jets
+
+
+class Producer(object):
+
+    def __init__(self, inputs, outputs, params):
+        self.inputs = inputs
+        self.outputs = outputs
+        self.params = params
+
+        self.prefix = self.inputs[0].replace('*', '')
+        if params and 'filter' in params:
+            self.jetFilter = self._load_filter_module(params['filter'])
+        else:
+            self.jetFilter = None
+        self.outputCollection = self.outputs[0]
+
+    def _load_filter_module(self, filterPath):
+        print(filterPath)
+        tokens = filterPath.split('.')
+        module_path = '.'.join(tokens[:-1])
+        function = tokens[-1]
+        mod = import_module(module_path)
+        return getattr(mod, function)
+
+    def produce(self, event):
+        if hasattr(event, self.outputCollection):
+            return
+        nJets = event[self.prefix + 'nJets']
+        jets = []
+        for i in range(nJets):
+            jet = Jet(event, i, self.prefix)
+            if self.jetFilter:
+                if not self.jetFilter(jet):
+                    continue
+                jet.usedFilter = self.jetFilter.__name__
+            jets.append(jet)
+
+        # sort by ET, largest first
+        sorted_jets = sorted(
+            jets,
+            key=lambda jet: jet[jet.sortBy],
+            reverse=True,
+        )
+
+        setattr(event, self.outputCollection, sorted_jets)
+        assert(hasattr(event, self.outputCollection))
+        return True

--- a/cmsl1t/producers/match.py
+++ b/cmsl1t/producers/match.py
@@ -1,0 +1,28 @@
+import math
+# TODO: make it into a proper producer
+
+
+def get_matched_obj_index(obj, objects, deltaR=0.3):
+    obj_eta, obj_phi = obj
+    closest_index = 9999
+    minDeltaR = deltaR
+
+    for i, o in enumerate(objects):
+        o_eta, o_phi = o
+        dEta = obj_eta - o_eta
+        dPhi = obj_phi - o_phi
+        dR = math.sqrt(dEta**2 + dPhi**2)
+        if dR < minDeltaR:
+            minDeltaR = dR
+            closest_index = i
+    return closest_index
+
+
+def get_matched_l1_jet(recoJet, l1Jets, deltaR=0.3):
+    recoObj = (recoJet['eta'], recoJet['phi'])
+    l1Objects = [(j['jetEta'], j['jetPhi']) for j in l1Jets]
+    index = get_matched_obj_index(recoObj, l1Objects, deltaR)
+    if index < len(l1Jets):
+        return l1Jets[index]
+    else:
+        return None

--- a/cmsl1t/producers/met.py
+++ b/cmsl1t/producers/met.py
@@ -1,5 +1,8 @@
 import math
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class MET(object):
@@ -50,3 +53,48 @@ def l1MetNot28HF(caloTowerIphis, caloTowerIetas, caloTowerIets):
         caloTowerIets,
         exclude=lambda towerIeta: abs(towerIeta) == 28
     )
+
+
+class Producer(object):
+
+    METHODS = {
+        'default': recalcMET,
+        'l1Met28Only': l1Met28Only,
+        'l1MetNot28': l1MetNot28,
+        'l1MetNot28HF': l1MetNot28HF,
+    }
+
+    INPUT_ORDER = ['phi', 'eta', 'et']
+
+    def __init__(self, inputs, outputs, params):
+        self.inputs = inputs
+        self.outputs = outputs
+        self.params = params
+
+        self.prefix = self.inputs[0].replace('*', '')
+        if params and 'method' in params:
+            self.method = Producer.METHODS[params['method']]
+        else:
+            msg = 'Could not find specified MET method, using default.'
+            logger.warn(msg)
+            self.method = Producer.METHODS['default']
+        self.outputCollection = self.outputs[0]
+
+        if not self._check_inputs():
+            logger.error('Unexpected input order.')
+            logger.error('Expected order' + ','.join(Producer.INPUT_ORDER))
+            logger.error('Got' + ','.join(self.input))
+
+    def _check_inputs(self):
+        for o, i in zip(self.INPUT_ORDER, self.inputs):
+            if not i.endswith(o):
+                return False
+        return True
+
+    def produce(self, event):
+        if hasattr(event, self.outputCollection):
+            return True
+        variables = [event[i] for i in self.inputs]
+        met = self.method(*variables)
+        setattr(event, self.outputCollection, met)
+        return True

--- a/cmsl1t/producers/met.py
+++ b/cmsl1t/producers/met.py
@@ -1,0 +1,52 @@
+import math
+import numpy as np
+
+
+class MET(object):
+
+    def __init__(self, metx, mety):
+        self.x = metx
+        self.y = mety
+
+    @property
+    def mag(self):
+        return np.linalg.norm([self.x, self.y])
+
+
+def recalcMET(caloTowerIphis, caloTowerIetas, caloTowerIets, exclude=None):
+    validTowers = [1] * len(caloTowerIphis)
+    if exclude is not None:
+        validTowers = map(exclude, caloTowerIetas)
+
+    ets = 0.5 * np.array(caloTowerIets)[validTowers]
+    phis = (math.pi / 36.0) * np.array(caloTowerIphis)[validTowers]
+    metx = -sum(ets * np.cos(phis))
+    mety = -sum(ets * np.sin(phis))
+    return MET(metx, mety)
+
+
+def l1Met28Only(caloTowerIphis, caloTowerIetas, caloTowerIets):
+    return recalcMET(
+        caloTowerIphis,
+        caloTowerIetas,
+        caloTowerIets,
+        exclude=lambda towerIeta: not abs(towerIeta) == 28
+    )
+
+
+def l1MetNot28(caloTowerIphis, caloTowerIetas, caloTowerIets):
+    return recalcMET(
+        caloTowerIphis,
+        caloTowerIetas,
+        caloTowerIets,
+        exclude=lambda towerIeta: abs(towerIeta) >= 28
+    )
+
+
+def l1MetNot28HF(caloTowerIphis, caloTowerIetas, caloTowerIets):
+    return recalcMET(
+        caloTowerIphis,
+        caloTowerIetas,
+        caloTowerIets,
+        exclude=lambda towerIeta: abs(towerIeta) == 28
+    )

--- a/cmsl1t/recalc/met.py
+++ b/cmsl1t/recalc/met.py
@@ -1,6 +1,7 @@
 import math
 import numpy as np
 
+from cmsl1t.utils.decorators import deprecated
 
 class MET(object):
     def __init__(self, metx, mety):
@@ -12,6 +13,7 @@ class MET(object):
         return np.linalg.norm([self.x, self.y])
 
 
+@deprecated('cmsl1t.producers.met.recalcMET')
 def recalcMET(caloTowers, exclude=None):
     ets = []
     phis = []

--- a/cmsl1t/recalc/met.py
+++ b/cmsl1t/recalc/met.py
@@ -3,7 +3,9 @@ import numpy as np
 
 from cmsl1t.utils.decorators import deprecated
 
+
 class MET(object):
+
     def __init__(self, metx, mety):
         self.x = metx
         self.y = mety

--- a/cmsl1t/utils/decorators.py
+++ b/cmsl1t/utils/decorators.py
@@ -5,6 +5,7 @@ From http://code.activestate.com/recipes/577819-deprecated-decorator/
 import warnings
 import functools
 
+
 def deprecated(replacement=None):
     def outer(fun):
         msg = "{0} is deprecated".format(fun.__name__)

--- a/cmsl1t/utils/decorators.py
+++ b/cmsl1t/utils/decorators.py
@@ -1,0 +1,22 @@
+'''
+From http://code.activestate.com/recipes/577819-deprecated-decorator/
+'''
+
+import warnings
+import functools
+
+def deprecated(replacement=None):
+    def outer(fun):
+        msg = "{0} is deprecated".format(fun.__name__)
+        if replacement is not None:
+            msg += "; use {0} instead".format(replacement)
+        if fun.__doc__ is None:
+            fun.__doc__ = msg
+
+        @functools.wraps(fun)
+        def inner(*args, **kwargs):
+            warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+            return fun(*args, **kwargs)
+
+        return inner
+    return outer

--- a/config/demo.yaml
+++ b/config/demo.yaml
@@ -43,7 +43,7 @@ analysis:
   pu_bins: 0,13,20,999
   analyzers:
     - cmsl1t.analyzers.demo_analyzer
-  modifiers:
+  producers:
     - cmsl1t.recalc.met.l1MetNot28:
         in: event.caloTowers
         out: event.l1MetNot28

--- a/config/demo.yaml
+++ b/config/demo.yaml
@@ -1,29 +1,5 @@
-# replicating
-# ntuple_cfg benchmark_cfg()
-# {
-#   ntuple_cfg config;
-#   config.sampleName   = "Data";
-#   config.sampleTitle  = "2016 Data";
-#   config.triggerName  = "SingleMu";
-#   config.triggerTitle = "Single Muon";
-#   config.puFilename   = "";
-#   config.run          = "276243";
-#   config.outDirBase   = "{{BENCHMARK_OUTPUT_FOLDER}}";
-#   config.doFit        = false;
-#   config.puType       = {"0PU12","13PU19","20PU"};
-#   config.puBins       = {0,13,20,999};
-#   config.inFiles      = {"{{BENCHMARK_DATA}}}/*.root"};
-#   config.baseOWdir    = config.outDirBase +
-#       "/20161101_"+config.sampleName+"_run-"+config.run+"_"+\
-#       config.triggerName+"_hadd/";
-#   config.outDir       = config.outDirBase+"/"+TL1DateTime::GetDate()+"_"+\
-#   config.sampleName+"_run-"+config.run+"_"+config.triggerName;
-#   return config;
-# }
-
-
 version: 0.0.1
-name: Benchmark
+name: Demo
 
 input:
   files:
@@ -50,14 +26,9 @@ analysis:
     - cmsl1t.recalc.met.l1MetNot28HF:
         in: event.caloTowers
         out: event.l1MetNot28HF
-  progress_bar:
-    report_every: 1000
-  # or to switch it off
-  # progress_bar:
-  #   enable: False
 
 output:
   # template is a list here that is joined (os.path.join) in the config parser
   template:
-     - benchmark/new
+     - output/demo
      - "{date}_{sample_name}_run-{run_number}_{trigger_name}"

--- a/config/demo.yaml
+++ b/config/demo.yaml
@@ -21,20 +21,24 @@ analysis:
   analyzers:
     - cmsl1t.analyzers.demo_analyzer
   producers:
-    - cmsl1t.producers.met.l1MetNot28:
-        in:
-          - event.L1CaloTower_iphi
-          - event.L1CaloTower_ieta
-          - event.L1CaloTower_iet
-        out:
-          - event.l1MetNot28
-    - cmsl1t.producers.met.l1MetNot28HF:
-        in:
-          - event.L1CaloTower_iphi
-          - event.L1CaloTower_ieta
-          - event.L1CaloTower_iet
-        out:
-          - event.l1MetNot28HF
+    - cmsl1t.producers.met:
+        inputs:
+          - L1CaloTower_iphi
+          - L1CaloTower_ieta
+          - L1CaloTower_iet
+        outputs:
+          - l1MetNot28
+        params:
+          method: l1MetNot28
+    - cmsl1t.producers.met:
+        inputs:
+          - L1CaloTower_iphi
+          - L1CaloTower_ieta
+          - L1CaloTower_iet
+        outputs:
+          - l1MetNot28HF
+        params:
+          method: l1MetNot28HF
 
 output:
   # template is a list here that is joined (os.path.join) in the config parser

--- a/config/demo.yaml
+++ b/config/demo.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 1
 name: Demo
 
 input:
@@ -12,6 +12,7 @@ input:
     title: Single Muon
   pileup_file: ""
   run_number: 276243
+  mapping: config/ntuple_map.yaml
 
 analysis:
   do_fit: False
@@ -20,12 +21,20 @@ analysis:
   analyzers:
     - cmsl1t.analyzers.demo_analyzer
   producers:
-    - cmsl1t.recalc.met.l1MetNot28:
-        in: event.caloTowers
-        out: event.l1MetNot28
-    - cmsl1t.recalc.met.l1MetNot28HF:
-        in: event.caloTowers
-        out: event.l1MetNot28HF
+    - cmsl1t.producers.met.l1MetNot28:
+        in:
+          - event.L1CaloTower_iphi
+          - event.L1CaloTower_ieta
+          - event.L1CaloTower_iet
+        out:
+          - event.l1MetNot28
+    - cmsl1t.producers.met.l1MetNot28HF:
+        in:
+          - event.L1CaloTower_iphi
+          - event.L1CaloTower_ieta
+          - event.L1CaloTower_iet
+        out:
+          - event.l1MetNot28HF
 
 output:
   # template is a list here that is joined (os.path.join) in the config parser

--- a/config/energy_sums_efficiencies.yaml
+++ b/config/energy_sums_efficiencies.yaml
@@ -1,29 +1,5 @@
-# replicating
-# ntuple_cfg benchmark_cfg()
-# {
-#   ntuple_cfg config;
-#   config.sampleName   = "Data";
-#   config.sampleTitle  = "2016 Data";
-#   config.triggerName  = "SingleMu";
-#   config.triggerTitle = "Single Muon";
-#   config.puFilename   = "";
-#   config.run          = "276243";
-#   config.outDirBase   = "{{BENCHMARK_OUTPUT_FOLDER}}";
-#   config.doFit        = false;
-#   config.puType       = {"0PU12","13PU19","20PU"};
-#   config.puBins       = {0,13,20,999};
-#   config.inFiles      = {"{{BENCHMARK_DATA}}}/*.root"};
-#   config.baseOWdir    = config.outDirBase +
-#       "/20161101_"+config.sampleName+"_run-"+config.run+"_"+\
-#       config.triggerName+"_hadd/";
-#   config.outDir       = config.outDirBase+"/"+TL1DateTime::GetDate()+"_"+\
-#   config.sampleName+"_run-"+config.run+"_"+config.triggerName;
-#   return config;
-# }
-
-
 version: 0.0.1
-name: Benchmark
+name: Energy_Sum_Efficiencies
 
 input:
   files:
@@ -43,14 +19,24 @@ analysis:
   pu_bins: 0,13,20,999
   analyzers:
     - cmsl1t.analyzers.energy_sums_efficiencies
-  progress_bar:
-    report_every: 1000
-  # or to switch it off
-  # progress_bar:
-  #   enable: False
+  producers:
+    - cmsl1t.producers.met:
+        inputs:
+          - L1CaloTower_iphi
+          - L1CaloTower_ieta
+          - L1CaloTower_iet
+        outputs:
+          - l1MetBERecalc
+    - cmsl1t.producers.met:
+        inputs:
+          - emu_L1CaloTower_iphi
+          - emu_L1CaloTower_ieta
+          - emu_L1CaloTower_iet
+        outputs:
+          - l1MetBERecalcEmu
 
 output:
   # template is a list here that is joined (os.path.join) in the config parser
   template:
-     - benchmark/new
+     - output/Energy_Sum_Efficiencies
      - "{date}_{sample_name}_run-{run_number}_{trigger_name}"

--- a/config/jet_efficiencies.yaml
+++ b/config/jet_efficiencies.yaml
@@ -1,29 +1,5 @@
-# replicating
-# ntuple_cfg benchmark_cfg()
-# {
-#   ntuple_cfg config;
-#   config.sampleName   = "Data";
-#   config.sampleTitle  = "2016 Data";
-#   config.triggerName  = "SingleMu";
-#   config.triggerTitle = "Single Muon";
-#   config.puFilename   = "";
-#   config.run          = "276243";
-#   config.outDirBase   = "{{BENCHMARK_OUTPUT_FOLDER}}";
-#   config.doFit        = false;
-#   config.puType       = {"0PU12","13PU19","20PU"};
-#   config.puBins       = {0,13,20,999};
-#   config.inFiles      = {"{{BENCHMARK_DATA}}}/*.root"};
-#   config.baseOWdir    = config.outDirBase +
-#       "/20161101_"+config.sampleName+"_run-"+config.run+"_"+\
-#       config.triggerName+"_hadd/";
-#   config.outDir       = config.outDirBase+"/"+TL1DateTime::GetDate()+"_"+\
-#   config.sampleName+"_run-"+config.run+"_"+config.triggerName;
-#   return config;
-# }
-
-
 version: 0.0.1
-name: Benchmark
+name: Jet_Efficiencies
 
 input:
   files:
@@ -43,14 +19,22 @@ analysis:
   pu_bins: 0,13,20,999
   analyzers:
     - cmsl1t.analyzers.jet_efficiencies
-  progress_bar:
-    report_every: 1000
-  # or to switch it off
-  # progress_bar:
-  #   enable: False
+  producers:
+    - cmsl1t.producers.jets:
+        inputs:
+          - L1Upgrade_*
+        outputs:
+          - l1Jets
+    - cmsl1t.producers.jets:
+        inputs:
+          - Jet_*
+        outputs:
+          - goodRecoJets
+        params:
+          filter: cmsl1t.filters.jets.defaultJetFilter
 
 output:
   # template is a list here that is joined (os.path.join) in the config parser
   template:
-     - benchmark/new
+     - output/Jet_Efficiencies
      - "{date}_{sample_name}_run-{run_number}_{trigger_name}"

--- a/config/jet_rates.yaml
+++ b/config/jet_rates.yaml
@@ -1,29 +1,5 @@
-# replicating
-# ntuple_cfg benchmark_cfg()
-# {
-#   ntuple_cfg config;
-#   config.sampleName   = "Data";
-#   config.sampleTitle  = "2016 Data";
-#   config.triggerName  = "SingleMu";
-#   config.triggerTitle = "Single Muon";
-#   config.puFilename   = "";
-#   config.run          = "276243";
-#   config.outDirBase   = "{{BENCHMARK_OUTPUT_FOLDER}}";
-#   config.doFit        = false;
-#   config.puType       = {"0PU12","13PU19","20PU"};
-#   config.puBins       = {0,13,20,999};
-#   config.inFiles      = {"{{BENCHMARK_DATA}}}/*.root"};
-#   config.baseOWdir    = config.outDirBase +
-#       "/20161101_"+config.sampleName+"_run-"+config.run+"_"+\
-#       config.triggerName+"_hadd/";
-#   config.outDir       = config.outDirBase+"/"+TL1DateTime::GetDate()+"_"+\
-#   config.sampleName+"_run-"+config.run+"_"+config.triggerName;
-#   return config;
-# }
-
-
 version: 0.0.1
-name: Benchmark
+name: Jet_rates
 
 input:
   files:
@@ -43,14 +19,15 @@ analysis:
   pu_bins: 0,13,20,999
   analyzers:
     - cmsl1t.analyzers.jet_rates
-  progress_bar:
-    report_every: 1000
-  # or to switch it off
-  # progress_bar:
-  #   enable: False
+  producers:
+    - cmsl1t.producers.jets:
+        inputs:
+          - L1Upgrade_*
+        outputs:
+          - l1Jets
 
 output:
   # template is a list here that is joined (os.path.join) in the config parser
   template:
-     - benchmark/new
+     - output/Jet_rates
      - "{date}_{sample_name}_run-{run_number}_{trigger_name}"

--- a/config/jet_resolutions.yaml
+++ b/config/jet_resolutions.yaml
@@ -1,29 +1,5 @@
-# replicating
-# ntuple_cfg benchmark_cfg()
-# {
-#   ntuple_cfg config;
-#   config.sampleName   = "Data";
-#   config.sampleTitle  = "2016 Data";
-#   config.triggerName  = "SingleMu";
-#   config.triggerTitle = "Single Muon";
-#   config.puFilename   = "";
-#   config.run          = "276243";
-#   config.outDirBase   = "{{BENCHMARK_OUTPUT_FOLDER}}";
-#   config.doFit        = false;
-#   config.puType       = {"0PU12","13PU19","20PU"};
-#   config.puBins       = {0,13,20,999};
-#   config.inFiles      = {"{{BENCHMARK_DATA}}}/*.root"};
-#   config.baseOWdir    = config.outDirBase +
-#       "/20161101_"+config.sampleName+"_run-"+config.run+"_"+\
-#       config.triggerName+"_hadd/";
-#   config.outDir       = config.outDirBase+"/"+TL1DateTime::GetDate()+"_"+\
-#   config.sampleName+"_run-"+config.run+"_"+config.triggerName;
-#   return config;
-# }
-
-
 version: 0.0.1
-name: Benchmark
+name: Jet_resolutions
 
 input:
   files:
@@ -43,14 +19,22 @@ analysis:
   pu_bins: 0,13,20,999
   analyzers:
     - cmsl1t.analyzers.jet_resolution
-  progress_bar:
-    report_every: 1000
-  # or to switch it off
-  # progress_bar:
-  #   enable: False
+  producers:
+    - cmsl1t.producers.jets:
+        inputs:
+          - L1Upgrade_*
+        outputs:
+          - l1Jets
+    - cmsl1t.producers.jets:
+        inputs:
+          - Jet_*
+        outputs:
+          - goodRecoJets
+        params:
+          filter: cmsl1t.filters.jets.defaultJetFilter
 
 output:
   # template is a list here that is joined (os.path.join) in the config parser
   template:
-     - benchmark/new
+     - output/Jet_resolutions
      - "{date}_{sample_name}_run-{run_number}_{trigger_name}"

--- a/config/legacy/demo.yaml
+++ b/config/legacy/demo.yaml
@@ -49,7 +49,7 @@ analysis:
     - cmsl1t.analyzers.legacy_analyzer:
         macro: 'legacy/MakePlots/studyTower28MET.cxx'
         name: legacy_study_tower28MET
-  modifiers: []
+  producers: []
 
 
   progress_bar:

--- a/config/ntuple_content.yaml
+++ b/config/ntuple_content.yaml
@@ -534,7 +534,7 @@ content:
         - event.Muon_hlt_mu
       Muon.isLooseMuon:
         aliases:
-        - event.emu_Muon_isLooseMuon
+        - event.Muon_isLooseMuon
       Muon.isMediumMuon:
         aliases:
         - event.Muon_isMediumMuon
@@ -555,7 +555,7 @@ content:
         - event.Muon_nMuons
       Muon.passesSingleMuon:
         aliases:
-        - event.emu_Muon_passesSingleMuon
+        - event.Muon_passesSingleMuon
       Muon.phi:
         aliases:
         - event.Muon_phi

--- a/config/study_tower28_met.yaml
+++ b/config/study_tower28_met.yaml
@@ -43,7 +43,7 @@ analysis:
   pu_bins: 0,13,20,999
   analyzers:
     - cmsl1t.analyzers.study_tower28_met
-  modifiers:
+  producers:
     - cmsl1t.recalc.met.l1MetNot28:
         in: event.caloTowers
         out: event.l1MetNot28

--- a/config/study_tower28_met.yaml
+++ b/config/study_tower28_met.yaml
@@ -1,29 +1,5 @@
-# replicating
-# ntuple_cfg benchmark_cfg()
-# {
-#   ntuple_cfg config;
-#   config.sampleName   = "Data";
-#   config.sampleTitle  = "2016 Data";
-#   config.triggerName  = "SingleMu";
-#   config.triggerTitle = "Single Muon";
-#   config.puFilename   = "";
-#   config.run          = "276243";
-#   config.outDirBase   = "{{BENCHMARK_OUTPUT_FOLDER}}";
-#   config.doFit        = false;
-#   config.puType       = {"0PU12","13PU19","20PU"};
-#   config.puBins       = {0,13,20,999};
-#   config.inFiles      = {"{{BENCHMARK_DATA}}}/*.root"};
-#   config.baseOWdir    = config.outDirBase +
-#       "/20161101_"+config.sampleName+"_run-"+config.run+"_"+\
-#       config.triggerName+"_hadd/";
-#   config.outDir       = config.outDirBase+"/"+TL1DateTime::GetDate()+"_"+\
-#   config.sampleName+"_run-"+config.run+"_"+config.triggerName;
-#   return config;
-# }
-
-
 version: 0.0.1
-name: Benchmark
+name: Study_tower28_met
 
 input:
   files:
@@ -44,20 +20,27 @@ analysis:
   analyzers:
     - cmsl1t.analyzers.study_tower28_met
   producers:
-    - cmsl1t.recalc.met.l1MetNot28:
-        in: event.caloTowers
-        out: event.l1MetNot28
-    - cmsl1t.recalc.met.l1MetNot28HF:
-        in: event.caloTowers
-        out: event.l1MetNot28HF
-  progress_bar:
-    report_every: 1000
-  # or to switch it off
-  # progress_bar:
-  #   enable: False
+    - cmsl1t.producers.met:
+        inputs:
+          - L1CaloTower_iphi
+          - L1CaloTower_ieta
+          - L1CaloTower_iet
+        outputs:
+          - l1MetNot28
+        params:
+          method: l1MetNot28
+    - cmsl1t.producers.met:
+        inputs:
+          - L1CaloTower_iphi
+          - L1CaloTower_ieta
+          - L1CaloTower_iet
+        outputs:
+          - l1MetNot28HF
+        params:
+          method: l1MetNot28HF
 
 output:
   # template is a list here that is joined (os.path.join) in the config parser
   template:
-     - benchmark/new
+     - output/Study_tower28_met
      - "{date}_{sample_name}_run-{run_number}_{trigger_name}"

--- a/config/weekly_checks.yaml
+++ b/config/weekly_checks.yaml
@@ -27,7 +27,7 @@ analysis:
   analyzers:
       - cmsl1t.analyzers.weekly_analyzer
       - cmsl1t.analyzers.offline_met_analyzer
-  modifiers: []
+  producers: []
   progress_bar:
     report_every: 1000
 

--- a/config/weekly_checks.yaml
+++ b/config/weekly_checks.yaml
@@ -5,7 +5,8 @@ input:
   files:
       # Single Muons
       # -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/SingleMuon/Collision2017-wRECO-l1t-integration-v96p27/SingleMuon/crab_Collision2017-wRECO-l1t-integration-v96p27__SingleMuon/170818_102121/000*/L1Ntuple_*.root
-      -  root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/SingleMuon/Fill*/Collision2017-wRECO-l1t-integration-v96p27_CaloMode/SingleMuon/crab_Collision2017-wRECO-l1t-integration-v96p27_CaloMode__SingleMuon/*/0000/L1Ntuple_*root
+      # -  root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/SingleMuon/Fill*/Collision2017-wRECO-l1t-integration-v96p27_CaloMode/SingleMuon/crab_Collision2017-wRECO-l1t-integration-v96p27_CaloMode__SingleMuon/*/0000/L1Ntuple_*root
+      - data/L1Ntuple*.root
       # Zero Bias
       # -  root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/ZeroBias/Fill6*/Collision2017-noRECO-l1t-integration-96p27_NoPUS/ZeroBias/crab_Collision2017-noRECO-l1t-integration-96p27_NoPUS__ZeroBias_Run2017C/*/0000/L1Ntuple_*root
       # -  root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/ZeroBias/Collision2017-noRECO-l1t-integration-96p20/ZeroBias/crab_Collision2017-noRECO-l1t-integration-96p20__ZeroBias_Run2017C/170726_094745/0000/*root
@@ -27,9 +28,19 @@ analysis:
   analyzers:
       - cmsl1t.analyzers.weekly_analyzer
       - cmsl1t.analyzers.offline_met_analyzer
-  producers: []
-  progress_bar:
-    report_every: 1000
+  producers:
+    - cmsl1t.producers.jets:
+        inputs:
+          - L1Upgrade_*
+        outputs:
+          - l1Jets
+    - cmsl1t.producers.jets:
+        inputs:
+          - Jet_*
+        outputs:
+          - goodRecoJets
+        params:
+          filter: cmsl1t.filters.jets.defaultJetFilter
 
 output:
   template:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,11 @@ FROM kreczko/htcondor-in-a-box
 ENV CMSL1T_CONDA_PATH /software/cmsl1t/miniconda
 
 # ROOT requirements
-RUN sudo apt install -y libxpm-dev libxft-dev
+RUN sudo apt install -y \
+             libjpeg-dev \
+             libpng++-dev
+             libxft-dev \
+             libxpm-dev \
 
 RUN sudo mkdir -p ${CMSL1T_CONDA_PATH};\
   cd ${CMSL1T_CONDA_PATH};\

--- a/nose2.cfg
+++ b/nose2.cfg
@@ -1,0 +1,3 @@
+[unittest]
+start-dir = test/io
+plugins = nose2.plugins.layers

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ memory_profiler
 flake8
 pep8
 nose
+nose2
 click==6.7
 click-log==0.2.0
 sphinx

--- a/test/io/test_eventreader.py
+++ b/test/io/test_eventreader.py
@@ -1,0 +1,47 @@
+
+from cmsl1t.io.eventreader import EventReader, Event
+from collections import namedtuple
+from nose2.tools import such
+
+CaloTree = namedtuple('CaloTree', ['CaloTP', 'L1CaloCluster'])
+CaloTP = namedtuple('CaloTP', ['ecalTPCaliphi', 'ecalTPcompEt'])
+CaloCluster = namedtuple('CaloCluster', ['et', 'eta'])
+
+with such.A('EventReader') as it:
+    @it.has_setup
+    def setup():
+        it.caloTP = CaloTP(ecalTPCaliphi=3.14, ecalTPcompEt=50)
+        it.caloCluster = CaloCluster(et=50, eta=0)
+        it.caloTree = CaloTree(CaloTP=it.caloTP, L1CaloCluster=it.caloCluster)
+
+    @it.should('map event attributes to tree attributes')
+    def test_mapping():
+
+        trees = {
+            'l1CaloTowerEmuTree/L1CaloTowerTree': it.caloTree,
+        }
+        mapping = {
+            'l1CaloTowerEmuTree_L1CaloTowerTree_CaloTP_ecalTPCaliphi': (
+                'l1CaloTowerEmuTree/L1CaloTowerTree',
+                'CaloTP.ecalTPCaliphi'
+            ),
+            'emu_L1CaloTowerTree_CaloTP_ecalTPCaliphi': (
+                'l1CaloTowerEmuTree/L1CaloTowerTree',
+                'CaloTP.ecalTPCaliphi'
+            ),
+            'emu_CaloTP_ecalTPCaliphi': (
+                'l1CaloTowerEmuTree/L1CaloTowerTree',
+                'CaloTP.ecalTPCaliphi'
+            ),
+        }
+
+        event = Event(trees, mapping)
+        observed = event.l1CaloTowerEmuTree_L1CaloTowerTree_CaloTP_ecalTPCaliphi
+        expected = it.caloTree.CaloTP.ecalTPCaliphi
+        it.assertEqual(observed, expected)
+        observed = event.emu_L1CaloTowerTree_CaloTP_ecalTPCaliphi
+        it.assertEqual(observed, expected)
+        observed = event.emu_CaloTP_ecalTPCaliphi
+        it.assertEqual(observed, expected)
+
+it.createTests(globals())

--- a/test/io/test_mapfile.py
+++ b/test/io/test_mapfile.py
@@ -1,0 +1,51 @@
+from nose2.tools import such
+from cmsl1t.io.mapfile import \
+    default_alias, full_path_alias, shorthand_alias
+
+
+with such.A('Mapfile') as it:
+    @it.has_setup
+    def setup():
+        it.set1 = dict(
+            path='l1CaloTowerEmuTree/L1CaloTowerTree',
+            treeName='L1CaloTowerTree',
+            objName='CaloTP.ecalTPCaliphi',
+        )
+        it.set2 = dict(
+            path='l1MuonRecoTree/Muon2RecoTree',
+            treeName='Muon2RecoTree',
+            objName='Muon.isLooseMuon',
+        )
+
+    @it.should('prefix emu_ to emulator variables')
+    def test_emu_prefix():
+        testSet = it.set1
+        observed = default_alias(**testSet)
+        expected = 'event.emu_L1CaloTowerTree_CaloTP_ecalTPCaliphi'
+        it.assertEqual(observed, expected)
+
+        observed = full_path_alias(testSet['path'], testSet['objName'])
+        expected = 'event.l1CaloTowerEmuTree_L1CaloTowerTree_CaloTP_ecalTPCaliphi'
+        it.assertEqual(observed, expected)
+
+        observed = shorthand_alias(**testSet)
+        expected = 'event.emu_CaloTP_ecalTPCaliphi'
+        it.assertEqual(observed, expected)
+
+    @it.should('not prefix emu_ to not emulator variables')
+    def test_incorrect_emu_prefix():
+        testSet = it.set2
+        observed = default_alias(**testSet)
+        expected = 'event.Muon2RecoTree_Muon_isLooseMuon'
+        it.assertEqual(observed, expected)
+
+        observed = full_path_alias(testSet['path'], testSet['objName'])
+        expected = 'event.l1MuonRecoTree_Muon2RecoTree_Muon_isLooseMuon'
+        it.assertEqual(observed, expected)
+
+        observed = shorthand_alias(**testSet)
+        expected = 'event.Muon_isLooseMuon'
+        it.assertEqual(observed, expected)
+
+
+it.createTests(globals())

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -34,7 +34,7 @@ analysis:
   pu_bins: 0,13,20,999
   analyzers:
     - cmsl1t.analyzers.demo_analyzer
-  modifiers:
+  producers:
     - cmsl1t.recalc.met.l1MetNot28:
         in: event.caloTowers
         out: event.l1MetNot28


### PR DESCRIPTION
This PR fixes issue #80.
**Should not be merged before PR #82.**

Unfortunately, more changes were necessary than previously thought. 

# New features
## `cmsl1t.io.eventreader`
 - Takes input from the ntuple map file and creates aliases
 - allows access to trees via both `event.myBranch` and `event['myBranch']` (latter should make things easier if we ever switch to dataframes
Still missing: better mapping for energy sums (one could also improve L1T ntuples ;))

## `cmsl1t.producers.jets`
 - adds `Jet` wrapper class
 - adds producer that can use filters (e.g. good jets)
 - distringuishes between L1Jets and RecoJets but does not normalise them!

## `cmsl1t.producers.met`
 - adds `Met` wrapper class for L1Met
 - adds producer that can use different recalculation methods


## `cmsl1t.producers.match`
 - adds functions for object matching

## `cmsl1t.utils.decorator`
 - added deprecation decorator


# Misc
 - updated muonfilter for new changes
 - updated all configs and analyzers to new eventreader and producers
 - added missing png and jpeg libraries to docker image

