### PR TITLE
A "cleaner" batch submission

### DIFF
--- a/bin/cmsl1t_batch
+++ b/bin/cmsl1t_batch
@@ -1,0 +1,1 @@
+#!/usr/bin/env python

--- a/bin/cmsl1t_batch
+++ b/bin/cmsl1t_batch
@@ -7,7 +7,6 @@ import yaml
 import os
 from textwrap import dedent
 import logging
-from itertools import izip
 
 from cmsl1t.config import ConfigParser
 from cmsl1t.batch import Batch, condor_submit, lsf_submit
@@ -43,8 +42,8 @@ def run(config_file, debug, batch, files_per_job):
     batch_filename = get_config_name_template(config_file, batch_config_dir)
     # Prepare input jobs
     outdir = os.path.join(batch_dir, "job_{index}")
-    job_generator = prepare_jobs(config, batch_filename, outdir, files_per_job)
-    job_configs, job_ids, output_folders = izip(*job_generator)
+    job_configs, job_ids, output_folders = prepare_jobs(
+        config, batch_filename, outdir, files_per_job)
 
     project_root = os.environ["PROJECT_ROOT"]
     setup_script = os.path.join(project_root, "bin", "env.sh")

--- a/bin/cmsl1t_batch
+++ b/bin/cmsl1t_batch
@@ -26,6 +26,7 @@ def prepare_output_folders(output_folder):
     os.makedirs(batch_config_dir)
     return batch_dir, batch_config_dir
 
+
 def get_config_name_template(config_file, batch_config_dir):
     batch_filename = os.path.basename(config_file.name)
     batch_filename = list(os.path.splitext(batch_filename))
@@ -33,6 +34,7 @@ def get_config_name_template(config_file, batch_config_dir):
     batch_filename = "".join(batch_filename)
     batch_filename = os.path.join(batch_config_dir, batch_filename)
     return batch_filename
+
 
 def prepare_jobs(config, batch_filename_template, outdir):
     # Get the list of input files
@@ -68,12 +70,11 @@ def prepare_jobs(config, batch_filename_template, outdir):
 def run(config_file, debug, batch, files_per_job):
     if batch == Batch.lsf:
         logger.warn('Legacy LSF system is no longer supported for cmsl1t.')
-        logger.warn(' see http://information-technology.web.cern.ch/services/batch')
+        logger.warn(
+            ' see http://information-technology.web.cern.ch/services/batch')
     # Read the config file
     config = ConfigParser()
     config.read(config_file)
-
-
 
     # Get the output directory
     output_folder = config.get('output', 'folder')
@@ -81,7 +82,6 @@ def run(config_file, debug, batch, files_per_job):
 
     # Sort out a name for the batch config files
     batch_filename = get_config_name_template(config_file, batch_config_dir)
-
 
     # Prepare input jobs
     outdir = "job_{index}"

--- a/bin/cmsl1t_batch
+++ b/bin/cmsl1t_batch
@@ -10,8 +10,8 @@ import logging
 from itertools import izip
 
 from cmsl1t.config import ConfigParser
-from cmsl1t.batch import Batch, condor_submit, lsf_submit, prepare_output_folders
-from cmsl1t.batch import lsf_submit, get_config_name_template
+from cmsl1t.batch import Batch, condor_submit, lsf_submit
+from cmsl1t.batch import prepare_output_folders, get_config_name_template
 
 from cmsl1t.batch import create_run_script, create_info_file, prepare_jobs
 
