### PR TITLE
After the long slumber, cmsl1t wakes up

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -103,3 +103,4 @@ external
 workspace
 data
 benchmark
+output

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ services:
 
 before_install:
   - docker pull hepsw/cvmfs-cms
-
-install:
- - sudo docker build -t cms-l1t-offline/cms-l1t-analysis -f ci/Dockerfile .
+  - docker pull kreczko/cms-l1t-analysis:travis
 
 script:
-  - sudo docker run -t -v $PWD:/analysis --privileged=true cms-l1t-offline/cms-l1t-analysis
+  - sudo docker run -t -v $PWD:/analysis --privileged=true kreczko/cms-l1t-analysis:travis
 cache: apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,14 @@ services:
 before_install:
   - docker pull hepsw/cvmfs-cms
   - docker pull kreczko/cms-l1t-analysis:travis
+  - docker run -d -v $PWD:/analysis --privileged=true --name=cmsl1t_test kreczko/cms-l1t-analysis:travis
+  - docker ps -a
+  - echo "Waiting for CVMFS to start up"
+  - sleep 30
 
 script:
-  - sudo docker run -t -v $PWD:/analysis --privileged=true kreczko/cms-l1t-analysis:travis
+  - docker exec -t cmsl1t_test /bin/bash -c 'source bin/env.sh;export PATH=~/.local/bin:$PATH;make test'
+
+after_script:
+  - docker stop cmsl1t_test
 cache: apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ before_install:
   - echo "Waiting for CVMFS to start up"
   - sleep 30
 
-script:
-  - docker exec -t cmsl1t_test /bin/bash -c 'source bin/env.sh;export PATH=~/.local/bin:$PATH;make test'
+script: docker exec -t cmsl1t_test /bin/bash -c 'source /ci/test.sh'
 
 after_script:
   - docker stop cmsl1t_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,15 @@ services:
 before_install:
   - docker pull hepsw/cvmfs-cms
   - docker pull kreczko/cms-l1t-analysis:travis
+
+install:
   - docker run -d -v $PWD:/analysis --privileged=true --name=cmsl1t_test kreczko/cms-l1t-analysis:travis
   - docker ps -a
   - echo "Waiting for CVMFS to start up"
   - sleep 30
 
-script: docker exec -t cmsl1t_test /bin/bash -c 'source /ci/test.sh'
+script:
+  - docker exec -t cmsl1t_test /bin/bash -c 'source /ci/test.sh'
 
 after_script:
   - docker stop cmsl1t_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # travis-ci.org build & test configuration
 sudo: required
 
-language: ruby
+language: python
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # travis-ci.org build & test configuration
 sudo: required
 
-language: python
+language: ruby
 
 services:
   - docker

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -41,6 +41,7 @@ unset envscript
 
 if [[ -z "${NO_CVMFS}" ]]
 then
+  echo "Getting dependencies from CVMFS"
   # this gives you voms-proxy-*, xrdcp and other grid tools
   source /cvmfs/grid.cern.ch/etc/profile.d/setup-cvmfs-ui.sh
   # ROOT 6, voms-proxy-init and other things

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -7,7 +7,9 @@ RUN mkdir -p /cvmfs/grid.cern.ch && mkdir -p /cvmfs/sft.cern.ch && \
     echo "grid.cern.ch /cvmfs/grid.cern.ch cvmfs defaults 0 0" >> /etc/fstab && \
     echo "sft.cern.ch /cvmfs/sft.cern.ch cvmfs defaults 0 0" >> /etc/fstab
 
-RUN yum install -y -q wget git
+RUN yum update -y --exclude=cvmfs* \
+ && yum install -y -q wget git \
+ &&  rm -fr /var/cache
 #RUN yum install -y -q glibc gcc && yum clean all
 RUN useradd cmsl1t
 RUN mkdir /analysis && chown -R cmsl1t /analysis

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -10,16 +10,15 @@ RUN mkdir -p /cvmfs/grid.cern.ch && mkdir -p /cvmfs/sft.cern.ch && \
 RUN yum update -y -q --exclude=cvmfs* \
  && yum install -y -q wget git \
  &&  rm -fr /var/cache
