### PR TITLE
Fixing the readthedocs errors

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,5 @@
+formats:
+  - none
+
+conda:
+  file: environment.yml

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,16 @@
+name: cms
+channels:
+- conda-forge
+- http://conda.anaconda.org/NLeSC
+- defaults
+dependencies:
+  - NLeSC::root=6.04=py2.7_gcc4.8.2
+  - NLeSC::root-numpy=4.4.0=root6.04_py2.7
+  - NLeSC::rootpy=master=py2.7
+  - nose
+  - numpy
+  - matplotlib
+  - pandas
+  - pytables
+  - python=2.7
+  - sphinx


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/cms-l1t-offline/cms-l1t-analysis/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->
Fixes https://readthedocs.org/projects/cms-l1t-analysis/builds/6175669/

#### What does this pull request implement/fix? Explain your changes.
Adds readthedocs configuration (`.readthedocs.yml`) and a conda `environment.yml` to  enable a conda build of the docs (includes ROOT).