@@ -69,6 +69,7 @@ def run(config_file, debug, batch, files_per_job):
     To check their status run
 
       cmsl1t_batch_status -i {1}""".format(batch_dir, info_file)))
+
 
 if __name__ == '__main__':
     run()

--- a/bin/cmsl1t_batch
+++ b/bin/cmsl1t_batch
@@ -65,7 +65,7 @@ def prepare_jobs(config, batch_filename_template, outdir):
 @click.option('-c', '--config_file', help='YAML style config file', type=click.File(), required=True)
 @click.option('-f', '--files-per-job', help='Give each job this many files', type=int, default=1)
 @click.option('--debug/--no-debug', help='Debug mode for the job submission', default=False)
-@click.option('--batch', default="htcondor", type=click.Choice(["LSF", "htcondor"]),
+@click.option('--batch', default="htcondor", type=click.Choice([Batch.lsf, Batch.condor]),
               help='Select the job submission system to use')
 def run(config_file, debug, batch, files_per_job):
     if batch == Batch.lsf:
@@ -87,6 +87,8 @@ def run(config_file, debug, batch, files_per_job):
     outdir = "job_{index}"
     outdir = os.path.join(batch_dir, outdir)
     job_configs = prepare_jobs(config, batch_filename, outdir)
+
+    # submit jobs
 
 if __name__ == '__main__':
     run()

--- a/bin/cmsl1t_batch
+++ b/bin/cmsl1t_batch
@@ -2,6 +2,7 @@
 from __future__ import print_function
 import click
 import click_log
+import collections
 import yaml
 import os
 import htcondor
@@ -10,9 +11,13 @@ import math
 from textwrap import dedent
 import logging
 import subprocess
+import pandas as pd
+import stat
+from itertools import izip
 
 from cmsl1t.config import ConfigParser, get_unique_out_dir
-from cmsl1t.batch import Batch, prepare_input_file_groups, condor_submit, lsf_submit
+from cmsl1t.batch import Batch, prepare_input_file_groups, condor_submit, \
+    lsf_submit, get_run_script
 
 logger = logging.getLogger(__name__)
 click_log.basic_config(logger)
@@ -22,9 +27,11 @@ def prepare_output_folders(output_folder):
     batch_dir = os.path.join(output_folder, "batch")
     batch_dir = get_unique_out_dir(batch_dir)
     batch_config_dir = os.path.join(batch_dir, "_configs")
+    batch_log_dir = os.path.join(batch_dir, "logs")
     logger.info("Batch config files will be placed under: " + batch_config_dir)
     os.makedirs(batch_config_dir)
-    return batch_dir, batch_config_dir
+    os.makedirs(batch_log_dir)
+    return batch_dir, batch_config_dir, batch_log_dir
 
 
 def get_config_name_template(config_file, batch_config_dir):
@@ -36,7 +43,7 @@ def get_config_name_template(config_file, batch_config_dir):
     return batch_filename
 
 
-def prepare_jobs(config, batch_filename_template, outdir):
+def prepare_jobs(config, batch_filename_template, outdir, files_per_job):
     # Get the list of input files
     input_ntuples = config.get('input', 'files')
     input_ntuples = prepare_input_file_groups(input_ntuples, files_per_job)
@@ -52,20 +59,41 @@ def prepare_jobs(config, batch_filename_template, outdir):
         config.config['input']['files'] = in_files
 
         # Reset the output directory
-        config.config['output']['folder'] = outdir.format(index=padded_index)
+        # TODO: assumes shared_fs
+        output_folder = outdir.format(index=padded_index)
+        config.config['output']['folder'] = output_folder
+        os.makedirs(output_folder)
 
         # Dump the config file
-        batch_file = batch_filename.format(index=padded_index)
+        batch_file = batch_filename_template.format(index=padded_index)
         config.dump(batch_file)
 
-        job_configs.append(batch_file)
+        yield (batch_file, padded_index, output_folder)
+
+
+def create_run_script(setup_script, project_root, batch_dir):
+    run_script_content = get_run_script(setup_script, project_root)
+    run_script = os.path.join(batch_dir, 'run.sh')
+    with open(run_script, 'w') as f:
+        f.write(run_script_content)
+    # make executable
+    st = os.stat(run_script)
+    os.chmod(run_script, st.st_mode | stat.S_IEXEC)
+    return run_script
+
+
+def create_info_file(info, batch_dir):
+    info_file = os.path.join(batch_dir, 'info.csv')
+    df = pd.DataFrame(info)
+    df.to_csv(info_file)
+    return info_file
 
 
 @click.command()
 @click.option('-c', '--config_file', help='YAML style config file', type=click.File(), required=True)
 @click.option('-f', '--files-per-job', help='Give each job this many files', type=int, default=1)
 @click.option('--debug/--no-debug', help='Debug mode for the job submission', default=False)
-@click.option('--batch', default="htcondor", type=click.Choice([Batch.lsf, Batch.condor]),
+@click.option('--batch', default=Batch.condor, type=click.Choice([Batch.lsf, Batch.condor]),
               help='Select the job submission system to use')
 def run(config_file, debug, batch, files_per_job):
     if batch == Batch.lsf:
@@ -78,17 +106,39 @@ def run(config_file, debug, batch, files_per_job):
 
     # Get the output directory
     output_folder = config.get('output', 'folder')
-    batch_dir, batch_config_dir = prepare_output_folder(output_folder)
+    batch_dir, batch_config_dir, batch_log_dir = prepare_output_folders(
+        output_folder)
 
     # Sort out a name for the batch config files
     batch_filename = get_config_name_template(config_file, batch_config_dir)
-
     # Prepare input jobs
-    outdir = "job_{index}"
-    outdir = os.path.join(batch_dir, outdir)
-    job_configs = prepare_jobs(config, batch_filename, outdir)
+    outdir = os.path.join(batch_dir, "job_{index}")
+    job_generator = prepare_jobs(config, batch_filename, outdir, files_per_job)
+    job_configs, job_ids, output_folders = izip(*job_generator)
 
+    project_root = os.environ["PROJECT_ROOT"]
+    setup_script = os.path.join(project_root, "bin", "env.sh")
+    run_script = create_run_script(setup_script, project_root, batch_dir)
     # submit jobs
+    submit = condor_submit
+    if batch == Batch.lsf:
+        submit = lsf_submit
+    results = submit(job_configs, batch_dir, batch_log_dir, run_script)
+    # from list of dict to dict of lists
+    info = collections.defaultdict(list)
+    for r in results:
+        for k, v in r.items():
+            info[k].append(v)
+    info['local_id'] = job_ids
+    info['output_folder'] = output_folders
+
+    info_file = create_info_file(info, batch_dir)
+
+    logger.info(dedent("""\
+    Submitted jobs in {0}.
+    To check their status run
+
+      cmsl1t_batch_status -i {1}""".format(batch_dir, info_file)))
 
 if __name__ == '__main__':
     run()

--- a/bin/cmsl1t_batch
+++ b/bin/cmsl1t_batch
@@ -5,88 +5,18 @@ import click_log
 import collections
 import yaml
 import os
-import htcondor
-import sys
-import math
 from textwrap import dedent
 import logging
-import subprocess
-import pandas as pd
-import stat
 from itertools import izip
 
-from cmsl1t.config import ConfigParser, get_unique_out_dir
-from cmsl1t.batch import Batch, prepare_input_file_groups, condor_submit, \
-    lsf_submit, get_run_script
+from cmsl1t.config import ConfigParser
+from cmsl1t.batch import Batch, condor_submit, lsf_submit, prepare_output_folders
+from cmsl1t.batch import lsf_submit, get_config_name_template
+
+from cmsl1t.batch import create_run_script, create_info_file, prepare_jobs
 
 logger = logging.getLogger(__name__)
 click_log.basic_config(logger)
-
-
-def prepare_output_folders(output_folder):
-    batch_dir = os.path.join(output_folder, "batch")
-    batch_dir = get_unique_out_dir(batch_dir)
-    batch_config_dir = os.path.join(batch_dir, "_configs")
-    batch_log_dir = os.path.join(batch_dir, "logs")
-    logger.info("Batch config files will be placed under: " + batch_config_dir)
-    os.makedirs(batch_config_dir)
-    os.makedirs(batch_log_dir)
-    return batch_dir, batch_config_dir, batch_log_dir
-
-
-def get_config_name_template(config_file, batch_config_dir):
-    batch_filename = os.path.basename(config_file.name)
-    batch_filename = list(os.path.splitext(batch_filename))
-    batch_filename.insert(1, "_{index}")
-    batch_filename = "".join(batch_filename)
-    batch_filename = os.path.join(batch_config_dir, batch_filename)
-    return batch_filename
-
-
-def prepare_jobs(config, batch_filename_template, outdir, files_per_job):
-    # Get the list of input files
-    input_ntuples = config.get('input', 'files')
-    input_ntuples = prepare_input_file_groups(input_ntuples, files_per_job)
-
-    n_jobs = len(input_ntuples)
-    n_jobs_pad_width = int(math.log10(n_jobs)) + 1
-    padding = "{{:0{}}}".format(n_jobs_pad_width)
-
-    for i, in_files in enumerate(input_ntuples):
-        padded_index = padding.format(i)
-
-        # Reset the input file list
-        config.config['input']['files'] = in_files
-
-        # Reset the output directory
-        # TODO: assumes shared_fs
-        output_folder = outdir.format(index=padded_index)
-        config.config['output']['folder'] = output_folder
-        os.makedirs(output_folder)
-
-        # Dump the config file
-        batch_file = batch_filename_template.format(index=padded_index)
-        config.dump(batch_file)
-
-        yield (batch_file, padded_index, output_folder)
-
-
-def create_run_script(setup_script, project_root, batch_dir):
-    run_script_content = get_run_script(setup_script, project_root)
-    run_script = os.path.join(batch_dir, 'run.sh')
-    with open(run_script, 'w') as f:
-        f.write(run_script_content)
-    # make executable
-    st = os.stat(run_script)
-    os.chmod(run_script, st.st_mode | stat.S_IEXEC)
-    return run_script
-
-
-def create_info_file(info, batch_dir):
-    info_file = os.path.join(batch_dir, 'info.csv')
-    df = pd.DataFrame(info)
-    df.to_csv(info_file)
-    return info_file
 
 
 @click.command()

--- a/bin/cmsl1t_batch
+++ b/bin/cmsl1t_batch
@@ -1,1 +1,92 @@
 #!/usr/bin/env python
+from __future__ import print_function
+import click
+import click_log
+import yaml
+import os
+import htcondor
+import sys
+import math
+from textwrap import dedent
+import logging
+import subprocess
+
+from cmsl1t.config import ConfigParser, get_unique_out_dir
+from cmsl1t.batch import Batch, prepare_input_file_groups, condor_submit, lsf_submit
+
+logger = logging.getLogger(__name__)
+click_log.basic_config(logger)
+
+
+def prepare_output_folders(output_folder):
+    batch_dir = os.path.join(output_folder, "batch")
+    batch_dir = get_unique_out_dir(batch_dir)
+    batch_config_dir = os.path.join(batch_dir, "_configs")
+    logger.info("Batch config files will be placed under: " + batch_config_dir)
+    os.makedirs(batch_config_dir)
+    return batch_dir, batch_config_dir
+
+def get_config_name_template(config_file, batch_config_dir):
+    batch_filename = os.path.basename(config_file.name)
+    batch_filename = list(os.path.splitext(batch_filename))
+    batch_filename.insert(1, "_{index}")
+    batch_filename = "".join(batch_filename)
+    batch_filename = os.path.join(batch_config_dir, batch_filename)
+    return batch_filename
+
+def prepare_jobs(config, batch_filename_template, outdir):
+    # Get the list of input files
+    input_ntuples = config.get('input', 'files')
+    input_ntuples = prepare_input_file_groups(input_ntuples, files_per_job)
+
+    n_jobs = len(input_ntuples)
+    n_jobs_pad_width = int(math.log10(n_jobs)) + 1
+    padding = "{{:0{}}}".format(n_jobs_pad_width)
+
+    for i, in_files in enumerate(input_ntuples):
+        padded_index = padding.format(i)
+
+        # Reset the input file list
+        config.config['input']['files'] = in_files
+
+        # Reset the output directory
+        config.config['output']['folder'] = outdir.format(index=padded_index)
+
+        # Dump the config file
+        batch_file = batch_filename.format(index=padded_index)
+        config.dump(batch_file)
+
+        job_configs.append(batch_file)
+
+
+@click.command()
+@click.option('-c', '--config_file', help='YAML style config file', type=click.File(), required=True)
+@click.option('-f', '--files-per-job', help='Give each job this many files', type=int, default=1)
+@click.option('--debug/--no-debug', help='Debug mode for the job submission', default=False)
+@click.option('--batch', default="htcondor", type=click.Choice(["LSF", "htcondor"]),
+              help='Select the job submission system to use')
+def run(config_file, debug, batch, files_per_job):
+    if batch == Batch.lsf:
+        logger.warn('Legacy LSF system is no longer supported for cmsl1t.')
+        logger.warn(' see http://information-technology.web.cern.ch/services/batch')
+    # Read the config file
+    config = ConfigParser()
+    config.read(config_file)
+
+
+
+    # Get the output directory
+    output_folder = config.get('output', 'folder')
+    batch_dir, batch_config_dir = prepare_output_folder(output_folder)
+
+    # Sort out a name for the batch config files
+    batch_filename = get_config_name_template(config_file, batch_config_dir)
+
+
+    # Prepare input jobs
+    outdir = "job_{index}"
+    outdir = os.path.join(batch_dir, outdir)
+    job_configs = prepare_jobs(config, batch_filename, outdir)
+
+if __name__ == '__main__':
+    run()

--- a/bin/cmsl1t_batch_resubmit
+++ b/bin/cmsl1t_batch_resubmit
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+import click
+import click_log
+import glob
+import logging
+import pandas as pd
+import re
+import os
+import sys
+from tabulate import tabulate
+import shutil
+
+from cmsl1t.batch import Batch, Status, condor_resubmit
+from cmsl1t.batch.common import PATHS
+
+if sys.version_info[0] < 3:
+    from StringIO import StringIO
+else:
+    from io import StringIO
+
+logger = logging.getLogger(__name__)
+click_log.basic_config(logger)
+
+
+def resubmit_jobs(df, batch_dir):
+    config_files = list(df['config_file'])
+    config_files = [batch_dir + cfg for cfg in config_files]
+    local_ids = list(df['local_id'])
+    batch_log_dir = os.path.join(batch_dir, PATHS.LOG)
+    run_script = os.path.join(batch_dir, PATHS.RUN_SCRIPT)
+
+    results = condor_resubmit(config_files, local_ids, batch_dir,
+                              batch_log_dir, run_script)
+    new_df = pd.DataFrame(results)
+    new_df['local_id'] = local_ids
+    return new_df
+
+
+@click.command()
+@click.option(
+    '-i', '--info_file', help='path to info.csv', type=click.Path(exists=True),
+    required=True,
+)
+@click.option(
+    '-r', '--resubmit', default=Status.FAILED, type=click.Choice(['all', Status.FAILED, Status.UNKNOWN])
+)
+@click_log.simple_verbosity_option(logger)
+def run(info_file, resubmit):
+    df = pd.read_csv(info_file)
+    if resubmit != 'all':
+        resub_df = df[df.status == resubmit]
+    else:
+        resub_df = df
+
+    batch_directory = os.path.dirname(info_file)
+    resub_df = resubmit_jobs(resub_df, batch_directory)
+    columns_to_update = ['batch_id', 'status']
+    df.loc[df.local_id.isin(resub_df.local_id), columns_to_update] = resub_df[
+        columns_to_update]
+    df.to_csv(info_file, index=False)
+
+
+if __name__ == '__main__':
+    run()

--- a/bin/cmsl1t_batch_status
+++ b/bin/cmsl1t_batch_status
@@ -22,7 +22,6 @@ click_log.basic_config(logger)
 
 
 def update_job_status(row):
-    job = row.local_id
     batch = row.batch
     batch_id = row.batch_id
     job_path = row.output_folder
@@ -73,6 +72,7 @@ def run(info_file):
     shutil.copy(info_file, info_file + '.bak')
     # update status file
     df.to_csv(info_file)
+
 
 if __name__ == '__main__':
     run()

--- a/bin/cmsl1t_batch_status
+++ b/bin/cmsl1t_batch_status
@@ -56,7 +56,7 @@ def get_batch_status(batch, batch_id):
 
 
 def job_summary(series, max_width=80):
-    def wrap_format(x,y):
+    def wrap_format(x, y):
         string = '{0}, {1}'.format(x, y)
         # TODO: make sure to insert a line break (\n) for every max_width
         # characters (after the next comma)
@@ -77,6 +77,10 @@ def run(info_file, summary):
     df = pd.read_csv(info_file)
 
     df['status'] = df.apply(update_job_status, axis=1)
+    # make backup file
+    shutil.copy(info_file, info_file + '.bak')
+    # update status file
+    df.to_csv(info_file, index=False)
 
     if summary:
         summarised_df = df.groupby(['status']).agg(dict(
@@ -84,12 +88,10 @@ def run(info_file, summary):
         ))
         print(tabulate(summarised_df, headers=['status', '# jobs', 'job IDs']))
     else:
-        print(tabulate(df[['local_id', 'status', 'output_folder']],
+        display_columns = ['local_id', 'batch_id', 'status', 'output_folder']
+        df['output_folder'] = df['batch_dir'] + df['output_folder']
+        print(tabulate(df[display_columns],
                        headers='keys', tablefmt='psql', showindex=False))
-    # make backup file
-    shutil.copy(info_file, info_file + '.bak')
-    # update status file
-    df.to_csv(info_file)
 
 
 if __name__ == '__main__':

--- a/bin/cmsl1t_batch_status
+++ b/bin/cmsl1t_batch_status
@@ -5,8 +5,12 @@ import glob
 import logging
 import pandas as pd
 import re
+import os
 import sys
 from tabulate import tabulate
+import shutil
+
+from cmsl1t.batch import Batch, Status, condor_status, lsf_status
 
 if sys.version_info[0] < 3:
     from StringIO import StringIO
@@ -16,36 +20,25 @@ else:
 logger = logging.getLogger(__name__)
 click_log.basic_config(logger)
 
-bjobs_test_out = """
-JOBID     USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME
-141968756 kreczko RUN   8nm        lxplus050.c b6e374f7fa  *s_10.yaml Feb  8 18:09
-"""
 
+def update_job_status(row):
+    job = row.local_id
+    batch = row.batch
+    batch_id = row.batch_id
+    job_path = row.output_folder
+    job_status = row.status
+    if job_status == Status.FINISHED:
+        return job_status
+    else:
+        # check if output files exist
+        if has_output_files(job_path):
+            return 'FINISHED'
 
-def update_job_status(df):
-    # skip update of finished jobs
-    finished_jobs = df.status == 'FINISHED'
-    print(df[~finished_jobs])
-    __update__(df[~finished_jobs])
-    return df
-
-
-def __update__(df):
-    pass
-
-
-def get_job_status(jobs):
-    for j in jobs:
-        # search for ROOT files
-        if has_output_files(j):
-            yield (j, 'FINISHED')
-            continue
-
-        if is_running(j):
-            yield (j, 'RUNNING')
-            continue
-
-        yield(j, 'UNKNOWN')
+        batch_status = get_batch_status(batch, batch_id)
+        if batch_status:
+            return batch_status
+        else:
+            return Status.FAILED
 
 
 def has_output_files(job_path):
@@ -54,19 +47,13 @@ def has_output_files(job_path):
     return output_files
 
 
-def is_running(job_path):
-    pass
-
-
-def is_running_lsf(job_id):
-    pass
-
-
-def parse_bjobs_output(bjobs_output):
-    bjobs_output = bjobs_output.lstrip('\n')
-    entries = re.split("\n+", bjobs_output)
-    job_id = entries[1].split(' ')[0]
-    return int(job_id)
+def get_batch_status(batch, batch_id):
+    if batch == Batch.lsf:
+        return lsf_status(batch_id)
+    elif batch == Batch.condor:
+        return condor_status(batch_id)
+    logging.error('Unknown batch system "{0}"'.format(batch))
+    return Status.UNKNOWN
 
 
 @click.command()
@@ -78,11 +65,14 @@ def parse_bjobs_output(bjobs_output):
 def run(info_file):
     df = pd.read_csv(info_file)
 
-    df = update_job_status(df)
+    df['status'] = df.apply(update_job_status, axis=1)
 
-    print(tabulate(df[['local_id', 'output_folder', 'status']],
-                   headers='keys', tablefmt='psql'))
-
+    print(tabulate(df[['local_id', 'status', 'output_folder']],
+                   headers='keys', tablefmt='psql', showindex=False))
+    # make backup file
+    shutil.copy(info_file, info_file + '.bak')
+    # update status file
+    df.to_csv(info_file)
 
 if __name__ == '__main__':
     run()

--- a/bin/cmsl1t_batch_status
+++ b/bin/cmsl1t_batch_status
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+import click
+import click_log
+import glob
+import logging
+import pandas as pd
+import re
+import sys
+from tabulate import tabulate
+
+if sys.version_info[0] < 3:
+    from StringIO import StringIO
+else:
+    from io import StringIO
+
+logger = logging.getLogger(__name__)
+click_log.basic_config(logger)
+
+bjobs_test_out = """
+JOBID     USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME
+141968756 kreczko RUN   8nm        lxplus050.c b6e374f7fa  *s_10.yaml Feb  8 18:09
+"""
+
+
+def update_job_status(df):
+    # skip update of finished jobs
+    finished_jobs = df.status == 'FINISHED'
+    print(df[~finished_jobs])
+    __update__(df[~finished_jobs])
+    return df
+
+
+def __update__(df):
+    pass
+
+
+def get_job_status(jobs):
+    for j in jobs:
+        # search for ROOT files
+        if has_output_files(j):
+            yield (j, 'FINISHED')
+            continue
+
+        if is_running(j):
+            yield (j, 'RUNNING')
+            continue
+
+        yield(j, 'UNKNOWN')
+
+
+def has_output_files(job_path):
+    path = os.path.join(job_path, 'plots-v1', '*.root')
+    output_files = glob.glob(path)
+    return output_files
+
+
+def is_running(job_path):
+    pass
+
+
+def is_running_lsf(job_id):
+    pass
+
+
+def parse_bjobs_output(bjobs_output):
+    bjobs_output = bjobs_output.lstrip('\n')
+    entries = re.split("\n+", bjobs_output)
+    job_id = entries[1].split(' ')[0]
+    return int(job_id)
+
+
+@click.command()
+@click.option(
+    '-i', '--info_file', help='path to info.csv', type=click.Path(exists=True),
+    required=True,
+)
+@click_log.simple_verbosity_option(logger)
+def run(info_file):
+    df = pd.read_csv(info_file)
+
+    df = update_job_status(df)
+
+    print(tabulate(df[['local_id', 'output_folder', 'status']],
+                   headers='keys', tablefmt='psql'))
+
+
+if __name__ == '__main__':
+    run()

--- a/bin/cmsl1t_batch_status
+++ b/bin/cmsl1t_batch_status
@@ -55,19 +55,37 @@ def get_batch_status(batch, batch_id):
     return Status.UNKNOWN
 
 
+def job_summary(series, max_width=80):
+    def wrap_format(x,y):
+        string = '{0}, {1}'.format(x, y)
+        # TODO: make sure to insert a line break (\n) for every max_width
+        # characters (after the next comma)
+        # all_commas = string.find_all(',')
+        # insert every max_width if not already present
+        return string
+    return reduce(wrap_format, series)
+
+
 @click.command()
 @click.option(
     '-i', '--info_file', help='path to info.csv', type=click.Path(exists=True),
     required=True,
 )
+@click.option('-s', '--summary', help='print summary', default=False, is_flag=True)
 @click_log.simple_verbosity_option(logger)
-def run(info_file):
+def run(info_file, summary):
     df = pd.read_csv(info_file)
 
     df['status'] = df.apply(update_job_status, axis=1)
 
-    print(tabulate(df[['local_id', 'status', 'output_folder']],
-                   headers='keys', tablefmt='psql', showindex=False))
+    if summary:
+        summarised_df = df.groupby(['status']).agg(dict(
+            batch_id=['count', job_summary],
+        ))
+        print(tabulate(summarised_df, headers=['status', '# jobs', 'job IDs']))
+    else:
+        print(tabulate(df[['local_id', 'status', 'output_folder']],
+                       headers='keys', tablefmt='psql', showindex=False))
     # make backup file
     shutil.copy(info_file, info_file + '.bak')
     # update status file

--- a/bin/cmsl1t_dirty_batch
+++ b/bin/cmsl1t_dirty_batch
@@ -203,6 +203,8 @@ def create_info_file(batch_dir):
               help='Select the job submission system to use')
 @click_log.simple_verbosity_option(logger)
 def run(config_file, debug, batch, files_per_job):
+    logger.warning('This command is deprecated and will be removed soon.')
+    logger.warning('Please use `cmsl1t_batch` instead.')
     # Read the config file
     config = ConfigParser()
     config.read(config_file)

--- a/bin/cmsl1t_dirty_batch
+++ b/bin/cmsl1t_dirty_batch
@@ -12,8 +12,14 @@ import math
 from textwrap import dedent
 import logging
 import subprocess
+import pandas as pd
 logger = logging.getLogger(__name__)
 click_log.basic_config(logger)
+
+JOB_INFO = pd.DataFrame(
+    columns=['local_id', 'batch_id', 'config_file', 'output_folder',
+             'stderr_log', 'stdout_log', 'status', 'batch']
+)
 
 
 class cmsl1t_batch_job_htcondor(object):
@@ -21,7 +27,8 @@ class cmsl1t_batch_job_htcondor(object):
 
     def __init__(self, batch_directory, debug):
         self.debug = debug
-        setup_script = os.path.join(os.environ["PROJECT_ROOT"], "bin", "env.sh")
+        setup_script = os.path.join(
+            os.environ["PROJECT_ROOT"], "bin", "env.sh")
 
         run_script_contents = dedent("""\
         #! /bin/bash