-#RUN yum install -y -q glibc gcc && yum clean all
+
+ENV CODE_PATH /analysis
 RUN useradd cmsl1t
-RUN mkdir /analysis && chown -R cmsl1t /analysis
-WORKDIR /analysis
+RUN mkdir ${CODE_PATH} && chown -R cmsl1t ${CODE_PATH}
+
+ADD ci/test.sh /ci/test.sh
+WORKDIR ${CODE_PATH}
 #USER cmsl1t
 
-# need to execute env.sh and ntp setup in CMD
-# as CVMFS needs 'privileged' rights,
-# but cannot do that when building the container
 ENTRYPOINT /usr/bin/cubied && \
   echo "Starting CMSL1T container" && \
   tail -f /dev/null
-#CMD ["/bin/bash", "-c", "source bin/env.sh;export PATH=~/.local/bin:$PATH;make test"]

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p /cvmfs/grid.cern.ch && mkdir -p /cvmfs/sft.cern.ch && \
     echo "grid.cern.ch /cvmfs/grid.cern.ch cvmfs defaults 0 0" >> /etc/fstab && \
     echo "sft.cern.ch /cvmfs/sft.cern.ch cvmfs defaults 0 0" >> /etc/fstab
 
-RUN yum update -y --exclude=cvmfs* \
+RUN yum update -y -q --exclude=cvmfs* \
  && yum install -y -q wget git \
  &&  rm -fr /var/cache
 #RUN yum install -y -q glibc gcc && yum clean all

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -19,4 +19,7 @@ WORKDIR /analysis
 # need to execute env.sh and ntp setup in CMD
 # as CVMFS needs 'privileged' rights,
 # but cannot do that when building the container
-CMD ["/bin/bash", "-c", "source bin/env.sh;export PATH=~/.local/bin:$PATH;make test"]
+ENTRYPOINT /usr/bin/cubied && \
+  echo "Starting CMSL1T container" && \
+  tail -f /dev/null
+#CMD ["/bin/bash", "-c", "source bin/env.sh;export PATH=~/.local/bin:$PATH;make test"]

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+export PATH=~/.local/bin:$PATH
+
+cd ${CODE_PATH}
+source bin/env.sh
+
+make test

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -5,3 +5,4 @@ matplotlib
 pytables
 rootpy
 pandas
+psutil

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
     image: kreczko/cms-l1t-analysis
     volumes:
       - .:/code
+      - /tmp/.X11-unix:/tmp/.X11-unix
     environment:
       DISPLAY: ${DISPLAY}
       TERM: ${TERM}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,10 @@ FROM kreczko/htcondor-in-a-box
 ENV CMSL1T_CONDA_PATH /software/cmsl1t/miniconda
 
 # ROOT requirements
-RUN sudo apt install -y libxpm-dev libxft-dev
+RUN sudo apt install -y \
+    libjpeg \
+    libxpm-dev \
+    libxft-dev
 
 RUN sudo mkdir -p ${CMSL1T_CONDA_PATH};\
   cd ${CMSL1T_CONDA_PATH};\

--- a/docker/cdw
+++ b/docker/cdw
@@ -1,6 +1,19 @@
 #!/bin/bash
+resize_term() {
+  old=$(stty -g)
+  stty raw -echo min 0 time 5
+
+  printf '\033[18t' > /dev/tty
+  IFS=';t' read -r _ rows cols _ < /dev/tty
+
+  stty "$old"
+
+  stty cols "$cols" rows "$rows"
+}
+
+
 cd /code
 export NO_CVMFS=1
 source bin/env.sh
-stty rows 256 cols 256
+resize_term
 bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,9 @@ nose
 click==6.7
 click-log==0.2.0
 sphinx
-pyfakefs
+pyfakefs==3.2
 htcondor
 pyaml
 rootpy
 dill
+mock


### PR DESCRIPTION
 - fixes some docker issues (X11, missing library, terminal size)
 - fixes conda requirements
 - fixes pip requirements

For the latter: pyfakefs has removed `fake_filesystem_glob` starting version 3.3 (see https://github.com/jmcgeheeiv/pyfakefs/blob/master/CHANGES.md) so I fixed it to version 3.2 for now.