### PR TITLE
[WIP] Adding HW vs Emulated overlaid rates plots. (Do not merge!)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -96,10 +96,11 @@ Lines in the yaml give the paths for the NTuples, starting with 'root://' and en
 Further down the yaml file you can specify relative/absolute paths for the output.
 
 You'll notice in the analyser section we have something like
+```
 thresholds:
   HTT: [val1, val2, ...]
   etc...
-
+```
 Change these to the thresholds you want for HW quantities.
 
 Once you're ready, run as so:
@@ -120,11 +121,12 @@ For example, you could do:
 Then one can combine the output with the command which will be given to you at this stage.
 
 Finally, the output of the code contains something like:
+```
 thresholds:
   HTT: [val1, val2, ...]
   HTT_Emu: [val1_, val2_, ...]
   etc...
-
+```
 Copy this, being careful to keep the formatting...
 
 Now we take a look at config/HW_Emu_constant_rate_turnons.yaml:

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -81,3 +81,70 @@ Once this submits the jobs it will tell you how to combine them together later :
 ```bash
 cmsl1t_dirty_batch -c config/offline_met_studies.yaml -f <ntuple_root_files_per_job>
 ```
+
+
+### HW vs Emu at Constant Rate:
+
+The code now has facility to calculate for a given HW L1 threshold the threshold at which the Emulated quantity gives the same rate.
+
+Then, we may plot the turnons etc for HW and Emu at their respective rates together, using the new analysers.
+
+To run this, first we want the config file `configs/HW_Emu_jet_rates.yaml`.
+
+Lines in the yaml give the paths for the NTuples, starting with 'root://' and ending with '/L1NTuple_*.root' -- You should edit these to point to the ZeroBias NTuples you're running on.
+
+Further down the yaml file you can specify relative/absolute paths for the output.
+
+You'll notice in the analyser section we have something like
+thresholds:
+  HTT: [val1, val2, ...]
+  etc...
+
+Change these to the thresholds you want for HW quantities.
+
+Once you're ready, run as so:
+
+```bash
+  cmsl1t -c config/HW_Emu_jet_rates.yaml -n <no_of_entries>
+```
+
+Or, for large running you can run on lxbatch with the NTuple list broken up into many jobs using the command cmsl1t_dirty_batch. Files per job specifiable with -f <number>.
+Try to keep max ~1000 jobs else combining later is a nightmare, but also if <number> is greater than baout 4 you might struggle for walltime per job.
+
+For example, you could do:
+
+```bash
+  cmsl1t_dirty_batch -c config/HW_Emu_jet_rates.yaml -f 4
+```
+
+Then one can combine the output with the command which will be given to you at this stage.
+
+Finally, the output of the code contains something like:
+thresholds:
+  HTT: [val1, val2, ...]
+  HTT_Emu: [val1_, val2_, ...]
+  etc...
+
+Copy this, being careful to keep the formatting...
+
+Now we take a look at config/HW_Emu_constant_rate_turnons.yaml:
+
+There are similar lines in here. Set the input ntuples to the SingleMu you wish to run on.
+
+Now again in the analyser section we have the thresholds listed in the same format, but now with emulated quantities too.
+
+Replace this with the stuff you just copied -- this format is interpreted as a python dictionary, so whitespace matters. thresholds: should be indented 2 spaces wrt lines above,
+and HTT etc indented 2 spaces wrt thresholds.
+
+Finally, we may run this like we did the previous step:
+
+```bash
+  cmsl1t_dirty_batch -c config/HW_Emu_constant_rate_turnons.yaml -f 4
+```
+Or of course
+
+```bash
+  cmsl1t -c config/HW_Emu_jet_rates.yaml -n <number_of_events>
+```
+
+if one wants a quick test job.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,83 @@
+# cms-l1t-analysis
+Software package to analyse L1TNtuples
+
+## Quick-Start Guide for lxplus
+ 1. Read the README etc if you want to dive deeper!
+ 2. To get cracking, follow the instructions below:
+
+### On Scientific Linux 6 with CVMFS available, e.g. lxplus, Soolin etc
+This includes nodes lxplus.cern.ch & private clusters
+
+For now let's use this repository, you can fork your own of course!
+```bash
+git clone -b overlay_plots https://github.com/professor-calculus/cms-l1t-analysis.git
+cd cms-l1t-analysis
+source bin/env.sh
+# you might need your grid cert -- but you shouldn't need it on lxplus with NTuples on EOS
+voms-proxy-init --voms cms
+make setup
+```
+
+make setup should work, but in the case that it throws Error 54 ignore it for now. This just means it cannot find
+the test NTuples, but everything else is compiled ok and ready to rock 'n' roll.
+
+### running tests
+Tests can be run either on an SL 6 machine or in the Vagrant box:
+```bash
+make test
+# if a grid proxy is provided (e.g. via voms-proxy-init --voms cms)
+# you can also run tests that require grid access:
+make test-all
+```
+
+This should fail if make setup threw Error 54.
+
+
+### Implementing and running an analysis script
+"Analyzers" are the parts of the code that receive events from the input tuples, extracts the relevant data and puts this into the histograms.
+
+You can see an example of an analyzer at: `cmsl1t/analyzers/demo_analyzer.py`.
+  
+To implement your own analyzer, all you need to do is make a new class in a file under `cmsl1t/analyzers/` which inherits from `cmsl1t.analyzers.BaseAnalyzer.BaseAnalyzer`.  You then need to implement two or three methods: `prepare_for_event`, ` fill_histograms`, `write_histograms`, and `make_plots`.  See the BaseAnalyzer class and the demo_analyzer for examples and documentation of these methods.
+
+Once you have implemented an analyzer and written a simple configuration for it, you can run it with `cmsl1t` command:
+```bash
+cmsl1t -c config/demo.yaml -n 1000
+```
+
+Get help on the command line options by doing:
+```bash
+cmsl1t --help
+```
+
+### Running the weekly checks:
+
+For the weekly checks of jets & sums efficiencies, 2D plots etc, we have an analyzer:
+
+Currently this is 'cmsl1t/analyzers/offline_met_analyzer.py' but in the future it will likely get rolled into weekly_analyzer.py.
+
+To run this, we want the config file 'configs/offline_met_studies.yaml'.
+
+Lines in the yaml give the paths for the NTuples, starting with 'root://' and ending with '/L1NTuple_*.root' -- You should edit these to point to the NTuples you're running on.
+
+Further down the yaml file you can specify relative/absolute paths for the output.
+
+Once you're ready, run as so:
+
+```bash
+cmsl1t -c config/offline_met_studies.yaml -n <no_of_entries>
+```
+
+Or, for large running you can run on lxbatch with the NTuple list broken up into many jobs. Files per job specifiable with -f <number>. Try to keep max ~1000 jobs else combining later is a nightmare.
+
+Also more than about 8 files per job will lead to some going over the walltime, since the bsub queue is 8nm... Edit bin/cmsl1t_dirty_batch to change 
+queue to 1nh or something 
+else if this happens a lot.
+
+For small runs I reccommend changing queue to 8nm and running ~4-6 files per job.
+
+Once this submits the jobs it will tell you how to combine them together later :-)
+
+```bash
+cmsl1t_dirty_batch -c config/offline_met_studies.yaml -f <ntuple_root_files_per_job>
+```

--- a/cmsl1t/analyzers/BaseAnalyzer.py
+++ b/cmsl1t/analyzers/BaseAnalyzer.py
@@ -22,6 +22,7 @@ class BaseAnalyzer(object):
             os.makedirs(self.plots_folder)
         self.all_plots = []
         self.puBins = config.try_get('analysis', 'pu_bins', [0, 999])