@@ -29,24 +36,39 @@ class cmsl1t_batch_job_htcondor(object):
         cmsl1t $@
         """).format(setup_script=setup_script)
 
-        self.run_script = os.path.realpath(os.path.join(batch_directory, self.run_script_name))
+        self.run_script = os.path.realpath(
+            os.path.join(batch_directory, self.run_script_name))
         with open(self.run_script, "w") as run_script:
             run_script.write(run_script_contents)
         os.chmod(self.run_script, 0777)
 
     def submit(self, config_files):
+        global JOB_INFO
         logger.info("Will submit %d jobs" % len(config_files))
         schedd = htcondor.Schedd()
         results = []
-        for cfg in config_files:
+        for local_id, config_file in enumerate(config_files):
             with schedd.transaction() as txn:
-                cfg = os.path.realpath(cfg)
-                job_cfg = dict(executable=self.run_script_name,
-                               arguments="-c {}".format(cfg),
-                               )
+                cfg = os.path.realpath(config_file)
+                config = ConfigParser()
+                with open(config_file) as f:
+                    config.read(f)
+                output_folder = config.config['output']['folder']
+                error_log = os.path.join(output_folder, 'error.log')
+                out_log = os.path.join(output_folder, 'out.log')
+
+                job_cfg = dict(
+                    executable=self.run_script_name,
+                    arguments="-c {}".format(cfg),
+                    Err=error_log,
+                    Out=out_log,
+                )
                 sub = htcondor.Submit(job_cfg)
-                out = sub.queue(txn)
-                results.append(out)
+                batch_id = sub.queue(txn)
+                results.append(batch_id)
+                JOB_INFO.loc[len(JOB_INFO)] = [
+                    local_id, batch_id, config_file, output_folder, error_log,
+                    out_log, 'SUBMITTED', 'htcondor']
         logger.info(dedent("""\
         Jobs should be running on htcondor now.  To monitor their progress use:
 
