### PR TITLE
Fix calo jets efficiencies and logic for emulator thresholds

### DIFF
--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -232,7 +232,7 @@ class Analyzer(BaseAnalyzer):
             for l1trig, thresh in allThresholds.items():
                 if emulator and "Emu" not in l1trig or not emulator and "Emu" in l1trig:
                     continue
-                if l1trig.replace("_Emu","") in cfg.name:
+                if l1trig.replace("_Emu", "") in cfg.name:
                     thresholds = thresh
                     break
             if 'pfMET' in cfg.name:

--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -230,9 +230,9 @@ class Analyzer(BaseAnalyzer):
 
             thresholds = []
             for l1trig, thresh in allThresholds.items():
-                if l1trig.replace("_Emu", "") in cfg.name:
-                    if emulator and "Emu" not in l1trig:
-                        continue
+                if emulator and "Emu" not in l1trig or not emulator and "Emu" in l1trig:
+                    continue
+                if l1trig.replace("_Emu","") in cfg.name:
                     thresholds = thresh
                     break
             if 'pfMET' in cfg.name:
@@ -251,7 +251,7 @@ class Analyzer(BaseAnalyzer):
 
             params = [
                 cfg.on_title, cfg.off_title + " (GeV)", puBins, thresholds,
-                100, cfg.min, cfg.max,
+                80, cfg.min, cfg.max,
             ]
             if high_range:
                 params = [
@@ -400,15 +400,15 @@ class Analyzer(BaseAnalyzer):
                 else:
                     caloL1EmuJetEt = 0.
 
-                    for region in caloFillRegions:
-                        for suffix in ['_eff', '_res', '_2D', '_eff_HR', '_2D_HR']:
-                            if '_res' in suffix and caloL1EmuJetEt == 0:
-                                continue
-                            name = 'caloJetET_{0}_Emu{1}'.format(
-                                region, suffix)
-                            getattr(self, name).fill(
-                                pileup, leadingCaloJet.etCorr, caloL1EmuJetEt,
-                            )
+                for region in caloFillRegions:
+                    for suffix in ['_eff', '_res', '_2D', '_eff_HR', '_2D_HR']:
+                        if '_res' in suffix and caloL1EmuJetEt == 0:
+                            continue
+                        name = 'caloJetET_{0}_Emu{1}'.format(
+                            region, suffix)
+                        getattr(self, name).fill(
+                            pileup, leadingCaloJet.etCorr, caloL1EmuJetEt,
+                        )
 
             caloL1Jet = event.getMatchedL1Jet(leadingCaloJet, l1Type='HW')
             if caloL1Jet:


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/cms-l1t-offline/cms-l1t-analysis/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->


#### What does this pull request implement/fix? Explain your changes.

A few small bug fixes:
- Wrong indentation for caloJet efficiencies, was only being filled when no matching caloEmuJet
- Correction to logic when assigning thresholds to emulator objects to fix edge case for METBE

As of this PR, the master branch reproduces the exact results of the updateFilters branch! 8)

#### Any other comments?
An example would be if you require another pull request to be merged before this one.
If you do, please reference it.
