### PR TITLE
Convert output of cum sum back to array to build cum hist

### DIFF
--- a/cmsl1t/math.py
+++ b/cmsl1t/math.py
@@ -20,7 +20,7 @@ def cumulative_sum_and_error(hist):
 
 
 def _reversed_cumulative_sum(values):
-    reversed_values = np.flipud(values)
+    reversed_values = np.array(np.flipud(values))
     cumsum = np.cumsum(reversed_values)
-    reversed_cumsum = np.flipud(cumsum)
+    reversed_cumsum = np.array(np.flipud(cumsum))
     return reversed_cumsum


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/cms-l1t-offline/cms-l1t-analysis/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->


#### What does this pull request implement/fix? Explain your changes.

Missing conversion of reversed cumulative hist contents into array.

#### Any other comments?
An example would be if you require another pull request to be merged before this one.
If you do, please reference it.