@@ -61,17 +83,19 @@ class cmsl1t_batch_job_bsub(object):
     def __init__(self, batch_directory, debug):
         self.batch_directory = batch_directory
         self.debug = debug
-        setup_script = os.path.join(os.environ["PROJECT_ROOT"], "bin", "env.sh")
+        setup_script = os.path.join(
+            os.environ["PROJECT_ROOT"], "bin", "env.sh")
 
         run_script_contents = dedent("""\
         #! /bin/bash
         pushd {project_root}
         source {setup_script}
-        popd
         cmsl1t -c "$1"
+        popd
         """).format(project_root=os.environ["PROJECT_ROOT"], setup_script=setup_script)
 
-        self.run_script = os.path.realpath(os.path.join(batch_directory, self.run_script_name))
+        self.run_script = os.path.realpath(
+            os.path.join(batch_directory, self.run_script_name))
         with open(self.run_script, "w") as run_script:
             run_script.write(run_script_contents)
         os.chmod(self.run_script, 0777)
@@ -81,33 +105,44 @@ class cmsl1t_batch_job_bsub(object):
         logger.info("Will submit %s jobs using bsub" % n_cfgs)
 
         job_group = "/CMS-L1T--"
-        directory_name = os.path.basename(os.path.dirname(self.batch_directory))
+        directory_name = os.path.basename(
+            os.path.dirname(self.batch_directory))
         job_group += directory_name.replace("/", "--")
 
         results = []
         for i, cfg in enumerate(config_files):
             logger.info("submitting: " + cfg)