+        self.thresholds = config.try_get('analysis', 'thresholds', None)
 
     def prepare_for_events(self, reader):
         """

--- a/cmsl1t/analyzers/HW_Emu_constant_rate_turnons.py
+++ b/cmsl1t/analyzers/HW_Emu_constant_rate_turnons.py
@@ -49,7 +49,7 @@ HIGH_RANGE_BINS = np.asarray(HIGH_RANGE_BINS, 'd')
 
 def ExtractSums(event):
     offline = dict(
-        HTT=Sum(event.sums.Ht),
+        HTT=Sum(event.sums.caloHt),
         MHT=Met(event.sums.mHt, event.sums.mHtPhi),
         MET_HF=Met(event.sums.caloMet, event.sums.caloMetPhi),
         MET=Met(event.sums.caloMetBE, event.sums.caloMetPhiBE),
@@ -57,7 +57,7 @@ def ExtractSums(event):
         MET_PF_NoMu=Met(event.sums.pfMetNoMu, event.sums.pfMetNoMuPhi),
         MET_PF_HF=Met(event.sums.met, event.sums.metPhi),
         MET_PF_NoMu_HF=Met(event.sums.pfMetNoMu, event.sums.pfMetNoMuPhi),
-        HTT_Emu=Sum(event.sums.Ht),
+        HTT_Emu=Sum(event.sums.caloHt),
         MHT_Emu=Met(event.sums.mHt, event.sums.mHtPhi),
         MET_HF_Emu=Met(event.sums.caloMet, event.sums.caloMetPhi),
         MET_Emu=Met(event.sums.caloMetBE, event.sums.caloMetPhiBE),
@@ -276,7 +276,7 @@ class Analyzer(BaseAnalyzer):
                 getattr(self, name + "_phi_res").fill(pileup, off.phi, on.phi)
                 getattr(self, name + "_phi_2D").fill(pileup, off.phi, on.phi)
 
-        goodJets = event.goodJets()
+        goodJets = event.goodJets(jetFilter=None)
 
         for recoJet in goodJets:
             l1Jet = event.getMatchedL1Jet(recoJet, l1Type='EMU')
@@ -286,7 +286,7 @@ class Analyzer(BaseAnalyzer):
                 self.res_vs_eta_CentralJets.fill(
                     pileup, recoJet.eta, recoJet.etCorr, l1Jet.et)
 
-        leadingRecoJet = event.getLeadingRecoJet()
+        leadingRecoJet = event.getLeadingRecoCaloJet()
         if not leadingRecoJet:
             return True
 

--- a/cmsl1t/analyzers/HW_Emu_constant_rate_turnons.py
+++ b/cmsl1t/analyzers/HW_Emu_constant_rate_turnons.py
@@ -276,7 +276,7 @@ class Analyzer(BaseAnalyzer):
                 getattr(self, name + "_phi_res").fill(pileup, off.phi, on.phi)
                 getattr(self, name + "_phi_2D").fill(pileup, off.phi, on.phi)
 
-        goodJets = event.goodJets(jetFilter=None)
+        goodJets = event.goodCaloJets(jetFilter=None)
 
         for recoJet in goodJets:
             l1Jet = event.getMatchedL1Jet(recoJet, l1Type='EMU')

--- a/cmsl1t/analyzers/HW_Emu_constant_rate_turnons.py
+++ b/cmsl1t/analyzers/HW_Emu_constant_rate_turnons.py
@@ -1,0 +1,357 @@
+from BaseAnalyzer import BaseAnalyzer
+from cmsl1t.plotting.efficiency import EfficiencyPlot
+from cmsl1t.collections import EfficiencyCollection
+from cmsl1t.plotting.onlineVsOffline import OnlineVsOffline
+from cmsl1t.plotting.resolution import ResolutionPlot
+from cmsl1t.plotting.resolution_vs_X import ResolutionVsXPlot
+import cmsl1t.recalc.met as recalc
+from cmsl1t.playground.eventreader import Met, Sum
+from math import pi
+import pprint
+from collections import namedtuple
+import numpy as np
+
+
+sum_types = [
+    "HTT", "MHT", "MET_HF", "MET", "MET_PF", "MET_PF_NoMu", "MET_PF_HF",
+    "MET_PF_NoMu_HF",
+]
+sum_types += [t + '_Emu' for t in sum_types]
+
+jet_types = ["singlel1JetEt", "doublel1JetEt", "triplel1JetEt", "quadl1JetEt"]
+jet_types += [t + '_Emu' for t in jet_types]
+
+Sums = namedtuple("Sums", sum_types)
+
+# Eta ranges so we can put |\eta| < val as the legend header on the
+# efficiency plots.
+ETA_RANGES = dict(
+    HTT="|\\eta| < 2.5",
+    MHT="|\\eta| < 2.5",
+    MET_HF="|\\eta| < 5.0",
+    MET="|\\eta| < 3.0",
+    MET_PF="|\\eta| < 3.0",
+    MET_PF_NoMu="|\\eta| < 3.0",
+    MET_PF_HF="|\\eta| < 5.0",
+    MET_PF_NoMu_HF="|\\eta| < 5.0",
+    jetET_B="|\\eta| < 1.479",
+    jetET_E="1.479 < |\\eta| < 3.0",
+    jetET_BE="|\\eta| < 3.0",
+    jetET_HF="3.0 < |\\eta| < 5.0",
+)
+
+
+HIGH_RANGE_BINS = list(range(0, 100, 5)) + list(range(100, 400, 10))
+HIGH_RANGE_BINS += list(range(400, 800, 50)) + list(range(800, 1000, 200))
+HIGH_RANGE_BINS += list(range(1000, 2100, 500))
+HIGH_RANGE_BINS = np.asarray(HIGH_RANGE_BINS, 'd')
+
+
+def ExtractSums(event):
+    offline = dict(
+        HTT=Sum(event.sums.Ht),
+        MHT=Met(event.sums.mHt, event.sums.mHtPhi),
+        MET_HF=Met(event.sums.caloMet, event.sums.caloMetPhi),
+        MET=Met(event.sums.caloMetBE, event.sums.caloMetPhiBE),
+        MET_PF=Met(event.sums.met, event.sums.metPhi),
+        MET_PF_NoMu=Met(event.sums.pfMetNoMu, event.sums.pfMetNoMuPhi),
+        MET_PF_HF=Met(event.sums.met, event.sums.metPhi),
+        MET_PF_NoMu_HF=Met(event.sums.pfMetNoMu, event.sums.pfMetNoMuPhi),
+        HTT_Emu=Sum(event.sums.Ht),
+        MHT_Emu=Met(event.sums.mHt, event.sums.mHtPhi),
+        MET_HF_Emu=Met(event.sums.caloMet, event.sums.caloMetPhi),
+        MET_Emu=Met(event.sums.caloMetBE, event.sums.caloMetPhiBE),
+        MET_PF_Emu=Met(event.sums.met, event.sums.metPhi),
+        MET_PF_NoMu_Emu=Met(event.sums.pfMetNoMu, event.sums.pfMetNoMuPhi),
+        MET_PF_HF_Emu=Met(event.sums.met, event.sums.metPhi),
+        MET_PF_NoMu_HF_Emu=Met(event.sums.pfMetNoMu, event.sums.pfMetNoMuPhi)
+    )
+    online = dict(
+        HTT=event.l1Sums["L1Htt"],
+        MHT=event.l1Sums["L1Mht"],
+        MET_HF=event.l1Sums["L1MetHF"],
+        MET=event.l1Sums["L1Met"],
+        MET_PF=event.l1Sums["L1Met"],
+        MET_PF_NoMu=event.l1Sums["L1Met"],
+        MET_PF_HF=event.l1Sums["L1MetHF"],
+        MET_PF_NoMu_HF=event.l1Sums["L1MetHF"],
+        HTT_Emu=event.l1Sums["L1EmuHtt"],
+        MHT_Emu=event.l1Sums["L1EmuMht"],
+        MET_HF_Emu=event.l1Sums["L1EmuMetHF"],
+        MET_Emu=event.l1Sums["L1EmuMet"],
+        MET_PF_Emu=event.l1Sums["L1EmuMet"],
+        MET_PF_NoMu_Emu=event.l1Sums["L1EmuMet"],
+        MET_PF_HF_Emu=event.l1Sums["L1EmuMetHF"],
+        MET_PF_NoMu_HF_Emu=event.l1Sums["L1EmuMetHF"]
+    )
+    return online, offline
+
+
+class Analyzer(BaseAnalyzer):
+
+    def __init__(self, config, **kwargs):
+        super(Analyzer, self).__init__("weekly_analyzer", config)
+
+        for name in sum_types:
+            eff_plot = EfficiencyPlot("L1", "offline_" + name)
+            res_plot = ResolutionPlot("energy", "L1", "offline_" + name)
+            twoD_plot = OnlineVsOffline("L1", "offline_" + name)
+            self.register_plotter(eff_plot)
+            self.register_plotter(res_plot)
+            self.register_plotter(twoD_plot)
+            setattr(self, name + "_eff", eff_plot)
+            setattr(self, name + "_res", res_plot)
+            setattr(self, name + "_2D", twoD_plot)
+
+            eff_plot_HR = EfficiencyPlot("L1", "offline_" + name + "_HiRange")
+            twoD_plot_HR = OnlineVsOffline(
+                "L1", "offline_" + name + "_HiRange")
+            self.register_plotter(eff_plot_HR)
+            self.register_plotter(twoD_plot_HR)
+            setattr(self, name + "_eff_HR", eff_plot_HR)
+            setattr(self, name + "_2D_HR", twoD_plot_HR)
+
+        for angle in sum_types:
+            name = angle + "_phi"
+            if 'HTT' in angle:
+                continue
+            res_plot = ResolutionPlot("phi", "L1", "offline_" + name)
+            twoD_plot = OnlineVsOffline("L1", "offline_" + name)
+            self.register_plotter(res_plot)
+            self.register_plotter(twoD_plot)
+            setattr(self, name + "_res", res_plot)
+            setattr(self, name + "_2D", twoD_plot)
+
+        for name in jet_types:
+            eff_plot = EfficiencyPlot("L1", "offline_" + name)
+            res_plot = ResolutionPlot("energy", "L1", "offline_" + name)
+            twoD_plot = OnlineVsOffline("L1", "offline_" + name)
+            self.register_plotter(eff_plot)
+            self.register_plotter(res_plot)
+            self.register_plotter(twoD_plot)
+            setattr(self, name + "_eff", eff_plot)
+            setattr(self, name + "_res", res_plot)
+            setattr(self, name + "_2D", twoD_plot)
+
+            eff_plot_HR = EfficiencyPlot("L1", "offline_" + name + "_HiRange")
+            twoD_plot_HR = OnlineVsOffline(
+                "L1", "offline_" + name + "_HiRange")
+            self.register_plotter(eff_plot_HR)
+            self.register_plotter(twoD_plot_HR)
+            setattr(self, name + "_eff_HR", eff_plot_HR)
+            setattr(self, name + "_2D_HR", twoD_plot_HR)
+
+        self.res_vs_eta_CentralJets = ResolutionVsXPlot(
+            "energy", "onlineJet", "offlineJet", "offlineJet_eta")
+        self.register_plotter(self.res_vs_eta_CentralJets)
+
+    def prepare_for_events(self, reader):
+        puBins = self.puBins
+        puBins_HR = [0, 999]
+
+        Config = namedtuple(
+            "Config",
+            "name off_title on_title min max",
+        )
+        cfgs = [
+            Config("HTT", "Offline HTT", "L1 HTT", 30, 600),
+            Config("MHT", "Offline MHT", "L1 MHT", 0, 400),
+            Config("MET_HF", "Offline MET with HF", "L1 MET", 0, 400),
+            Config("MET", "Offline MET no HF", "L1 MET", 0, 400),
+            Config("MET_PF", "Offline PF MET", "L1 MET", 0, 400),
+            Config("MET_PF_NoMu", "Offline PF MET without Muons",
+                   "L1 MET", 0, 400),
+            Config(
+                "MET_PF_HF", "Offline PF MET with HF", "L1 MET", 0, 400,
+            ),
+            Config(
+                "MET_PF_NoMu_HF", "Offline PF MET with HF without Muons",
+                "L1 MET", 0, 400,
+            ),
+            Config(
+                "singlel1JetEt", "Offline Jet ET in for Single Jet",
+                "L1 Jet ET", 0, 400,
+            ),
+            Config(
+                "doublel1JetEt", "Offline Jet ET for Double Jet",
+                "L1 Jet ET", 0, 400,
+            ),
+            Config(
+                "triplel1JetEt", "Offline Jet ET for Triple Jet",
+                "L1 Jet ET", 0, 400,
+            ),
+            Config(
+                "quadl1JetEt", "Offline Jet ET for Quad Jet",
+                "L1 Jet ET", 0, 400,
+            ),
+
+        ]
+        self._plots_from_cfgs(cfgs, puBins)
+        self._plots_from_cfgs(cfgs, puBins, emulator=True)
+        self._plots_from_cfgs(cfgs, puBins_HR, high_range=True)
+        self._plots_from_cfgs(cfgs, puBins_HR, emulator=True, high_range=True)
+
+        self.res_vs_eta_CentralJets.build(
+            "Online Jet energy (GeV)",
+            "Offline Jet energy (GeV)",
+            "Offline Jet Eta (rad)",
+            puBins,
+            50, -0.5, 3.5, 50, -5.0, 5.0,
+        )
+        return True
+
+    def _plots_from_cfgs(self, cfgs, puBins, emulator=False, high_range=False):
+
+        THRESHOLDS = self.thresholds
+        for i in ['HF', 'PF', 'PF_NoMu', 'PF_HF', 'PF_NoMu_HF']:
+            if THRESHOLDS['MET_' + i] == None:
+                THRESHOLDS['MET_' + i] = THRESHOLDS['MET']
+
+        suffix = ""
+        prefix = ""
+        if high_range:
+            suffix = '_HR'
+        if emulator:
+            prefix = '_Emu'
+        for cfg in cfgs:
+            eff_plot = getattr(self, cfg.name + prefix + "_eff" + suffix)
+
+            twoD_plot = getattr(self, cfg.name + prefix + "_2D" + suffix)
+            thresholds = THRESHOLDS.get(cfg.name + prefix)
+            params = [
+                cfg.on_title, cfg.off_title + " (GeV)", puBins, thresholds,
+                50, cfg.min, cfg.max,
+            ]
+            if high_range:
+                params = [
+                    cfg.on_title, cfg.off_title + " (GeV)", puBins, thresholds,
+                    HIGH_RANGE_BINS.size - 1, HIGH_RANGE_BINS,
+                ]
+
+            eff_plot.build(*params, legend_title=ETA_RANGES.get(cfg.name, ""))
+            params.remove(thresholds)
+            twoD_plot.build(*params)
+
+            if high_range:
+                continue
+            res_plot = getattr(self, cfg.name + prefix + "_res" + suffix)
+            res_plot.build(cfg.on_title, cfg.off_title,
+                           puBins, 50, -10, 10)
+
+            if not hasattr(self, cfg.name + prefix + "_phi_res"):
+                continue
+            res_plot = getattr(self, cfg.name + prefix + "_phi_res")
+            twoD_plot = getattr(self, cfg.name + prefix + "_phi_2D")
+            twoD_plot.build(
+                cfg.on_title + " Phi (rad)",
+                cfg.off_title + " Phi (rad)",
+                puBins, 50,
+                -pi,
+                2 * pi,
+            )
+            res_plot.build(
+                cfg.on_title + " Phi",
+                cfg.off_title + " Phi",
+                puBins,
+                50,
+                -2,
+                2,
+            )
+
+    def fill_histograms(self, entry, event):
+        if not event.passesMETFilter():
+            return True
+
+        offline, online = ExtractSums(event)
+        pileup = event.nVertex
+
+        for name in sum_types:
+            on = online[name]
+            if on.et == 0:
+                continue
+            off = offline[name]
+            for suffix in ['_eff', '_res', '_2D', '_eff_HR', '_2D_HR']:
+                getattr(self, name + suffix).fill(pileup, off.et, on.et)
+            if hasattr(self, name + "_phi_res"):
+                getattr(self, name + "_phi_res").fill(pileup, off.phi, on.phi)
+                getattr(self, name + "_phi_2D").fill(pileup, off.phi, on.phi)
+
+        goodJets = event.goodJets()
+
+        for recoJet in goodJets:
+            l1Jet = event.getMatchedL1Jet(recoJet, l1Type='EMU')
+            if not l1Jet:
+                continue
+            if recoJet.etCorr > 30.:
+                self.res_vs_eta_CentralJets.fill(
+                    pileup, recoJet.eta, recoJet.etCorr, l1Jet.et)
+
+        leadingRecoJet = event.getLeadingRecoJet()
+        if not leadingRecoJet:
+            return True
+
+        l1EmuJet = event.getMatchedL1Jet(leadingRecoJet, l1Type='EMU')
+        if not l1EmuJet:
+            return True
+
+        l1JetEts = [jet.et for jet in event._l1Jets]
+        nJets = len(l1JetEts)
+
+        l1EmuJetEts = [jet.et for jet in event._l1EmuJets]
+        nEmuJets = len(l1EmuJetEts)
+
+        fillRegions = []
+        if nEmuJets >= 1:
+            fillRegions += ['singlel1JetEt']
+        if nEmuJets >= 2:
+            fillRegions += ['doublel1JetEt']
+        if nEmuJets >= 3:
+            fillRegions += ['triplel1JetEt']
+        if nEmuJets >= 4:
+            fillRegions += ['quadl1JetEt']
+        for region in fillRegions:
+            for suffix in ['_eff', '_res', '_2D', '_eff_HR', '_2D_HR']:
+                name = '{0}_Emu{1}'.format(region, suffix)
+                getattr(self, name).fill(
+                    pileup, leadingRecoJet.etCorr, l1EmuJet.et,
+                )
+
+        l1Jet = event.getMatchedL1Jet(leadingRecoJet, l1Type='HW')
+        if not l1Jet:
+            return True
+
+        fillRegions = []
+        if nJets >= 1:
+            fillRegions += ['singlel1JetEt']
+        if nJets >= 2:
+            fillRegions += ['doublel1JetEt']
+        if nJets >= 3:
+            fillRegions += ['triplel1JetEt']
+        if nJets >= 4:
+            fillRegions += ['quadl1JetEt']
+        for region in fillRegions:
+            for suffix in ['_eff', '_res', '_2D', '_eff_HR', '_2D_HR']:
+                name = '{0}{1}'.format(region, suffix)
+                getattr(self, name).fill(
+                    pileup, leadingRecoJet.etCorr, l1Jet.et,
+                )
+
+        return True
+
+    def make_plots(self):
+        """
+        Custom version, does what the normal one does but also overlays whatever you like.
+        """
+        for plot in self.all_plots:
+            plot.draw()
+        getattr(self, 'HTT_eff').overlay_with_emu(getattr(self, 'HTT_Emu_eff'))
+        getattr(self, 'MET_eff').overlay_with_emu(getattr(self, 'MET_Emu_eff'))
+        getattr(self, 'MET_HF_eff').overlay_with_emu(getattr(self, 'MET_HF_Emu_eff'))
+        getattr(self, 'MET_PF_eff').overlay_with_emu(getattr(self, 'MET_PF_Emu_eff'))
+        getattr(self, 'MET_PF_NoMu_eff').overlay_with_emu(getattr(self, 'MET_PF_NoMu_Emu_eff'))
+        getattr(self, 'singlel1JetEt_eff').overlay_with_emu(getattr(self, 'singlel1JetEt_Emu_eff'))
+        getattr(self, 'doublel1JetEt_eff').overlay_with_emu(getattr(self, 'doublel1JetEt_Emu_eff'))
+        getattr(self, 'triplel1JetEt_eff').overlay_with_emu(getattr(self, 'triplel1JetEt_Emu_eff'))
+        getattr(self, 'quadl1JetEt_eff').overlay_with_emu(getattr(self, 'quadl1JetEt_Emu_eff'))
+
+        return True

--- a/cmsl1t/analyzers/HW_Emu_jet_rates.py
+++ b/cmsl1t/analyzers/HW_Emu_jet_rates.py
@@ -146,8 +146,6 @@ class Analyzer(BaseAnalyzer):
         return True
 
     def make_plots(self):
-        # TODO: implement this in BaseAnalyzer
-        # make_plots -> make_plots(plot_func)
 
         # Get EMU thresholds for each HW threshold.
 
@@ -170,15 +168,18 @@ class Analyzer(BaseAnalyzer):
             if bin1 != 0.:
                 hist.Scale(40000000./bin1)
             h = get_cumulative_hist(hist)
-            bin1cumul = h.get_bin_content(1)
-            if bin1cumul != 0.:
-                h.Scale(40000000./bin1cumul)
             setattr(self, plot.online_name, h)
             plot.draw()
 
         print('  thresholds:')
 
         for histo_name in HW_types:
+            # Overlay HW with emulated
+            getattr(self, histo_name + '_rates').overlay_with_emu(getattr(self, histo_name + '_Emu_rates'))
+
+        for histo_name in HW_types:
+            # This is where we calculate the threshold for SingleMu which gives the same rate
+            # (i.e. this next bit is not needed if you're just plotting rates)
             h = getattr(self, histo_name)
             h_emu = getattr(self, histo_name + "_Emu")
             bin1 = h.get_bin_content(1)
@@ -247,4 +248,4 @@ def plot(hist, name, output_folder):
     hist.set_y_title('Rate (Hz)')
     hist.set_x_title(name)
     hist.Draw()
-    c.SaveAs(os.path.join(output_folder, file_name + '.pdf'))
+    c.SaveAs(os.path.join(output_folder, file_name + '_old.pdf'))

--- a/cmsl1t/analyzers/HW_Emu_jet_rates.py
+++ b/cmsl1t/analyzers/HW_Emu_jet_rates.py
@@ -1,0 +1,250 @@
+"""
+Study the MET distibutions and various PUS schemes
+"""
+import numpy as np
+import six
+import ROOT
+import os
+from cmsl1t.analyzers.BaseAnalyzer import BaseAnalyzer
+from cmsl1t.collections import HistogramsByPileUpCollection
+from cmsl1t.utils.draw import draw, label_canvas
+from cmsl1t.plotting.rates import RatesPlot
+import cmsl1t.hist.binning as bn
+
+
+sum_types = [
+    "HTT", "MHT", "MET_HF", "MET", "MET_PF", "MET_PF_NoMu", "MET_PF_HF",
+    "MET_PF_NoMu_HF",
+]
+
+jet_types = ["singlel1JetEt", "doublel1JetEt", "triplel1JetEt", "quadl1JetEt"]
+
+HW_types = sum_types + jet_types
+
+sum_types += [t + '_Emu' for t in sum_types]
+jet_types += [u + '_Emu' for u in jet_types]
+
+object_types = sum_types + jet_types
+
+def ExtractSums(event):
+    online = dict(
+        HTT=event.l1Sums["L1Htt"],
+        MHT=event.l1Sums["L1Mht"],
+        MET_HF=event.l1Sums["L1MetHF"],
+        MET=event.l1Sums["L1Met"],
+        MET_PF=event.l1Sums["L1Met"],
+        MET_PF_NoMu=event.l1Sums["L1Met"],
+        MET_PF_HF=event.l1Sums["L1MetHF"],
+        MET_PF_NoMu_HF=event.l1Sums["L1MetHF"],
+        HTT_Emu=event.l1Sums["L1EmuHtt"],
+        MHT_Emu=event.l1Sums["L1EmuMht"],
+        MET_HF_Emu=event.l1Sums["L1EmuMetHF"],
+        MET_Emu=event.l1Sums["L1EmuMet"],
+        MET_PF_Emu=event.l1Sums["L1EmuMet"],
+        MET_PF_NoMu_Emu=event.l1Sums["L1EmuMet"],
+        MET_PF_HF_Emu=event.l1Sums["L1EmuMetHF"],
+        MET_PF_NoMu_HF_Emu=event.l1Sums["L1EmuMetHF"]
+    )
+    return online
+
+class Analyzer(BaseAnalyzer):
+
+    def __init__(self, config, **kwargs):
+        super(Analyzer, self).__init__("HW_Emu_jet_rates", config)
+        self.triggerName = self.config.get('input', 'trigger')['name']
+
+        for name in object_types:
+            rates_plot = RatesPlot(name)
+            self.register_plotter(rates_plot)
+            setattr(self, name + "_rates", rates_plot)
+
+    def prepare_for_events(self, reader):
+        bins = np.arange(0.0, 400.0, 1.0)
+        puBins = self.puBins
+
+        for name in object_types:
+            rates_plot = getattr(self, name + "_rates")
+            rates_plot.build(name, puBins, 400, 0, 400)
+
+        '''
+        self.rates = HistogramsByPileUpCollection(
+            pileupBins=puBins, dimensions=2)
+        for thing in object_types:
+            self.rates.add(thing, bins)
+        '''
+
+        return True
+    
+    '''
+    def reload_histograms(self, input_file):
+        # Something like this needs to be implemented still
+        self.rates = HistogramsByPileUpCollection.from_root(input_file)
+        return True
+    '''
+
+    def fill_histograms(self, entry, event):
+        
+        # Get pileup if ntuples have reco trees in them.
+        # If not, set PU to 1 so that it fills the (only) pu bin.
+
+        try:
+            pileup = event.nVertex
+        except AttributeError:
+            pileup = 1.
+
+        #Sums:
+        online = ExtractSums(event)
+        for name in sum_types:
+            on = online[name]
+            getattr(self, name + "_rates").fill(pileup, on.et)
+
+        #Jets:
+        l1JetEts = [jet.et for jet in event._l1Jets]
+        nJets = len(l1JetEts)
+        if nJets > 0:
+            maxL1JetEt = max(l1JetEts)
+        else:
+            maxL1JetEt = 0.
+
+
+        l1EmuJetEts = [jet.et for jet in event._l1EmuJets]
+        nEmuJets = len(l1EmuJetEts)
+        if nEmuJets > 0:
+            maxL1EmuJetEt = max(l1EmuJetEts)
+        else:
+            maxL1EmuJetEt = 0.
+
+
+        if nJets == 0:
+            getattr(self, 'singlel1JetEt_rates').fill(pileup, 0.)
+            getattr(self, 'doublel1JetEt_rates').fill(pileup, 0.)
+            getattr(self, 'triplel1JetEt_rates').fill(pileup, 0.)
+            getattr(self, 'quadl1JetEt_rates').fill(pileup, 0.)
+        if nJets >= 1:
+            getattr(self, 'singlel1JetEt_rates').fill(pileup, maxL1JetEt)
+        if nJets >= 2:
+            getattr(self, 'doublel1JetEt_rates').fill(pileup, maxL1JetEt)
+        if nJets >= 3:
+            getattr(self, 'triplel1JetEt_rates').fill(pileup, maxL1JetEt)
+        if nJets >= 4:
+            getattr(self, 'quadl1JetEt_rates').fill(pileup, maxL1JetEt)
+
+        if nEmuJets == 0:
+            getattr(self, 'singlel1JetEt_Emu_rates').fill(pileup, 0.)
+            getattr(self, 'doublel1JetEt_Emu_rates').fill(pileup, 0.)
+            getattr(self, 'triplel1JetEt_Emu_rates').fill(pileup, 0.)
+            getattr(self, 'quadl1JetEt_Emu_rates').fill(pileup, 0.)
+        if nEmuJets >= 1:
+            getattr(self, 'singlel1JetEt_Emu_rates').fill(pileup, maxL1EmuJetEt)
+        if nEmuJets >= 2:
+            getattr(self, 'doublel1JetEt_Emu_rates').fill(pileup, maxL1EmuJetEt)
+        if nEmuJets >= 3:
+            getattr(self, 'triplel1JetEt_Emu_rates').fill(pileup, maxL1EmuJetEt)
+        if nEmuJets >= 4:
+            getattr(self, 'quadl1JetEt_Emu_rates').fill(pileup, maxL1EmuJetEt)
+
+        return True
+
+    def make_plots(self):
+        # TODO: implement this in BaseAnalyzer
+        # make_plots -> make_plots(plot_func)
+
+        # Get EMU thresholds for each HW threshold.
+
+        THRESHOLDS = self.thresholds
+        if THRESHOLDS == None:
+            print('Error: Please specify thresholds in the config .yaml in dictionary format')
+
+        for i in ['HF', 'PF', 'PF_NoMu', 'PF_HF', 'PF_NoMu_HF']:
+            if THRESHOLDS['MET_' + i] == None:
+                THRESHOLDS['MET_' + i] = THRESHOLDS['MET']
+
+        for j in ['doublel1JetEt', 'triplel1JetEt', 'quadl1JetEt']:
+            if THRESHOLDS[j] == None:
+                THRESHOLDS[j] = THRESHOLDS['singlel1JetEt']
+
+        # calculate cumulative histograms
+        for plot in self.all_plots:
+            hist = plot.plots.get_bin_contents([bn.Base.everything])
+            bin1 = hist.get_bin_content(1)
+            if bin1 != 0.:
+                hist.Scale(40000000./bin1)
+            h = get_cumulative_hist(hist)
+            bin1cumul = h.get_bin_content(1)
+            if bin1cumul != 0.:
+                h.Scale(40000000./bin1cumul)
+            setattr(self, plot.online_name, h)
+            plot.draw()
+
+        print('  thresholds:')
+
+        for histo_name in HW_types:
+            h = getattr(self, histo_name)
+            h_emu = getattr(self, histo_name + "_Emu")
+            bin1 = h.get_bin_content(1)
+            if bin1 != 0.:
+                h.Scale(40000000./bin1)
+            bin1_emu = h_emu.get_bin_content(1)
+            if bin1_emu != 0.:
+                h_emu.Scale(40000000./bin1_emu)
+            thresholds = THRESHOLDS.get(histo_name)
+            emu_thresholds = []
+            for thresh in thresholds:
+                rate_delta = []
+                hw_rate = h.get_bin_content(thresh)
+                for i in range(h.nbins()):
+                    emu_rate = h_emu.get_bin_content(i)
+                    if hw_rate == 0. or emu_rate == 0.:
+                        rate_delta.append(40000000.)
+                    else:
+                        rate_delta.append(abs(hw_rate - emu_rate))
+                emu_thresholds.append(rate_delta.index(min(rate_delta)))
+            outputline = ('    {0}: {1}'.format(histo_name, thresholds) + '\n'
+                          + '    {0}: {1}'.format(histo_name + '_Emu', emu_thresholds))
+            print(outputline)
+
+        '''
+        for histo_name in object_types:
+            h = getattr(self, histo_name)
+            plot(h, histo_name, self.output_folder)
+        '''
+        return True
+
+
+def _reverse(a):
+    return np.array(np.flipud(a))
+
+
+def get_cumulative_hist(hist):
+    h = hist.clone(hist.name + '_cumul')
+    arr = np.cumsum(_reverse([bin.value for bin in hist]))
+    h.set_content(_reverse(arr))
+    errors_sq = np.cumsum(_reverse([bin.error**2 for bin in hist]))
+    h.set_error(_reverse(np.sqrt(errors_sq)))
+
+    # now scale
+    bin1 = h.get_bin_content(1)
+    if bin1 != 0:
+        h.GetSumw2()
+        h.Scale(4.0e7 / bin1)
+    return h
+
+
+def plot(hist, name, output_folder):
+    pu = ''
+    if '_pu' in name:
+        pu = name.split('_')[-1]
+        name = name.replace('_' + pu, '')
+    file_name = 'rates_{name}'.format(name=name)
+    if 'nVertex' in name:
+        file_name = 'nVertex'
+    if pu:
+        file_name += '_' + pu
+    canvas_name = file_name.replace('SingleMu', 'Rates')
+    c = ROOT.TCanvas(canvas_name)
+    if 'nVertex' not in name:
+        c.SetLogy()
+    hist.set_y_title('Rate (Hz)')
+    hist.set_x_title(name)
+    hist.Draw()
+    c.SaveAs(os.path.join(output_folder, file_name + '.pdf'))

--- a/cmsl1t/analyzers/offline_met_analyzer.py
+++ b/cmsl1t/analyzers/offline_met_analyzer.py
@@ -283,7 +283,7 @@ class Analyzer(BaseAnalyzer):
                 getattr(self, name + "_phi_res").fill(pileup, off.phi, on.phi)
                 getattr(self, name + "_phi_2D").fill(pileup, off.phi, on.phi)
 
-        goodJets = event.goodJets(jetFilter=None)
+        goodJets = event.goodCaloJets(jetFilter=None)
 
         for recoJet in goodJets:
             l1Jet = event.getMatchedL1Jet(recoJet, l1Type='EMU')

--- a/cmsl1t/analyzers/offline_met_analyzer.py
+++ b/cmsl1t/analyzers/offline_met_analyzer.py
@@ -242,7 +242,7 @@ class Analyzer(BaseAnalyzer):
                 continue
             res_plot = getattr(self, cfg.name + prefix + "_res" + suffix)
             res_plot.build(cfg.on_title, cfg.off_title,
-                           puBins, 50, -10, 10, legend_title=ETA_RANGES.get(cfg.name, ""))
+                           puBins, 100, -5, 5, legend_title=ETA_RANGES.get(cfg.name, ""))
 
             if not hasattr(self, cfg.name + prefix + "_phi_res"):
                 continue
@@ -251,7 +251,7 @@ class Analyzer(BaseAnalyzer):
             twoD_plot.build(
                 cfg.on_title + " Phi (rad)",
                 cfg.off_title + " Phi (rad)",
-                puBins, 50,
+                puBins, 100,
                 -pi,
                 2 * pi,
             )
@@ -259,9 +259,9 @@ class Analyzer(BaseAnalyzer):
                 cfg.on_title + " Phi",
                 cfg.off_title + " Phi",
                 puBins,
-                50,
-                -2,
-                2,
+                100,
+                -2 * pi,
+                2 * pi,
                 legend_title=ETA_RANGES.get(cfg.name, ""),
             )
 

--- a/cmsl1t/analyzers/offline_met_analyzer.py
+++ b/cmsl1t/analyzers/offline_met_analyzer.py
@@ -283,17 +283,17 @@ class Analyzer(BaseAnalyzer):
                 getattr(self, name + "_phi_res").fill(pileup, off.phi, on.phi)
                 getattr(self, name + "_phi_2D").fill(pileup, off.phi, on.phi)
 
-        goodJets = event.goodJets()
+        goodJets = event.goodJets(jetFilter=None)
 
         for recoJet in goodJets:
             l1Jet = event.getMatchedL1Jet(recoJet, l1Type='EMU')
             if not l1Jet:
                 continue
-            if recoJet.caloEtCorr > 30.:
+            if recoJet.etCorr > 30.:
                 self.res_vs_eta_CentralJets.fill(
-                    pileup, recoJet.caloEta, recoJet.caloEtCorr, l1Jet.et)
+                    pileup, recoJet.eta, recoJet.etCorr, l1Jet.et)
 
-        leadingRecoJet = event.getLeadingRecoJet()
+        leadingRecoJet = event.getLeadingRecoCaloJet()
         if not leadingRecoJet:
             return True
 
@@ -302,9 +302,9 @@ class Analyzer(BaseAnalyzer):
             return True
 
         fillRegions = []
-        if abs(leadingRecoJet.caloEta) < 1.479:
+        if abs(leadingRecoJet.eta) < 1.479:
             fillRegions = ['B', 'BE']
-        elif abs(leadingRecoJet.caloEta) < 3.0:
+        elif abs(leadingRecoJet.eta) < 3.0:
             fillRegions = ['E', 'BE']
         else:
             fillRegions = ['HF']
@@ -312,7 +312,7 @@ class Analyzer(BaseAnalyzer):
             for suffix in ['_eff', '_res', '_2D', '_eff_HR', '_2D_HR']:
                 name = 'jetET_{0}_Emu{1}'.format(region, suffix)
                 getattr(self, name).fill(
-                    pileup, leadingRecoJet.caloEtCorr, l1EmuJet.et,
+                    pileup, leadingRecoJet.etCorr, l1EmuJet.et,
                 )
 
         l1Jet = event.getMatchedL1Jet(leadingRecoJet, l1Type='HW')
@@ -323,7 +323,7 @@ class Analyzer(BaseAnalyzer):
             for suffix in ['_eff', '_res', '_2D', '_eff_HR', '_2D_HR']:
                 name = 'jetET_{0}{1}'.format(region, suffix)
                 getattr(self, name).fill(
-                    pileup, leadingRecoJet.caloEtCorr, l1Jet.et,
+                    pileup, leadingRecoJet.etCorr, l1Jet.et,
                 )
 
         return True

--- a/cmsl1t/analyzers/offline_met_analyzer.py
+++ b/cmsl1t/analyzers/offline_met_analyzer.py
@@ -69,7 +69,7 @@ def ExtractSums(event):
         MET_PF_NoMu=Met(event.sums.pfMetNoMu, event.sums.pfMetNoMuPhi),
         MET_PF_HF=Met(event.sums.met, event.sums.metPhi),
         MET_PF_NoMu_HF=Met(event.sums.pfMetNoMu, event.sums.pfMetNoMuPhi),
-        HTT_Emu=Sum(event.sums.Ht),
+        HTT_Emu=Sum(event.sums.caloHt),
         MHT_Emu=Met(event.sums.mHt, event.sums.mHtPhi),
         MET_HF_Emu=Met(event.sums.caloMet, event.sums.caloMetPhi),
         MET_Emu=Met(event.sums.caloMetBE, event.sums.caloMetPhiBE),
@@ -226,7 +226,7 @@ class Analyzer(BaseAnalyzer):
             thresholds = THRESHOLDS.get(cfg.name)
             params = [
                 cfg.on_title, cfg.off_title + " (GeV)", puBins, thresholds,
-                50, cfg.min, cfg.max,
+                200, cfg.min, cfg.max,
             ]
             if high_range:
                 params = [
@@ -289,9 +289,9 @@ class Analyzer(BaseAnalyzer):
             l1Jet = event.getMatchedL1Jet(recoJet, l1Type='EMU')
             if not l1Jet:
                 continue
-            if recoJet.etCorr > 30.:
+            if recoJet.caloEtCorr > 30.:
                 self.res_vs_eta_CentralJets.fill(
-                    pileup, recoJet.eta, recoJet.etCorr, l1Jet.et)
+                    pileup, recoJet.caloEta, recoJet.caloEtCorr, l1Jet.et)
 
         leadingRecoJet = event.getLeadingRecoJet()
         if not leadingRecoJet:
@@ -302,9 +302,9 @@ class Analyzer(BaseAnalyzer):
             return True
 
         fillRegions = []
-        if abs(leadingRecoJet.eta) < 1.479:
+        if abs(leadingRecoJet.caloEta) < 1.479:
             fillRegions = ['B', 'BE']
-        elif abs(leadingRecoJet.eta) < 3.0:
+        elif abs(leadingRecoJet.caloEta) < 3.0:
             fillRegions = ['E', 'BE']
         else:
             fillRegions = ['HF']
@@ -312,7 +312,7 @@ class Analyzer(BaseAnalyzer):
             for suffix in ['_eff', '_res', '_2D', '_eff_HR', '_2D_HR']:
                 name = 'jetET_{0}_Emu{1}'.format(region, suffix)
                 getattr(self, name).fill(
-                    pileup, leadingRecoJet.etCorr, l1EmuJet.et,
+                    pileup, leadingRecoJet.caloEtCorr, l1EmuJet.et,
                 )
 
         l1Jet = event.getMatchedL1Jet(leadingRecoJet, l1Type='HW')

--- a/cmsl1t/analyzers/offline_met_analyzer.py
+++ b/cmsl1t/analyzers/offline_met_analyzer.py
@@ -326,3 +326,21 @@ class Analyzer(BaseAnalyzer):
                 )
 
         return True
+
+    def make_plots(self):
+        """
+        Custom version, does what the normal one does but also overlays whatever you like.
+        """
+        for plot in self.all_plots:
+            plot.draw()
+        getattr(self, 'HTT_eff').overlay_with_emu(getattr(self, 'HTT_Emu_eff'))
+        getattr(self, 'MET_eff').overlay_with_emu(getattr(self, 'MET_Emu_eff'))
+        getattr(self, 'MET_HF_eff').overlay_with_emu(getattr(self, 'MET_HF_Emu_eff'))
+        getattr(self, 'MET_PF_eff').overlay_with_emu(getattr(self, 'MET_PF_Emu_eff'))
+        getattr(self, 'MET_PF_NoMu_eff').overlay_with_emu(getattr(self, 'MET_PF_NoMu_Emu_eff'))
+        getattr(self, 'jetET_B_eff').overlay_with_emu(getattr(self, 'jetET_B_Emu_eff'))
+        getattr(self, 'jetET_E_eff').overlay_with_emu(getattr(self, 'jetET_E_Emu_eff'))
+        getattr(self, 'jetET_BE_eff').overlay_with_emu(getattr(self, 'jetET_BE_Emu_eff'))
+        getattr(self, 'jetET_HF_eff').overlay_with_emu(getattr(self, 'jetET_HF_Emu_eff'))
+
+        return True

--- a/cmsl1t/analyzers/offline_met_analyzer.py
+++ b/cmsl1t/analyzers/offline_met_analyzer.py
@@ -61,7 +61,7 @@ for i in ['E', 'BE', 'HF']:
 
 def ExtractSums(event):
     offline = dict(
-        HTT=Sum(event.sums.Ht),
+        HTT=Sum(event.sums.caloHt),
         MHT=Met(event.sums.mHt, event.sums.mHtPhi),
         MET_HF=Met(event.sums.caloMet, event.sums.caloMetPhi),
         MET=Met(event.sums.caloMetBE, event.sums.caloMetPhiBE),
@@ -323,7 +323,7 @@ class Analyzer(BaseAnalyzer):
             for suffix in ['_eff', '_res', '_2D', '_eff_HR', '_2D_HR']:
                 name = 'jetET_{0}{1}'.format(region, suffix)
                 getattr(self, name).fill(
-                    pileup, leadingRecoJet.etCorr, l1Jet.et,
+                    pileup, leadingRecoJet.caloEtCorr, l1Jet.et,
                 )
 
         return True

--- a/cmsl1t/analyzers/offline_met_analyzer.py
+++ b/cmsl1t/analyzers/offline_met_analyzer.py
@@ -242,7 +242,7 @@ class Analyzer(BaseAnalyzer):
                 continue
             res_plot = getattr(self, cfg.name + prefix + "_res" + suffix)
             res_plot.build(cfg.on_title, cfg.off_title,
-                           puBins, 50, -10, 10)
+                           puBins, 50, -10, 10, legend_title=ETA_RANGES.get(cfg.name, ""))
 
             if not hasattr(self, cfg.name + prefix + "_phi_res"):
                 continue
@@ -262,6 +262,7 @@ class Analyzer(BaseAnalyzer):
                 50,
                 -2,
                 2,
+                legend_title=ETA_RANGES.get(cfg.name, ""),
             )
 
     def fill_histograms(self, entry, event):
@@ -342,5 +343,15 @@ class Analyzer(BaseAnalyzer):
         getattr(self, 'jetET_E_eff').overlay_with_emu(getattr(self, 'jetET_E_Emu_eff'))
         getattr(self, 'jetET_BE_eff').overlay_with_emu(getattr(self, 'jetET_BE_Emu_eff'))
         getattr(self, 'jetET_HF_eff').overlay_with_emu(getattr(self, 'jetET_HF_Emu_eff'))
+
+        getattr(self, 'HTT_res').overlay_with_emu(getattr(self, 'HTT_Emu_res'))
+        getattr(self, 'MET_res').overlay_with_emu(getattr(self, 'MET_Emu_res'))
+        getattr(self, 'MET_HF_res').overlay_with_emu(getattr(self, 'MET_HF_Emu_res'))
+        getattr(self, 'MET_PF_res').overlay_with_emu(getattr(self, 'MET_PF_Emu_res'))
+        getattr(self, 'MET_PF_NoMu_res').overlay_with_emu(getattr(self, 'MET_PF_NoMu_Emu_res'))
+        getattr(self, 'jetET_B_res').overlay_with_emu(getattr(self, 'jetET_B_Emu_res'))
+        getattr(self, 'jetET_E_res').overlay_with_emu(getattr(self, 'jetET_E_Emu_res'))
+        getattr(self, 'jetET_BE_res').overlay_with_emu(getattr(self, 'jetET_BE_Emu_res'))
+        getattr(self, 'jetET_HF_res').overlay_with_emu(getattr(self, 'jetET_HF_Emu_res'))
 
         return True

--- a/cmsl1t/hist/binning.py
+++ b/cmsl1t/hist/binning.py
@@ -54,6 +54,16 @@ class Base():
             return bin_index
         return self._bin_center(bin_index)
 
+    def get_bin_upper(self, bin_index):
+        if bin_index in [self.overflow, self.underflow, self.everything]:
+            return bin_index
+        return self._bin_upper_edge(bin_index)
+
+    def get_bin_lower(self, bin_index):
+        if bin_index in [self.overflow, self.underflow, self.everything]:
+            return bin_index
+        return self._bin_lower_edge(bin_index)
+
     def get_bin_contents(self, bin_index):
         contents = self.values.get(bin_index, "DoesntExist")
         if contents is "DoesntExist":
@@ -125,6 +135,20 @@ class Sorted(Base):
             return (self.bins[bin_index + 1] + self.bins[bin_index]) * 0.5
         except IndexError as e:
             logger.error("Cannot get bin center for index " + str(bin_index))
+            raise e
+
+    def _bin_upper_edge(self, bin_index):
+        try:
+            return (self.bins[bin_index + 1])
+        except IndexError as e:
+            logger.error("Cannot get bin upper edge for index " + str(bin_index))
+            raise e
+
+    def _bin_lower_edge(self, bin_index):
+        try:
+            return (self.bins[bin_index])
+        except IndexError as e:
+            logger.error("Cannot get bin lower edge for index " + str(bin_index))
             raise e
 
 

--- a/cmsl1t/playground/eventreader.py
+++ b/cmsl1t/playground/eventreader.py
@@ -88,7 +88,7 @@ class Event(object):
 
         if "jetReco" in tree_names:
             self._jets = []
-            for i in range(self._jetReco.Jet.nJets):
+            for i in range(self._jetReco.Jet.nCaloJets):
                 self._jets.append(Jet(self._jetReco.Jet, i))
 
     def _readUpgradeSums(self):
@@ -154,7 +154,7 @@ class Event(object):
         '''
         goodJets = filter(jetFilter, self._jets)
         sorted_jets = sorted(
-            goodJets, key=lambda jet: jet.etCorr, reverse=True)
+            goodJets, key=lambda jet: jet.caloEtCorr, reverse=True)
         return sorted_jets
 
     def getLeadingRecoJet(self, jetFilter=defaultJetFilter):
@@ -162,7 +162,7 @@ class Event(object):
         if not goodJets:
             return None
         leadingRecoJet = goodJets[0]
-        if leadingRecoJet.etCorr > 10.0:
+        if leadingRecoJet.caloEtCorr > 10.0:
             return leadingRecoJet
         return None
 
@@ -220,7 +220,7 @@ class Jet(object):
         # this could be simplified with a list of attributes
         read_attributes = [
             'etCorr', 'muMult', 'eta', 'phi', 'nhef', 'pef', 'mef', 'chMult',
-            'elMult', 'nhMult', 'phMult', 'chef', 'eef'
+            'elMult', 'nhMult', 'phMult', 'chef', 'eef', 'caloEtCorr', 'caloEta'
         ]
         for attr in read_attributes:
             setattr(self, attr, getattr(jets, attr)[index])

--- a/cmsl1t/playground/eventreader.py
+++ b/cmsl1t/playground/eventreader.py
@@ -178,8 +178,8 @@ class Event(object):
         minDeltaR = 0.3
         closestJet = None
         for l1Jet in l1Jets:
-            dEta = recoJet.eta - l1Jet.eta
-            dPhi = recoJet.phi - l1Jet.phi
+            dEta = recoJet.caloEta - l1Jet.eta
+            dPhi = recoJet.caloPhi - l1Jet.phi
             dR = math.sqrt(dEta**2 + dPhi**2)
             if dR < minDeltaR:
                 minDeltaR = dR
@@ -220,7 +220,7 @@ class Jet(object):
         # this could be simplified with a list of attributes
         read_attributes = [
             'etCorr', 'muMult', 'eta', 'phi', 'nhef', 'pef', 'mef', 'chMult',
-            'elMult', 'nhMult', 'phMult', 'chef', 'eef', 'caloEtCorr', 'caloEta'
+            'elMult', 'nhMult', 'phMult', 'chef', 'eef', 'caloEtCorr', 'caloEta', 'caloPhi'
         ]
         for attr in read_attributes:
             setattr(self, attr, getattr(jets, attr)[index])

--- a/cmsl1t/playground/eventreader.py
+++ b/cmsl1t/playground/eventreader.py
@@ -162,6 +162,17 @@ class Event(object):
             goodJets, key=lambda jet: jet.etCorr, reverse=True)
         return sorted_jets
 
+    def goodCaloJets(self, jetFilter=None):
+        '''
+            filters and ET orders the calo jet collection
+        '''
+        goodJets = self._caloJets
+        if jetFilter:
+            goodJets = filter(jetFilter, self._caloJets)
+        sorted_jets = sorted(
+            goodJets, key=lambda jet: jet.etCorr, reverse=True)
+        return sorted_jets
+
     def getLeadingRecoJet(self, jetFilter=defaultJetFilter):
         goodJets = self.goodJets(jetFilter)
         if not goodJets:
@@ -171,9 +182,14 @@ class Event(object):
             return leadingRecoJet
         return None
 
-    def getLeadingRecoCaloJet(self):
-        leadingRecoCaloJet = self.getLeadingRecoJet(jetFilter=None)
-        return leadingRecoCaloJet
+    def getLeadingRecoCaloJet(self, jetFilter=None):
+        goodJets = self.goodCaloJets(jetFilter)
+        if not goodJets:
+            return None
+        leadingRecoJet = goodJets[0]
+        if leadingRecoJet.etCorr > 10.0:
+            return leadingRecoJet
+        return None
 
     def getMatchedL1Jet(self, recoJet, l1Type='HW'):
         l1Jets = None

--- a/cmsl1t/playground/jetfilters.py
+++ b/cmsl1t/playground/jetfilters.py
@@ -5,8 +5,8 @@ def jetFilterNoHF(jet):
     '''
         also a lot of potential for simplification
     '''
-    isForwardJet = geo.is_in_region('HF', jet.eta)
-    innerJet = abs(jet.eta) <= 2.4
+    isForwardJet = geo.is_in_region('HF', jet.caloEta)
+    innerJet = abs(jet.caloEta) <= 2.4
     reject_if = [
         jet.muMult != 0,
         isForwardJet,
@@ -24,4 +24,4 @@ def jetFilterNoHF(jet):
 
 
 def defaultJetFilter(jet):
-    return (abs(jet.eta) > 3.0 or jetFilterNoHF(jet)) and jet.etCorr > 30.
+    return (abs(jet.caloEta) > 3.0 or jetFilterNoHF(jet)) and jet.caloEtCorr > 30.

--- a/cmsl1t/playground/jetfilters.py
+++ b/cmsl1t/playground/jetfilters.py
@@ -5,8 +5,8 @@ def jetFilterNoHF(jet):
     '''
         also a lot of potential for simplification
     '''
-    isForwardJet = geo.is_in_region('HF', jet.caloEta)
-    innerJet = abs(jet.caloEta) <= 2.4
+    isForwardJet = geo.is_in_region('HF', jet.eta)
+    innerJet = abs(jet.eta) <= 2.4
     reject_if = [
         jet.muMult != 0,
         isForwardJet,
@@ -24,4 +24,4 @@ def jetFilterNoHF(jet):
 
 
 def defaultJetFilter(jet):
-    return (abs(jet.caloEta) > 3.0 or jetFilterNoHF(jet)) and jet.caloEtCorr > 30.
+    return (abs(jet.eta) > 3.0 or jetFilterNoHF(jet)) and jet.etCorr > 30.

--- a/cmsl1t/plotting/efficiency.py
+++ b/cmsl1t/plotting/efficiency.py
@@ -63,7 +63,7 @@ class EfficiencyPlot(BasePlotter):
                 eff = asrootpy(
                     ROOT.TEfficiency(this_name, this_title, n_bins, low, high)
                 )
-            eff.drawstyle = "EP"
+            eff.drawstyle = "HIST"
             return eff
         self.efficiencies = HistogramCollection(
             [self.pileup_bins, self.thresholds],
@@ -99,7 +99,7 @@ class EfficiencyPlot(BasePlotter):
             if not isinstance(threshold, int):
                 continue
             hist = all_pileup_effs.get_bin_contents(threshold)
-            hist.drawstyle = "EP"
+            hist.drawstyle = "P"
             hists.append(hist)
 
             label = label_template.format(
@@ -123,7 +123,7 @@ class EfficiencyPlot(BasePlotter):
                 if not isinstance(pileup, int):
                     continue
                 hist = self.efficiencies.get_bin_contents([pileup, threshold])
-                hist.drawstyle = "EP"
+                hist.drawstyle = "P"
                 hists.append(hist)
                 if with_fits:
                     fits.append(self.fits.get_bin_contents(
@@ -150,11 +150,14 @@ class EfficiencyPlot(BasePlotter):
         labels = []
         fits = []
         label_template = '{online_title} > {threshold} (GeV)'
+
+        ROOT.gStyle.SetErrorX(0.)
+
         for threshold in all_pileup_effs.iter_all():
             if not isinstance(threshold, int):
                 continue
             hist = all_pileup_effs.get_bin_contents(threshold)
-            hist.drawstyle = "EP"
+            hist.drawstyle = "P"
             hists.append(hist)
 
             label = label_template.format(
@@ -170,7 +173,7 @@ class EfficiencyPlot(BasePlotter):
             if not isinstance(threshold, int):
                 continue
             hist = emu_pileup_effs.get_bin_contents(threshold)
-            hist.drawstyle = "EP"
+            hist.drawstyle = "P"
             hist.markerstyle = 3
             hists.append(hist)
 
@@ -244,8 +247,8 @@ class EfficiencyPlot(BasePlotter):
                 topmargin=0.35,
                 rightmargin=0.3,
                 leftmargin=0.7,
-                textsize=0.02,
-                entryheight=0.02,
+                textsize=0.015,
+                entryheight=0.015,
             )
             for hist, label in zip(hists, labels):
                 legend.AddEntry(hist, label)

--- a/cmsl1t/plotting/efficiency.py
+++ b/cmsl1t/plotting/efficiency.py
@@ -72,7 +72,7 @@ class EfficiencyPlot(BasePlotter):
             make_efficiency
         )
 
-    def fill(self, pileup, online, offline):
+    def fill(self, pileup, offline, online):
         efficiencies = {(pu, thresh): eff
                         for (pu,), thresholds in self.efficiencies[pileup].items()
                         for thresh, eff in thresholds.items()}

--- a/cmsl1t/plotting/efficiency.py
+++ b/cmsl1t/plotting/efficiency.py
@@ -59,10 +59,12 @@ class EfficiencyPlot(BasePlotter):
                 eff = asrootpy(
                     ROOT.TEfficiency(this_name, this_title, n_bins, low)
                 )
+                self.x_max = 1700
             else:
                 eff = asrootpy(
                     ROOT.TEfficiency(this_name, this_title, n_bins, low, high)
                 )
+                self.x_max = high
             eff.drawstyle = "HIST"
             return eff
         self.efficiencies = HistogramCollection(
@@ -230,6 +232,7 @@ class EfficiencyPlot(BasePlotter):
     def __make_overlay(self, pileup, threshold, hists, fits, labels, header):
         with preserve_current_style():
             # Draw each efficiency (with fit)
+
             canvas = draw(hists, draw_args={"xtitle": self.offline_title,
                                             "ytitle": "Efficiency"})
             if len(fits) > 0:
@@ -254,6 +257,20 @@ class EfficiencyPlot(BasePlotter):
                 legend.AddEntry(hist, label)
             legend.SetBorderSize(0)
             legend.Draw()
+
+            xmax = self.x_max
+
+            for val in [0.25, 0.5, 0.75, 1.]:
+                line = ROOT.TLine(0., val, xmax, val)
+                line.SetLineStyle("dashed")
+                line.SetLineColor(15)
+                line.Draw()
+
+            for val in range(150, xmax, 150):
+                line = ROOT.TLine(val, 0., val, 1.)
+                line.SetLineStyle("dashed")
+                line.SetLineColor(15)
+                line.Draw()
 
             # Save canvas to file
             name = self.filename_format.format(pileup=pileup,

--- a/cmsl1t/plotting/efficiency.py
+++ b/cmsl1t/plotting/efficiency.py
@@ -136,6 +136,80 @@ class EfficiencyPlot(BasePlotter):
         if with_fits:
             self.__summarize_fits()
 
+    def overlay_with_emu(self, emu_plotter, with_fits=True):
+        # Fit the efficiencies if requested
+        if with_fits:
+            self.__fit_efficiencies()
+
+        # Overlay the "all" pile-up bin for each threshold
+        all_pileup_effs = self.efficiencies.get_bin_contents(
+            [bn.Base.everything])
+        emu_pileup_effs = emu_plotter.efficiencies.get_bin_contents(
+            [bn.Base.everything])
+        hists = []
+        labels = []
+        fits = []
+        label_template = '{online_title} > {threshold} (GeV)'
+        for threshold in all_pileup_effs.iter_all():
+            if not isinstance(threshold, int):
+                continue
+            hist = all_pileup_effs.get_bin_contents(threshold)
+            hist.drawstyle = "EP"
+            hists.append(hist)
+
+            label = label_template.format(
+                online_title=self.online_title,
+                threshold=self.thresholds.bins[threshold],
+            )
+            labels.append(label)
+            if with_fits:
+                fits.append(self.fits.get_bin_contents(
+                    [bn.Base.everything, threshold]))
+
+        for threshold in emu_pileup_effs.iter_all():
+            if not isinstance(threshold, int):
+                continue
+            hist = emu_pileup_effs.get_bin_contents(threshold)
+            hist.drawstyle = "EP"
+            hist.markerstyle = 3
+            hists.append(hist)
+
+            label = label_template.format(
+                online_title=emu_plotter.online_title + ' Emu',
+                threshold=emu_plotter.thresholds.bins[threshold],
+            )
+            labels.append(label)
+            if with_fits:
+                fits.append(emu_plotter.fits.get_bin_contents(
+                    [bn.Base.everything, threshold]))
+
+        self.__make_overlay(
+            "all", "all_overlay_with_Emu", hists, fits, labels, self.online_title,
+        )
+
+        '''
+        # Overlay individual pile-up bins for each threshold
+        for threshold in self.thresholds:
+            hists = []
+            labels = []
+            fits = []
+            for pileup in self.pileup_bins:
+                if not isinstance(pileup, int):
+                    continue
+                hist = self.efficiencies.get_bin_contents([pileup, threshold])
+                hist.drawstyle = "EP"
+                hists.append(hist)
+                if with_fits:
+                    fits.append(self.fits.get_bin_contents(
+                        [pileup, threshold]))
+                labels.append(str(self.pileup_bins.bins[pileup]))
+            self.__make_overlay(pileup, threshold, hists,
+                                fits, labels, "PU bin")
+        '''
+        # Produce the fit summary plot
+        if with_fits:
+            self.__summarize_fits()
+
     def __fit_efficiencies(self):
         def make_fit(labels):
             pileup_bin = labels["pileup"]
@@ -170,8 +244,8 @@ class EfficiencyPlot(BasePlotter):
                 topmargin=0.35,
                 rightmargin=0.3,
                 leftmargin=0.7,
-                textsize=0.035,
-                entryheight=0.035,
+                textsize=0.02,
+                entryheight=0.02,
             )
             for hist, label in zip(hists, labels):
                 legend.AddEntry(hist, label)

--- a/cmsl1t/plotting/rates.py
+++ b/cmsl1t/plotting/rates.py
@@ -1,0 +1,124 @@
+from __future__ import print_function
+import numpy as np
+from cmsl1t.plotting.base import BasePlotter
+from cmsl1t.hist.hist_collection import HistogramCollection
+from cmsl1t.hist.factory import HistFactory
+import cmsl1t.hist.binning as bn
+from cmsl1t.utils.draw import draw, label_canvas
+from cmsl1t.recalc.resolution import get_resolution_function
+
+from rootpy.context import preserve_current_style
+from rootpy.plotting import Legend
+
+def get_cumulative_hist(hist):
+    h = hist.clone(hist.name + '_cumul')
+    arr = np.cumsum(_reverse([bin.value for bin in hist]))
+    h.set_content(_reverse(arr))
+    errors_sq = np.cumsum(_reverse([bin.error**2 for bin in hist]))
+    h.set_error(_reverse(np.sqrt(errors_sq)))
+
+    # now scale
+    bin1 = h.get_bin_content(1)
+    if bin1 != 0:
+        h.GetSumw2()
+        h.Scale(4.0e7 / bin1)
+    return h
+
+def _reverse(a):
+    return np.array(np.flipud(a))
+
+class RatesPlot(BasePlotter):
+    def __init__(self, online_name):
+        name = ["rates", online_name]
+        super(RatesPlot, self).__init__("__".join(name))
+        self.online_name = online_name
+
+    def create_histograms(self,
+                          online_title,
+                          pileup_bins, n_bins, low, high):
+        """ This is not in an init function so that we can by-pass this in the
+        case where we reload things from disk """
+        self.online_title = online_title
+        self.pileup_bins = bn.Sorted(pileup_bins, "pileup",
+                                     use_everything_bin=True)
+
+        name = ["resolution", self.online_name, "pu_{pileup}"]
+        name = "__".join(name)
+        title = " ".join([self.online_name, "vs.", "in PU bin: {pileup}"])
+        title = ";".join([title, self.online_title])
+        self.plots = HistogramCollection([self.pileup_bins],
+                                         "Hist1D", n_bins, low, high,
+                                         name=name, title=title)
+        self.filename_format = name
+
+    def fill(self, pileup, online):
+        self.plots[pileup].fill(online)
+
+    def draw(self, with_fits=False):
+        hists = []
+        labels = []
+        fits = []
+        for (pile_up, ), hist in self.plots.flat_items_all():
+            h = get_cumulative_hist(hist)
+            bin1 = h.get_bin_content(1)
+            if bin1 != 0.:
+                h.scale(40000000./bin1)
+            if pile_up == bn.Base.everything:
+                h.linestyle = "dashed"
+                label = "Everything"
+            elif isinstance(pile_up, int):
+                h.drawstyle = "EP"
+                label = "~ {:.0f}".format(self.pileup_bins.get_bin_center(pile_up))
+            else:
+                continue
+            h = get_cumulative_hist(hist)
+            h.SetMarkerSize(0.5)
+            hists.append(h)
+            labels.append(label)
+            # if with_fits:
+            #     fits.append(self.fits.get_bin_contents([pile_up]))
+        self.__make_overlay(hists, fits, labels, "Number of events")
+
+        normed_hists = [hist / hist.integral() if hist.integral() != 0 else hist.Clone() for hist in hists]
+        self.__make_overlay(normed_hists, fits, labels, "Fraction of events", "__shapes")
+
+    def __make_overlay(self, hists, fits, labels, ytitle, suffix=""):
+        with preserve_current_style():
+            # Draw each resolution (with fit)
+            xtitle = self.online_title
+            canvas = draw(hists, draw_args={"xtitle": xtitle, "ytitle": ytitle})
+            if fits:
+                for fit, hist in zip(fits, hists):
+                    fit["asymmetric"].linecolor = hist.GetLineColor()
+                    fit["asymmetric"].Draw("same")
+
+            # Add labels
+            label_canvas()
+
+            # Add a legend
+            legend = Legend(len(hists), header="Pile-up bin",
+                            topmargin=0.35, entryheight=0.035)
+            for hist, label in zip(hists, labels):
+                legend.AddEntry(hist, label)
+            legend.SetBorderSize(0)
+            legend.Draw()
+
+            # Save canvas to file
+            name = self.filename_format.format(pileup="all")
+            self.save_canvas(canvas, name + suffix)
+
+
+    def _is_consistent(self, new):
+        """
+        Check the two plotters are the consistent, so same binning and same axis names
+        """
+        return all([self.pileup_bins.bins == new.pileup_bins.bins,
+                    self.online_name == new.online_name,
+                    ])
+
+    def _merge(self, other):
+        """
+        Merge another plotter into this one
+        """
+        self.plots += other.plots
+        return self.plots

--- a/cmsl1t/plotting/resolution.py
+++ b/cmsl1t/plotting/resolution.py
@@ -58,6 +58,7 @@ class ResolutionPlot(BasePlotter):
             else:
                 continue
             hist.SetMarkerSize(0.5)
+            hist.SetLineWidth(2)
             hists.append(hist)
             labels.append(label)
             # if with_fits:
@@ -65,6 +66,9 @@ class ResolutionPlot(BasePlotter):
         self.__make_overlay(hists, fits, labels, "Number of events")
 
         normed_hists = [hist / hist.integral() if hist.integral() != 0 else hist.Clone() for hist in hists]
+        for hist in normed_hists:
+            if hist.integral != 0:
+                hist.GetYaxis().SetRangeUser(-0.1, 1.1)
         self.__make_overlay(normed_hists, fits, labels, "Fraction of events", "__shapes")
 
 
@@ -79,7 +83,7 @@ class ResolutionPlot(BasePlotter):
                 label = "HW, all PU"
             else:
                 continue
-            hist.SetLineWidth(3)
+            hist.SetLineWidth(2)
             hists.append(hist)
             labels.append(label)
 
@@ -90,7 +94,7 @@ class ResolutionPlot(BasePlotter):
                 label = "Emu, all PU"
             else:
                 continue
-            hist.SetLineWidth(3)
+            hist.SetLineWidth(2)
             hists.append(hist)
             labels.append(label)
 

--- a/cmsl1t/plotting/resolution.py
+++ b/cmsl1t/plotting/resolution.py
@@ -8,6 +8,7 @@ from cmsl1t.recalc.resolution import get_resolution_function
 
 from rootpy.context import preserve_current_style
 from rootpy.plotting import Legend
+from rootpy import ROOT
 
 
 class ResolutionPlot(BasePlotter):
@@ -50,10 +51,10 @@ class ResolutionPlot(BasePlotter):
             if pile_up == bn.Base.everything:
                 hist.linestyle = "dashed"
                 hist.drawstyle = "hist"
-                label = "Everything"
+                label = "All PU"
             elif isinstance(pile_up, int):
                 hist.drawstyle = "hist"
-                label = "PU ~ {:.0f}".format(self.pileup_bins.get_bin_center(pile_up))
+                label = "{:.0f} \\leq PU < {:.0f}".format(self.pileup_bins.get_bin_lower(pile_up), self.pileup_bins.get_bin_upper(pile_up))
             else:
                 continue
             hist.SetMarkerSize(0.5)
@@ -125,6 +126,13 @@ class ResolutionPlot(BasePlotter):
                 legend.AddEntry(hist, label)
             legend.SetBorderSize(0)
             legend.Draw()
+
+            ymax = 1.2 * hists[-1].GetMaximum()
+
+            line = ROOT.TLine(0., 0., 0., ymax)
+            line.SetLineStyle("dashed")
+            line.SetLineColor(15)
+            line.Draw()
 
             # Save canvas to file
             name = self.filename_format.format(pileup="all")

--- a/cmsl1t/plotting/resolution.py
+++ b/cmsl1t/plotting/resolution.py
@@ -132,7 +132,7 @@ class ResolutionPlot(BasePlotter):
             line = ROOT.TLine(0., 0., 0., ymax)
             line.SetLineStyle("dashed")
             line.SetLineColor(15)
-            line.Draw()
+            #line.Draw()
 
             # Save canvas to file
             name = self.filename_format.format(pileup="all")

--- a/cmsl1t/utils/draw.py
+++ b/cmsl1t/utils/draw.py
@@ -3,7 +3,7 @@ from rootpy.plotting.hist import _HistBase, Efficiency
 from rootpy.plotting.graph import _GraphBase
 from rootpy.plotting import Style, Canvas
 from rootpy.context import preserve_current_style
-from rootpy.ROOT import gStyle, TLatex
+from rootpy.ROOT import gStyle, TLatex, TStyle
 from rootpy import asrootpy
 import rootpy.ROOT as ROOT
 from exceptions import RuntimeError
@@ -84,13 +84,14 @@ def __clean(hists):
     for hist in hists:
         if isinstance(hist, Efficiency):
             new = asrootpy(hist.CreateGraph("e0"))
-            np = new.GetN()
-            for i in range(1, new.GetN() + 1):
-                new.SetPointEXhigh(i,0.)
-                new.SetPointEXlow(i,0.)
+            #for i in range(1, new.GetN() + 1):
+                #new.SetPointEXhigh(i,0.)
+                #new.SetPointEXlow(i,0.)
             new.decorate(hist)
             hist = new
             hist.SetMarkerSize(0.5)
+            hist.SetLineWidth(1)
+            gStyle.SetLineScalePS(1)
         cleaned_hists.append(hist)
 
     axis_hist = cleaned_hists[0]

--- a/cmsl1t/utils/draw.py
+++ b/cmsl1t/utils/draw.py
@@ -92,6 +92,8 @@ def __clean(hists):
             hist.SetMarkerSize(0.5)
             hist.SetLineWidth(1)
             gStyle.SetLineScalePS(1)
+        else:
+            gStyle.SetLineScalePS(3)
         cleaned_hists.append(hist)
 
     axis_hist = cleaned_hists[0]

--- a/cmsl1t/utils/draw.py
+++ b/cmsl1t/utils/draw.py
@@ -84,6 +84,10 @@ def __clean(hists):
     for hist in hists:
         if isinstance(hist, Efficiency):
             new = asrootpy(hist.CreateGraph("e0"))
+            np = new.GetN()
+            for i in range(1, new.GetN() + 1):
+                new.SetPointEXhigh(i,0.)
+                new.SetPointEXlow(i,0.)
             new.decorate(hist)
             hist = new
             hist.SetMarkerSize(0.5)

--- a/config/HW_Emu_constant_rate_turnons.yaml
+++ b/config/HW_Emu_constant_rate_turnons.yaml
@@ -26,13 +26,38 @@ analysis:
   do_fit: True
   pu_type: 0PU12,13PU19,20PU
   pu_bins: [0,13,20,999]
+  thresholds:
+    HTT: [160, 220, 280, 340, 400]
+    HTT_Emu: [160, 218, 273, 333, 333]
+    MHT: [40, 60, 80, 100, 120]
+    MHT_Emu: [40, 60, 80, 100, 120]
+    MET_HF: [40, 60, 80, 100, 120]
+    MET_HF_Emu: [40, 60, 80, 99, 105]
+    MET: [40, 60, 80, 100, 120]
+    MET_Emu: [40, 60, 80, 99, 111]
+    MET_PF: [40, 60, 80, 100, 120]
+    MET_PF_Emu: [40, 60, 80, 99, 111]
+    MET_PF_NoMu: [40, 60, 80, 100, 120]
+    MET_PF_NoMu_Emu: [40, 60, 80, 99, 111]
+    MET_PF_HF: [40, 60, 80, 100, 120]
+    MET_PF_HF_Emu: [40, 60, 80, 99, 105]
+    MET_PF_NoMu_HF: [40, 60, 80, 100, 120]
+    MET_PF_NoMu_HF_Emu: [40, 60, 80, 99, 105]
+    singlel1JetEt: [35, 60, 90, 140, 180]
+    singlel1JetEt_Emu: [21, 44, 68, 103, 120]
+    doublel1JetEt: [35, 60, 90, 140, 180]
+    doublel1JetEt_Emu: [22, 45, 71, 106, 121]
+    triplel1JetEt: [35, 60, 90, 140, 180]
+    triplel1JetEt_Emu: [22, 47, 74, 108, 122]
+    quadl1JetEt: [35, 60, 90, 140, 180]
+    quadl1JetEt_Emu: [21, 48, 75, 109, 122]
   analyzers:
-     - cmsl1t.analyzers.offline_met_analyzer
+     - cmsl1t.analyzers.HW_Emu_constant_rate_turnons
   modifiers: []
   progress_bar:
     report_every: 1000
 
 output:
   template:
-     - output/offline_met_studies
+     - output/constant_rate_turnons
      - "{date}_Fill-{run_number}_{sample_name}_{trigger_name}"

--- a/config/HW_Emu_jet_rates.yaml
+++ b/config/HW_Emu_jet_rates.yaml
@@ -1,5 +1,5 @@
 version: 0.0.1
-name: 'Offline Met Studies'
+name: 'Jet Rates'
 
 input:
   files:
@@ -7,32 +7,44 @@ input:
       # -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/SingleMuon/Collision2017-wRECO-l1t-integration-v96p27/SingleMuon/crab_Collision2017-wRECO-l1t-integration-v96p27__SingleMuon/170818_102121/000*/L1Ntuple_*.root
       # -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/SingleMuon/Fill*/Collision2017-wRECO-l1t-integration-v96p27_CaloMode/SingleMuon/crab_Collision2017-wRECO-l1t-integration-v96p27_CaloMode__SingleMuon/*/0000/L1Ntuple_*root
       # -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/SingleMuon/Collision2017-wRECO-l1t-integration-v96p27_NoPUS/SingleMuon/crab_Collision2017-wRECO-l1t-integration-v96p27_NoPUS__SingleMuon/170828_103245/0000/L1Ntuple*.root
-       -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/wRECO-l1t-v96p27/SingleMuon/crab_wRECO-l1t-v96p27__Run*/*/0001/L1Ntuple_*root
+      # -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/wRECO-l1t-v96p27/SingleMuon/crab_wRECO-l1t-v96p27__Run*/*/0001/L1Ntuple_*root
       # Zero Bias
       # -  root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/ZeroBias/Fill6*/Collision2017-noRECO-l1t-integration-96p27_NoPUS/ZeroBias/crab_Collision2017-noRECO-l1t-integration-96p27_NoPUS__ZeroBias_Run2017C/*/0000/L1Ntuple_*root
-      # -  root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/ZeroBias/Collision2017-noRECO-l1t-integration-96p20/ZeroBias/crab_Collision2017-noRECO-l1t-integration-96p20__ZeroBias_Run2017C/170726_094745/0000/*root
+       -  root://eoscms.cern.ch//eos/cms//store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/ZeroBias/Collision2017-noRECO-l1t-integration-96p20/ZeroBias/crab_Collision2017-noRECO-l1t-integration-96p20__ZeroBias_Run2017C/170726_094745/0000/L1Ntuple_10*.root
   sample:
     name: Data
     title: 2017 Data
   trigger:
-    # name: ZeroBias
-    # title: Zero Bias
-    name: SingleMu
-    title: Single Muon
+    name: ZeroBias
+    title: Zero Bias
   pileup_file: ""
   run_number: 6XXX
 
 analysis:
   do_fit: True
   pu_type: 0PU12,13PU19,20PU
-  pu_bins: [0,13,20,999]
+  pu_bins: [0,999]
+  thresholds:
+    HTT: [160, 220, 280, 340, 400]
+    MHT: [40, 60, 80, 100, 120]
+    MET_HF: [40, 60, 80, 100, 120]
+    MET: [40, 60, 80, 100, 120]
+    MET_PF: [40, 60, 80, 100, 120]
+    MET_PF_NoMu: [40, 60, 80, 100, 120]
+    MET_PF_HF: [40, 60, 80, 100, 120]
+    MET_PF_NoMu_HF: [40, 60, 80, 100, 120]
+    singlel1JetEt: [35, 60, 90, 140, 180]
+    doublel1JetEt: [35, 60, 90, 140, 180]
+    triplel1JetEt: [35, 60, 90, 140, 180]
+    quadl1JetEt: [35, 60, 90, 140, 180]
   analyzers:
-     - cmsl1t.analyzers.offline_met_analyzer
+     - cmsl1t.analyzers.HW_Emu_jet_rates
   modifiers: []
   progress_bar:
     report_every: 1000
 
 output:
   template:
-     - output/offline_met_studies
+     - output/ZB_rates
      - "{date}_Fill-{run_number}_{sample_name}_{trigger_name}"
+

--- a/config/HW_Emu_jet_rates.yaml
+++ b/config/HW_Emu_jet_rates.yaml
@@ -10,7 +10,10 @@ input:
       # -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/wRECO-l1t-v96p27/SingleMuon/crab_wRECO-l1t-v96p27__Run*/*/0001/L1Ntuple_*root
       # Zero Bias
       # -  root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/ZeroBias/Fill6*/Collision2017-noRECO-l1t-integration-96p27_NoPUS/ZeroBias/crab_Collision2017-noRECO-l1t-integration-96p27_NoPUS__ZeroBias_Run2017C/*/0000/L1Ntuple_*root
-       -  root://eoscms.cern.ch//eos/cms//store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/ZeroBias/Collision2017-noRECO-l1t-integration-96p20/ZeroBias/crab_Collision2017-noRECO-l1t-integration-96p20__ZeroBias_Run2017C/170726_094745/0000/L1Ntuple_10*.root
+      # - root://eoscms.cern.ch//eos/cms//store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/ZeroBias/Collision2017-noRECO-l1t-integration-96p20/ZeroBias/crab_Collision2017-noRECO-l1t-integration-96p20__ZeroBias_Run2017C/170726_094745/0000/L1Ntuple_10*.root
+      # -  root://eoscms.cern.ch//eos/cms//store/group/dpg_trigger/comm_trigger/L1Trigger/bundocka/ZeroBias/zbLUT/180313_160352/0000/L1Ntuple_*.root
+       - root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/ZeroBias/HighPU/noRECO-l1t-v96p27_NoPUS/ZeroBias8b4e1/crab_noRECO-l1t-v96p27_NoPUS__8b4e1/170915_101410/0000/L1Ntuple*.root
+      #  -  data/L1Ntuple_test_1.root
   sample:
     name: Data
     title: 2017 Data

--- a/config/jet_rates.yaml
+++ b/config/jet_rates.yaml
@@ -54,3 +54,44 @@ output:
   template:
      - benchmark/new
      - "{date}_{sample_name}_run-{run_number}_{trigger_name}"
+
+
+version: 0.0.1
+name: 'Jet Rates'
+
+input:
+  files:
+      # Single Muons
+      # -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/SingleMuon/Collision2017-wRECO-l1t-integration-v96p27/SingleMuon/crab_Collision2017-wRECO-l1t-integration-v96p27__SingleMuon/170818_102121/000*/L1Ntuple_*.root
+      # -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/SingleMuon/Fill*/Collision2017-wRECO-l1t-integration-v96p27_CaloMode/SingleMuon/crab_Collision2017-wRECO-l1t-integration-v96p27_CaloMode__SingleMuon/*/0000/L1Ntuple_*root
+      # -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/SingleMuon/Collision2017-wRECO-l1t-integration-v96p27_NoPUS/SingleMuon/crab_Collision2017-wRECO-l1t-integration-v96p27_NoPUS__SingleMuon/170828_103245/0000/L1Ntuple*.root
+       -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/wRECO-l1t-v96p27/SingleMuon/crab_wRECO-l1t-v96p27__Run*/*/0001/L1Ntuple_*root
+      # Zero Bias
+      # -  root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/ZeroBias/Fill6*/Collision2017-noRECO-l1t-integration-96p27_NoPUS/ZeroBias/crab_Collision2017-noRECO-l1t-integration-96p27_NoPUS__ZeroBias_Run2017C/*/0000/L1Ntuple_*root
+      # -  root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/safarzad/2017/ZeroBias/Collision2017-noRECO-l1t-integration-96p20/ZeroBias/crab_Collision2017-noRECO-l1t-integration-96p20__ZeroBias_Run2017C/170726_094745/0000/*root
+  sample:
+    name: Data
+    title: 2017 Data
+  trigger:
+    # name: ZeroBias
+    # title: Zero Bias
+    name: SingleMu
+    title: Single Muon
+  pileup_file: ""
+  run_number: 6XXX
+
+analysis:
+  do_fit: True
+  pu_type: 0PU12,13PU19,20PU
+  pu_bins: [0,13,20,999]
+  analyzers:
+     - cmsl1t.analyzers.jet_rates
+  modifiers: []
+  progress_bar:
+    report_every: 1000
+
+output:
+  template:
+     - output/jet_rates
+     - "{date}_Fill-{run_number}_{sample_name}_{trigger_name}"
+

--- a/docs/tutorial/quickstart.rst
+++ b/docs/tutorial/quickstart.rst
@@ -118,9 +118,11 @@ Lines in the yaml give the paths for the NTuples, starting with 'root://' and en
 Further down the yaml file you can specify relative/absolute paths for the output.
 
 You'll notice in the analyser section we have something like
-thresholds:
-  HTT: [val1, val2, ...]
-  etc...
+.. code-block:: bash
+
+  thresholds:
+    HTT: [val1, val2, ...]
+    etc...
 
 Change these to the thresholds you want for HW quantities.
 
@@ -143,10 +145,13 @@ For example, you could do:
 Then one can combine the output with the command which will be given to you at this stage.
 
 Finally, the output of the code contains something like:
-thresholds:
-  HTT: [val1, val2, ...]
-  HTT_Emu: [val1_, val2_, ...]
-  etc...
+
+.. code-block:: bash
+
+  thresholds:
+    HTT: [val1, val2, ...]
+    HTT_Emu: [val1_, val2_, ...]
+    etc...
 
 Copy this, being careful to keep the formatting...
 

--- a/docs/tutorial/quickstart.rst
+++ b/docs/tutorial/quickstart.rst
@@ -102,3 +102,73 @@ Once this submits the jobs it will tell you how to combine them together later :
 .. code-block:: bash
 
   cmsl1t_dirty_batch -c config/offline_met_studies.yaml -f <ntuple_root_files_per_job>
+
+
+HW vs Emu at Constant Rate:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The code now has facility to calculate for a given HW L1 threshold the threshold at which the Emulated quantity gives the same rate.
+
+Then, we may plot the turnons etc for HW and Emu at their respective rates together, using the new analysers.
+
+To run this, first we want the config file `configs/HW_Emu_jet_rates.yaml`.
+
+Lines in the yaml give the paths for the NTuples, starting with 'root://' and ending with '/L1NTuple_*.root' -- You should edit these to point to the ZeroBias NTuples you're running on.
+
+Further down the yaml file you can specify relative/absolute paths for the output.
+
+You'll notice in the analyser section we have something like
+thresholds:
+  HTT: [val1, val2, ...]
+  etc...
+
+Change these to the thresholds you want for HW quantities.
+
+Once you're ready, run as so:
+
+.. code-block:: bash
+
+  cmsl1t -c config/HW_Emu_jet_rates.yaml -n <no_of_entries>
+
+
+Or, for large running you can run on lxbatch with the NTuple list broken up into many jobs using the command cmsl1t_dirty_batch. Files per job specifiable with -f <number>.
+Try to keep max ~1000 jobs else combining later is a nightmare, but also if <number> is greater than baout 4 you might struggle for walltime per job.
+
+For example, you could do:
+
+.. code-block:: bash
+
+  cmsl1t_dirty_batch -c config/HW_Emu_jet_rates.yaml -f 4
+
+Then one can combine the output with the command which will be given to you at this stage.
+
+Finally, the output of the code contains something like:
+thresholds:
+  HTT: [val1, val2, ...]
+  HTT_Emu: [val1_, val2_, ...]
+  etc...
+
+Copy this, being careful to keep the formatting...
+
+Now we take a look at config/HW_Emu_constant_rate_turnons.yaml:
+
+There are similar lines in here. Set the input ntuples to the SingleMu you wish to run on.
+
+Now again in the analyser section we have the thresholds listed in the same format, but now with emulated quantities too.
+
+Replace this with the stuff you just copied -- this format is interpreted as a python dictionary, so whitespace matters. thresholds: should be indented 2 spaces wrt lines above,
+and HTT etc indented 2 spaces wrt thresholds.
+
+Finally, we may run this like we did the previous step:
+
+.. code-block:: bash
+
+  cmsl1t_dirty_batch -c config/HW_Emu_constant_rate_turnons.yaml -f 4
+
+Or of course
+
+.. code-block:: bash
+
+  cmsl1t -c config/HW_Emu_jet_rates.yaml -n <number_of_events>
+
+if one wants a quick test job.


### PR DESCRIPTION
#### What does this pull request implement/fix? Explain your changes.

Adds the function overlay_with_emu to the rates plotter such that we can easily compare HW vs Emulated quantities.

This was done before the plotter was updated in the master repo. I have an updated version of this which should play nicely with the updated structure, but I cannot get the master repo to work at all in order to test it...

TypeError: branch `L1Upgrade` has unsupported type `L1Analysis::L1AnalysisL1UpgradeDataFormat`
Will open an issue to track this.
