### PR TITLE
Minor fixes for Makefile and bin/*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean-external:
 	@rm -fr external
 
 clean-so:
-	@[ -d external ] && find external -name "*.so" -exec rm {} \;
+	@if [ -d external ]; then find external -name "*.so" -exec rm {} \; ;fi;
 	@find legacy -name "*.so" -exec rm {} \;
 
 clean-pyc:

--- a/bin/cmsl1t_dirty_batch
+++ b/bin/cmsl1t_dirty_batch
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 from __future__ import print_function
 import click

--- a/bin/compile_l1Analysis
+++ b/bin/compile_l1Analysis
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 import os
 
 from ROOT import gSystem, gROOT

--- a/bin/get_l1Analysis
+++ b/bin/get_l1Analysis
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 import os
 import requests

--- a/bin/run_benchmark
+++ b/bin/run_benchmark
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 from __future__ import print_function
 import ROOT
 import os


### PR DESCRIPTION
 - fixed `make clean-so` (did not realise it was broken)
 - replaced `#!/bin/env` with the more general `#!/usr/bin/env` (works now on both Debian and RedHat derivatives)