-            results.append(self._submit_one(cfg, job_group))
+            results.append(self._submit_one(cfg, i, group=job_group))
 
-        logger.info("    Check job status using:\n\n         bjobs -g {group}".format(group=job_group))
+        logger.info(
+            "    Check job status using:\n\n         bjobs -g {group}".format(group=job_group))
         return results
 
-    def _submit_one(self, config_file, group=None):
+    def _submit_one(self, config_file, local_id, group=None):
+        global JOB_INFO
         config = ConfigParser()
-        config.read(config_file)
+        with open(config_file) as f:
+            config.read(f)
         output_folder = config.config['output']['folder']
         error_log = os.path.join(output_folder, 'error.log')
         out_log = os.path.join(output_folder, 'out.log')
+        # create empty log files
+        os.makedirs(output_folder)
+        open(error_log, 'a').close()
+        open(out_log, 'a').close()
         # Prepare the args
         args = ["bsub", "-q", "1nh"]
         if group:
             args += ["-g", group]
         args += ["-eo", error_log, "-oo", out_log]
+        args += ['-outdir', output_folder]
         command = ' '.join([self.run_script, config_file])
         args += [command]
 
+        batch_id = 0
         try:
-            subprocess.check_output(args)
+            batch_output = subprocess.check_output(args)
+            batch_id = self.get_bsub_id(batch_output)
         except subprocess.CalledProcessError as e:
             msg = dedent("""\
                     Error submitting to bsub.
@@ -117,8 +152,21 @@ class cmsl1t_batch_job_bsub(object):
                     Return code was:
                        {e.returncode}""")
             logger.error(msg.format(e=e))
+            JOB_INFO.loc[len(JOB_INFO)] = [
+                local_id, -1, config_file, output_folder, error_log,
+                out_log, 'SUBMIT_FAILED', 'LSF']
             return False
+
+        JOB_INFO.loc[len(JOB_INFO)] = [
+            local_id, batch_id, config_file, output_folder, error_log,
+            out_log, 'SUBMITTED', 'LSF']
         return True
+
+    def get_bsub_id(self, bsub_output):
+        tokens = bsub_output.split(' ')
+        job_id = tokens[1]
+        job_id = job_id.strip('<>')
+        return int(job_id)
 
 
 def prepare_input_file_groups(input_ntuples, files_per_job):
@@ -134,11 +182,17 @@ def prepare_input_file_groups(input_ntuples, files_per_job):
             file_lists.append(current_list)
             current_list = []
 
-    # Even if the last list had fewer files than needed, make sure to use this too
+    # Even if the last list had fewer files than needed, make sure to use this
+    # too
     if current_list:
         file_lists.append(current_list)
 
     return file_lists
+
+
+def create_info_file(batch_dir):
+    global JOB_INFO
+    JOB_INFO.to_csv(os.path.join(batch_dir, 'info.csv'))
 
 
 @click.command()
@@ -218,6 +272,7 @@ def run(config_file, debug, batch, files_per_job):
 
     logger.info(next_steps.format(cfg=config_file.name,
                                   out_dir=out_dir.format(index="*")))
+    create_info_file(batch_dir)
 
     return True
 

--- a/bin/cmsl1t_dirty_batch
+++ b/bin/cmsl1t_dirty_batch
@@ -92,14 +92,18 @@ class cmsl1t_batch_job_bsub(object):
         logger.info("    Check job status using:\n\n         bjobs -g {group}".format(group=job_group))
         return results
 
-    def _submit_one(self, config, group=None):
+    def _submit_one(self, config_file, group=None):
+        config = ConfigParser()
+        config.read(config_file)
+        output_folder = config.config['output']['folder']
+        error_log = os.path.join(output_folder, 'error.log')
+        out_log = os.path.join(output_folder, 'out.log')
         # Prepare the args
         args = ["bsub", "-q", "1nh"]
         if group:
             args += ["-g", group]
-        if not self.debug:
-            args += ["-eo", os.devnull, "-oo", os.devnull]
-        command = ' '.join([self.run_script, config])
+        args += ["-eo", error_log, "-oo", out_log]
+        command = ' '.join([self.run_script, config_file])
         args += [command]
 
         try:

--- a/cmsl1t/__init__.py
+++ b/cmsl1t/__init__.py
@@ -13,7 +13,7 @@ logger.setLevel(logging.DEBUG)
 # add loggers
 ch = logging.StreamHandler()
 if not os.environ.get("DEBUG", False):
-    ch.setLevel(logging.WARNING)
+    ch.setLevel(logging.INFO)
 else:
     ch.setLevel(logging.DEBUG)
 # log format

--- a/cmsl1t/batch/__init__.py
+++ b/cmsl1t/batch/__init__.py
@@ -1,0 +1,22 @@
+from textwrap import dedent
+
+
+def get_run_script(setup_script, shared_fs=True):
+    project_root = os.environ["PROJECT_ROOT"]
+    run_script_contents = [
+        '#!/usr/bin/env bash',
+        'pushd {project_root}',
+        'source {setup_script}',
+        'popd',
+        'cmsl1t -c "$1"',
+        '',
+    ]
+    if not shared_fs:
+        # infer project root
+        pass
+    run_script_contents = '\n'.join(run_script_contents)
+    run_script_contents = run_script_contents.format(
+        project_root=project_root,
+        setup_script=setup_script,
+    )
+    return run_script_contents

--- a/cmsl1t/batch/__init__.py
+++ b/cmsl1t/batch/__init__.py
@@ -9,8 +9,7 @@ from .lsf import submit as lsf_submit
 from .lsf import get_status as lsf_status
 
 
-def get_run_script(setup_script, shared_fs=True):
-    project_root = os.environ["PROJECT_ROOT"]
+def get_run_script(setup_script, project_root, shared_fs=True):
     run_script_contents = [
         '#!/usr/bin/env bash',
         'pushd {project_root}',

--- a/cmsl1t/batch/__init__.py
+++ b/cmsl1t/batch/__init__.py
@@ -1,5 +1,12 @@
 from textwrap import dedent
 
+from .common import Status, Batch
+
+from .condor import submit as condor_submit
+from .condor import get_status as condor_status
+from .lsf import submit as lsf_submit
+from .lsf import get_status as lsf_status
+
 
 def get_run_script(setup_script, shared_fs=True):
     project_root = os.environ["PROJECT_ROOT"]
@@ -20,3 +27,35 @@ def get_run_script(setup_script, shared_fs=True):
         setup_script=setup_script,
     )
     return run_script_contents
+
+
+def prepare_input_file_groups(input_ntuples, files_per_job):
+    file_lists = []
+    current_list = []
+    for infile in input_ntuples:
+        if not infile.startswith("root:"):
+            infile = os.path.realpath(infile)
+        current_list.append(infile)
+
+        # Is the current list full?
+        if len(current_list) >= files_per_job:
+            file_lists.append(current_list)
+            current_list = []
+
+    # Even if the last list had fewer files than needed, make sure to use this
+    # too
+    if current_list:
+        file_lists.append(current_list)
+
+    return file_lists
+
+__all__ = [
+    'Status',
+    'Batch',
+    'condor_submit',
+    'condor_status',
+    'get_run_script',
+    'prepare_input_file_groups',
+    'lsf_submit',
+    'lsf_status',
+]

