### PR TITLE
Speeding up docker build for travis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -105,3 +105,6 @@ data
 benchmark
 legacy
 output
+build
+.git
+*.root

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
 
 before_install:
   - docker pull hepsw/cvmfs-cms
+  - docker pull kreczko/cms-l1t-analysis-ci-base
   - docker pull kreczko/cms-l1t-analysis:ci
 
 install:

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -4,16 +4,14 @@ MAINTAINER kreczko@cern.ch
 
 COPY conda_requirements.txt /tmp/conda_requirements.txt
 
-RUN conda create -n cms python=2.7 -yq &&\
-   echo "Created conda environment, installing basic dependencies" && \
-   /bin/bash -c "source activate cms && \
-   conda install -yq --file /tmp/conda_requirements.txt" && \
+RUN /bin/bash -c "source activate cms && \
+   conda update -yq --file /tmp/conda_requirements.txt" && \
    conda clean -t -y
 
  COPY requirements.txt /tmp/requirements.txt
 
  RUN /bin/bash -c "source activate cms && \
-     pip install --no-cache-dir -r /tmp/requirements.txt"
+     pip install -U --no-cache-dir -r /tmp/requirements.txt"
 
 ENV CODE_PATH /code
 ENV USERNAME cmsl1t

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER kreczko@cern.ch
 COPY conda_requirements.txt /tmp/conda_requirements.txt
 
 RUN /bin/bash -c "source activate cms && \
-   conda update -yq --file /tmp/conda_requirements.txt" && \
+   conda install -yq --file /tmp/conda_requirements.txt" && \
    conda clean -t -y
 
  COPY requirements.txt /tmp/requirements.txt

--- a/ci/base/Dockerfile
+++ b/ci/base/Dockerfile
@@ -33,3 +33,16 @@ RUN echo "Finished conda installation, updating conda and pip" \
  && conda config --add channels http://conda.anaconda.org/NLeSC \
  && conda config --set show_channel_urls yes \
  && conda clean -t -y
+
+ COPY conda_requirements.txt /tmp/conda_requirements.txt
+
+ RUN conda create -n cms python=2.7 -yq &&\
+    echo "Created conda environment, installing basic dependencies" && \
+    /bin/bash -c "source activate cms && \
+    conda install -yq --file /tmp/conda_requirements.txt" && \
+    conda clean -t -y
+
+  COPY requirements.txt /tmp/requirements.txt
+
+  RUN /bin/bash -c "source activate cms && \
+      pip install --no-cache-dir -r /tmp/requirements.txt"


### PR DESCRIPTION
Currently, the travis build takes 17 minutes to execute, of which 580s is spent on building the CI image.

I've moved the creation of the conda ENV from `ci` to `ci-base` which should be now a simple download.
Modifications are only executed if `conda_requirements.txt` or `requirements.txt` differ w.r.t. what is in the base image