### PR TITLE
fixing issue #95

### DIFF
--- a/cmsl1t/analyzers/offline_met_analyzer.py
+++ b/cmsl1t/analyzers/offline_met_analyzer.py
@@ -123,7 +123,9 @@ class Analyzer(BaseAnalyzer):
             setattr(self, name + "_eff_HR", eff_plot_HR)
             setattr(self, name + "_2D_HR", twoD_plot_HR)
 
-        for angle in sum_types[2:]:
+        for angle in sum_types:
+            if 'HTT' in angle:
+                continue
             name = angle + "_phi"
             res_plot = ResolutionPlot("phi", "L1", "offline_" + name)
             twoD_plot = OnlineVsOffline("L1", "offline_" + name)


### PR DESCRIPTION
Fixes issue #95.
`phi` attributes are no longer generated for `HTT` and `HTT_Emu`.

@professor-calculus Could you please confirm if this does the job?