--- a/cmsl1t/batch/__init__.py
+++ b/cmsl1t/batch/__init__.py
@@ -1,62 +1,27 @@
 import os
 from textwrap import dedent
 
-from .common import Status, Batch
+from .common import Batch, create_run_script, create_info_file, \
+    get_config_name_template, prepare_jobs, prepare_output_folders, Status
 
 from .condor import submit as condor_submit
 from .condor import get_status as condor_status
+from .condor import resubmit as condor_resubmit
 from .lsf import submit as lsf_submit
 from .lsf import get_status as lsf_status
 
 
-def get_run_script(setup_script, project_root, shared_fs=True):
-    run_script_contents = [
-        '#!/usr/bin/env bash',
-        'pushd {project_root}',
-        'source {setup_script}',
-        'popd',
-        'cmsl1t -c "$1"',
-        '',
-    ]
-    if not shared_fs:
-        # infer project root
-        pass
-    run_script_contents = '\n'.join(run_script_contents)
-    run_script_contents = run_script_contents.format(
-        project_root=project_root,
-        setup_script=setup_script,
-    )
-    return run_script_contents
-
-
-def prepare_input_file_groups(input_ntuples, files_per_job):
-    file_lists = []
-    current_list = []
-    for infile in input_ntuples:
-        if not infile.startswith("root:"):
-            infile = os.path.realpath(infile)
-        current_list.append(infile)
-
-        # Is the current list full?
-        if len(current_list) >= files_per_job:
-            file_lists.append(current_list)
-            current_list = []
-
-    # Even if the last list had fewer files than needed, make sure to use this
-    # too
-    if current_list:
-        file_lists.append(current_list)
-
-    return file_lists
-
-
 __all__ = [
-    'Status',
     'Batch',
-    'condor_submit',
+    'condor_resubmit',
     'condor_status',
-    'get_run_script',
-    'prepare_input_file_groups',
-    'lsf_submit',
+    'condor_submit',
+    'create_info_file',
+    'create_run_script',
+    'get_config_name_template',
+    'prepare_jobs',
+    'prepare_output_folders',
+    'Status',
     'lsf_status',
+    'lsf_submit',
 ]

--- a/cmsl1t/batch/__init__.py
+++ b/cmsl1t/batch/__init__.py
@@ -1,3 +1,4 @@
+import os
 from textwrap import dedent
 
 from .common import Status, Batch
@@ -48,6 +49,7 @@ def prepare_input_file_groups(input_ntuples, files_per_job):
         file_lists.append(current_list)
 
     return file_lists
+
 
 __all__ = [
     'Status',

--- a/cmsl1t/batch/common.py
+++ b/cmsl1t/batch/common.py
@@ -1,3 +1,4 @@
+from itertools import izip
 import math
 import logging
 import os
@@ -120,6 +121,13 @@ def prepare_output_folders(output_folder):
 
 
 def prepare_jobs(config, batch_filename_template, outdir, files_per_job):
+    job_generator = _prepare_jobs(
+        config, batch_filename_template, outdir, files_per_job)
+    job_configs, job_ids, output_folders = izip(*job_generator)
+    return job_configs, job_ids, output_folders
+
+
+def _prepare_jobs(config, batch_filename_template, outdir, files_per_job):
     # Get the list of input files
     input_ntuples = config.get('input', 'files')
     input_ntuples = _prepare_input_file_groups(input_ntuples, files_per_job)

--- a/cmsl1t/batch/common.py
+++ b/cmsl1t/batch/common.py
@@ -1,3 +1,12 @@
+import math
+import logging
+import os
+import pandas as pd
+import stat
+from cmsl1t.config import get_unique_out_dir
+logger = logging.getLogger(__name__)
+
+
 class Status:
     CREATED = 'CREATED'
     PENDING = 'PENDING'
@@ -11,3 +20,133 @@ class Status:
 class Batch:
     lsf = 'LSF'
     condor = 'HTCondor'
+
+
+class PATHS:
+    RUN_SCRIPT = 'run.sh'
+    LOG = 'logs'
+    CONFIGS = '_configs'
+    INFO_FILE = 'info.csv'
+
+
+def _get_info_file_path(batch_dir):
+    return os.path.join(batch_dir, 'info.csv')
+
+
+def get_config_name_template(config_file, batch_config_dir):
+    batch_filename = os.path.basename(config_file.name)
+    batch_filename = list(os.path.splitext(batch_filename))
+    batch_filename.insert(1, "_{index}")
+    batch_filename = "".join(batch_filename)
+    batch_filename = os.path.join(batch_config_dir, batch_filename)
+    return batch_filename
+
+
+def create_run_script(setup_script, project_root, batch_dir):
+    run_script_content = _get_run_script(setup_script, project_root)
+    run_script = os.path.join(batch_dir, PATHS.RUN_SCRIPT)
+    with open(run_script, 'w') as f:
+        f.write(run_script_content)
+    # make executable
+    st = os.stat(run_script)
+    os.chmod(run_script, st.st_mode | stat.S_IEXEC)
+    return run_script
+
+
+def create_info_file(info, batch_dir):
+    info_file = os.path.join(batch_dir, PATHS.INFO_FILE)
+    df = pd.DataFrame(info)
+    df['run_script'] = PATHS.RUN_SCRIPT
+    df['batch_dir'] = batch_dir
+    df['config_file'] = df['config_file'].str.replace(batch_dir, '')
+    df['job_log'] = df['job_log'].str.replace(batch_dir, '')
+    df['output_folder'] = df['output_folder'].str.replace(batch_dir, '')
+    df['stderr_log'] = df['stderr_log'].str.replace(batch_dir, '')
+    df['stdout_log'] = df['stdout_log'].str.replace(batch_dir, '')
+    df.to_csv(info_file, index=False)
+    return info_file
+
+
+def _get_run_script(setup_script, project_root, shared_fs=True):
+    run_script_contents = [
+        '#!/usr/bin/env bash',
+        'pushd {project_root}',
+        'source {setup_script}',
+        'popd',
+        'cmsl1t -c "$1"',
+        '',
+    ]
+    run_script_contents = [
+        '#!/usr/bin/env bash',
+        'sleep 600',
+        '',
+    ]
+    if not shared_fs:
+        # infer project root
+        pass
+    run_script_contents = '\n'.join(run_script_contents)
+    run_script_contents = run_script_contents.format(
+        project_root=project_root,
+        setup_script=setup_script,
+    )
+    return run_script_contents
+
+
+def _prepare_input_file_groups(input_ntuples, files_per_job):
+    file_lists = []
+    current_list = []
+    for infile in input_ntuples:
+        if not infile.startswith("root:"):
+            infile = os.path.realpath(infile)
+        current_list.append(infile)
+
+        # Is the current list full?
+        if len(current_list) >= files_per_job:
+            file_lists.append(current_list)
+            current_list = []
+
+    # Even if the last list had fewer files than needed, make sure to use this
+    # too
+    if current_list:
+        file_lists.append(current_list)
+
+    return file_lists
+
+
+def prepare_output_folders(output_folder):
+    batch_dir = os.path.join(output_folder, "batch")
+    batch_dir = get_unique_out_dir(batch_dir)
+    batch_config_dir = os.path.join(batch_dir, PATHS.CONFIGS)
+    batch_log_dir = os.path.join(batch_dir, PATHS.LOG)
+    logger.info("Batch config files will be placed under: " + batch_config_dir)
+    os.makedirs(batch_config_dir)
+    os.makedirs(batch_log_dir)
+    return batch_dir, batch_config_dir, batch_log_dir
+
+
+def prepare_jobs(config, batch_filename_template, outdir, files_per_job):
+    # Get the list of input files
+    input_ntuples = config.get('input', 'files')
+    input_ntuples = _prepare_input_file_groups(input_ntuples, files_per_job)
+
+    n_jobs = len(input_ntuples)
+    n_jobs_pad_width = int(math.log10(n_jobs)) + 1
+    padding = "{{:0{}}}".format(n_jobs_pad_width)
+
+    for i, in_files in enumerate(input_ntuples):
+        padded_index = padding.format(i)
+
+        # Reset the input file list
+        config.config['input']['files'] = in_files
+
+        # Reset the output directory
+        # TODO: assumes shared_fs
+        output_folder = outdir.format(index=padded_index)
+        config.config['output']['folder'] = output_folder
+        os.makedirs(output_folder)
+
+        # Dump the config file
+        batch_file = batch_filename_template.format(index=padded_index)
+        config.dump(batch_file)
+
+        yield (batch_file, padded_index, output_folder)

--- a/cmsl1t/batch/common.py
+++ b/cmsl1t/batch/common.py
@@ -76,11 +76,6 @@ def _get_run_script(setup_script, project_root, shared_fs=True):
         'cmsl1t -c "$1"',
         '',
     ]
-    run_script_contents = [
-        '#!/usr/bin/env bash',
-        'sleep 600',
-        '',
-    ]
     if not shared_fs:
         # infer project root
         pass

--- a/cmsl1t/batch/common.py
+++ b/cmsl1t/batch/common.py
@@ -1,0 +1,11 @@
+class Status:
+    CREATED = 'CREATED'
+    PENDING = 'PENDING'
+    RUNNING = 'RUNNING'
+    FAILED = 'FAILED'
+    FINISHED = 'FINISHED'
+    UNKNOWN = 'UNKNOWN'
+
+class Batch:
+    lsf = 'LSF'
+    condor = 'HTCondor'

--- a/cmsl1t/batch/common.py
+++ b/cmsl1t/batch/common.py
@@ -6,6 +6,7 @@ class Status:
     FINISHED = 'FINISHED'
     UNKNOWN = 'UNKNOWN'
 
+
 class Batch:
     lsf = 'LSF'
     condor = 'HTCondor'

--- a/cmsl1t/batch/common.py
+++ b/cmsl1t/batch/common.py
@@ -5,6 +5,7 @@ class Status:
     FAILED = 'FAILED'
     FINISHED = 'FINISHED'
     UNKNOWN = 'UNKNOWN'
+    HELD = 'HELD'
 
 
 class Batch:

--- a/cmsl1t/batch/condor.py
+++ b/cmsl1t/batch/condor.py
@@ -1,0 +1,21 @@
+import htcondor
+
+def submit(config_files, batch_directory, run_script):
+    logger.info("Will submit {0} jobs".format(len(config_files)))
+    schedd = htcondor.Schedd()
+    results = []
+    for cfg in config_files:
+        with schedd.transaction() as txn:
+            cfg = os.path.realpath(cfg)
+            job_cfg = dict(executable=run_script_name,
+                           arguments="-c {}".format(cfg),
+                           )
+            sub = htcondor.Submit(job_cfg)
+            out = sub.queue(txn)
+            results.append(out)
+    logger.info(dedent("""\
+    Jobs should be running on htcondor now.  To monitor their progress use:
+
+        condor_q $USER """))
+
+    return results

--- a/cmsl1t/batch/condor.py
+++ b/cmsl1t/batch/condor.py
@@ -1,34 +1,77 @@
 import htcondor
 import logging
 import os
-from textwrap import dedent
 
-from .common import Status
+from .common import Status, Batch
 
 logger = logging.getLogger(__name__)
 
+CONDOR_STATUS = [
+    Status.CREATED,
+    Status.PENDING,
+    Status.RUNNING,
+    Status.FINISHED,
+    Status.HELD,
+]
 
-def submit(config_files, batch_directory, run_script):
+
+def submit(config_files, batch_directory, batch_log_dir, run_script):
     logger.info("Will submit {0} jobs".format(len(config_files)))
     schedd = htcondor.Schedd()
     results = []
-    for cfg in config_files:
-        with schedd.transaction() as txn:
+    with schedd.transaction() as txn:
+        for i, cfg in enumerate(config_files):
             cfg = os.path.realpath(cfg)
-            job_cfg = dict(executable=run_script,
-                           arguments="-c {}".format(cfg),
-                           )
+            stderr_log = os.path.join(batch_log_dir, 'job_{0}.err'.format(i))
+            stdout_log = os.path.join(batch_log_dir, 'job_{0}.out'.format(i))
+            job_log = os.path.join(batch_log_dir, 'job_{0}.log'.format(i))
+            job_cfg = dict(
+                executable=run_script,
+                arguments="-c {}".format(cfg),
+                output=stdout_log,
+                error=stderr_log,
+                log=job_log,
+            )
             sub = htcondor.Submit(job_cfg)
             out = sub.queue(txn)
-            results.append(out)
-    logger.info(dedent("""\
-    Jobs should be running on htcondor now.  To monitor their progress use:
-
-        condor_q $USER """))
+            results.append(
+                dict(
+                    batch_id=int(out),
+                    batch=Batch.condor,
+                    config_file=cfg,
+                    stderr_log=stderr_log,
+                    stdout_log=stdout_log,
+                    job_log=job_log,
+                    status=Status.CREATED,
+                )
+            )
 
     return results
 
 
 def get_status(batch_id):
-    raise NotImplementedError('condor.get_status is not implemented (yet)')
-    return Status.UNKNOWN
+    schedd = htcondor.Schedd()
+    status, exit_code = __status_from_schedd(batch_id, schedd)
+    if status == Status.UNKNOWN:
+        status, exit_code = __status_from_history(batch_id, schedd)
+
+    if exit_code is None or exit_code == 0:
+        return status
+    else:
+        return Status.FAILED
+
+
+def __status_from_schedd(batch_id, schedd):
+    job = schedd.query('ClusterId==38', ['JobStatus', 'ExitCode'])
+    if job:
+        exit_code = job['ExitCode'] if 'ExitCode' in job else None
+        return job['JobStatus'], exit_code
+    else:
+        return Status.UNKNOWN, None
+
+
+def __status_from_history(batch_id, schedd):
+    query = 'ClusterId=={0}'.format(batch_id)
+    for job in schedd.history(query, ['JobStatus', 'ExitCode'], 1):
+        exit_code = job['ExitCode'] if 'ExitCode' in job else None
+        return job['JobStatus'], exit_code

--- a/cmsl1t/batch/condor.py
+++ b/cmsl1t/batch/condor.py
@@ -1,6 +1,12 @@
 import htcondor
+import logging
+import os
+from textwrap import dedent
 
 from .common import Status
+
+logger = logging.getLogger(__name__)
+
 
 def submit(config_files, batch_directory, run_script):
     logger.info("Will submit {0} jobs".format(len(config_files)))
@@ -9,7 +15,7 @@ def submit(config_files, batch_directory, run_script):
     for cfg in config_files:
         with schedd.transaction() as txn:
             cfg = os.path.realpath(cfg)
-            job_cfg = dict(executable=run_script_name,
+            job_cfg = dict(executable=run_script,
                            arguments="-c {}".format(cfg),
                            )
             sub = htcondor.Submit(job_cfg)
@@ -21,6 +27,7 @@ def submit(config_files, batch_directory, run_script):
         condor_q $USER """))
 
     return results
+
 
 def get_status(batch_id):
     raise NotImplementedError('condor.get_status is not implemented (yet)')

--- a/cmsl1t/batch/condor.py
+++ b/cmsl1t/batch/condor.py
@@ -1,5 +1,7 @@
 import htcondor
 
+from .common import Status
+
 def submit(config_files, batch_directory, run_script):
     logger.info("Will submit {0} jobs".format(len(config_files)))
     schedd = htcondor.Schedd()
@@ -19,3 +21,7 @@ def submit(config_files, batch_directory, run_script):
         condor_q $USER """))
 
     return results
+
+def get_status(batch_id):
+    raise NotImplementedError('condor.get_status is not implemented (yet)')
+    return Status.UNKNOWN

--- a/cmsl1t/batch/lsf.py
+++ b/cmsl1t/batch/lsf.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import subprocess
 from textwrap import dedent
 
@@ -20,6 +21,7 @@ __bjobs_status = dict(
     WAIT=Status.PENDING,
     ZOMBI=Status.FAILED,
 )
+
 
 def submit(config_files, batch_directory, run_script):
     logger.info("Will submit {0} jobs using bsub".format(len(config_files)))
@@ -77,6 +79,7 @@ def get_status(batch_id):
 
 
 def __parse_bjobs_output(bjobs_output):
+    global __bjobs_status
     bjobs_output = bjobs_output.lstrip('\n')
     entries = re.split("\n+", bjobs_output)
     tokens = entries[1].split(' ')
@@ -84,4 +87,4 @@ def __parse_bjobs_output(bjobs_output):
 
     job_id = tokens[0]
     status = tokens[2]
-    return int(job_id), bjobs_status[status]
+    return int(job_id), __bjobs_status[status]

--- a/cmsl1t/batch/lsf.py
+++ b/cmsl1t/batch/lsf.py
@@ -4,7 +4,7 @@ import re
 import subprocess
 from textwrap import dedent
 
-from .common import Status
+from .common import Batch, Status
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ def __submit_one(config, run_script, group=None):
     job_id = 0
     try:
         out = subprocess.check_output(args)
-        job_id = __parse_bsub_output(out)
+        job_id = _parse_bsub_output(out)
     except subprocess.CalledProcessError as e:
         msg = dedent("""\
             Error submitting to bsub.
@@ -79,11 +79,11 @@ def __submit_one(config, run_script, group=None):
     return job_id
 
 
-def __parse_bsub_output(bsub_output):
+def _parse_bsub_output(bsub_output):
     """
     Job <145417932> is submitted to default queue <8nm>.
     """
-    job_id = re.search(r'\d+', headline).group()
+    job_id = re.search(r'\d+', bsub_output).group()
     job_id = int(job_id)
     return job_id
 
@@ -91,7 +91,7 @@ def __parse_bsub_output(bsub_output):
 def get_status(batch_id):
     args = ['bjobs', str(batch_id)]
     bjobs_output = subprocess.check_output(args)
-    job_id, status = __parse_bjobs_output(bjobs_output)
+    job_id, status = _parse_bjobs_output(bjobs_output)
     if job_id != batch_id:
         msg = 'Checked job ID "{0}" but found "{1}" - something went wrong'.format(
             batch_id, job_id)
@@ -100,7 +100,7 @@ def get_status(batch_id):
     return status
 
 
-def __parse_bjobs_output(bjobs_output):
+def _parse_bjobs_output(bjobs_output):
     global __bjobs_status
     bjobs_output = bjobs_output.lstrip('\n')
     entries = re.split("\n+", bjobs_output)

--- a/cmsl1t/batch/lsf.py
+++ b/cmsl1t/batch/lsf.py
@@ -1,0 +1,46 @@
+import logging
+import os
+from textwrap import dedent
+
+
+def submit(config_files, batch_directory, run_script):
+    logger.info("Will submit {0} jobs using bsub".format(len(config_files)))
+
+    job_group = "/CMS-L1T--"
+    directory_name = os.path.basename(os.path.dirname(batch_directory))
+    job_group += directory_name.replace("/", "--")
+
+    results = []
+    for i, cfg in enumerate(config_files):
+        logger.info("submitting: " + cfg)
+        results.append(__submit_one(cfg, run_script, job_group))
+
+    logger.info(
+        "\tCheck job status using:\n\n\t\tbjobs -g {0}".format(job_group)
+    )
+    return results
+
+
+def __submit_one(config, run_script, group=None):
+    # Prepare the args
+    args = ["bsub", "-q", "8nm"]
+    if group:
+        args += ["-g", group]
+    if not os.environ.get("DEBUG", False):
+        args += ["-eo", os.devnull, "-oo", os.devnull]
+    command = ' '.join([run_script, config])
+    args += [command]
+
+    try:
+        subprocess.check_output(args)
+    except subprocess.CalledProcessError as e:
+        msg = dedent("""\
+            Error submitting to bsub.
+            Output was:
+                {e.output}
+
+            Return code was:
+            {e.returncode}""")
+        logger.error(msg.format(e=e))
+        return False
+    return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ rootpy
 dill
 mock
 boltons
+tabulate

--- a/test/batch/mock_bjobs
+++ b/test/batch/mock_bjobs
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+job_id=$1
+echo "JOBID     USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME"
+echo "${job_id}     user2   RUN   normal     hostA       hostA       myjob     Jun 14 15:13"

--- a/test/batch/mock_bjobs
+++ b/test/batch/mock_bjobs
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# alias bjobs='echo "JOBID     USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME";echo "113     user1   PEND  normal     hostA                   myjob     Jun 17 16:15"'
 job_id=$1
 echo "JOBID     USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME"
 echo "${job_id}     user2   RUN   normal     hostA       hostA       myjob     Jun 14 15:13"

--- a/test/batch/test_condor.py
+++ b/test/batch/test_condor.py
@@ -1,0 +1,1 @@
+# mock htcondor python module

--- a/test/batch/test_lsf.py
+++ b/test/batch/test_lsf.py
@@ -1,0 +1,8 @@
+bjobs_test_out = """
+JOBID     USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME
+113     user1   PEND  normal     hostA                   myjob     Jun 17 16:15
+111     user2   RUN   normal     hostA       hostA       myjob     Jun 14 15:13
+110     user1   RUN   normal     hostB       hostA       myjob     Jun 12 05:03
+104     user3   RUN   normal     hostA       hostC       myjob     Jun 11 13:18
+"""
+# alias bjobs='echo "JOBID     USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME";echo "113     user1   PEND  normal     hostA                   myjob     Jun 17 16:15"'

--- a/test/batch/test_lsf.py
+++ b/test/batch/test_lsf.py
@@ -1,3 +1,9 @@
+import unittest
+from cmsl1t.batch import Status
+from cmsl1t.batch.lsf import _parse_bsub_output, _parse_bjobs_output
+
+test_bsub_output = "Job <145417932> is submitted to default queue <8nm>."
+
 bjobs_test_out = """
 JOBID     USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME
 113     user1   PEND  normal     hostA                   myjob     Jun 17 16:15
@@ -5,3 +11,15 @@ JOBID     USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIM
 110     user1   RUN   normal     hostB       hostA       myjob     Jun 12 05:03
 104     user3   RUN   normal     hostA       hostC       myjob     Jun 11 13:18
 """
+
+
+class TestLSFBatch(unittest.TestCase):
+
+    def test_parse_bsub_output(self):
+        job_id = _parse_bsub_output(test_bsub_output)
+        self.assertEqual(job_id, 145417932)
+
+    def test_parse_bjobs_output(self):
+        job_id, status = _parse_bjobs_output(bjobs_test_out)
+        self.assertEqual(job_id, 113)
+        self.assertEqual(status, Status.PENDING)

--- a/test/batch/test_lsf.py
+++ b/test/batch/test_lsf.py
@@ -5,4 +5,3 @@ JOBID     USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIM
 110     user1   RUN   normal     hostB       hostA       myjob     Jun 12 05:03
 104     user3   RUN   normal     hostA       hostC       myjob     Jun 11 13:18
 """
-# alias bjobs='echo "JOBID     USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME";echo "113     user1   PEND  normal     hostA                   myjob     Jun 17 16:15"'


### PR DESCRIPTION
Fixes #99

The plan here is to:
 - minimally enhance `cmsl1t_dirty_batch` to provide extra information needed
   - [x] stdout & stderr logs
   - [x] batch system
   - [x] job ID
 - [x] add new and improved&trade; `cmsl1t_batch`
 - [x] add `cmsl1t_batch_status` to produce a summary
 - [x] add `cmsl1t_batch_resubmit` to resubmit failed jobs

I intend to add, where possible, the extra information as `<path to batch dir>/info.csv` which can be used for versioning. E.g. status and resubmit scripts would read that file first to determine paths, etc (should allow for easier versioning).
