### PR TITLE
Replacing `do_X` with `load_trees` in configs, analysers and eventReader

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -37,7 +37,7 @@ This should fail if make setup threw Error 54.
 "Analyzers" are the parts of the code that receive events from the input tuples, extracts the relevant data and puts this into the histograms.
 
 You can see an example of an analyzer at: `cmsl1t/analyzers/demo_analyzer.py`.
-  
+
 To implement your own analyzer, all you need to do is make a new class in a file under `cmsl1t/analyzers/` which inherits from `cmsl1t.analyzers.BaseAnalyzer.BaseAnalyzer`.  You then need to implement two or three methods: `prepare_for_event`, ` fill_histograms`, `write_histograms`, and `make_plots`.  See the BaseAnalyzer class and the demo_analyzer for examples and documentation of these methods.
 
 Once you have implemented an analyzer and written a simple configuration for it, you can run it with `cmsl1t` command:
@@ -54,7 +54,7 @@ cmsl1t --help
 
 For the weekly checks of jets & sums efficiencies, 2D plots etc, we have an analyzer:
 
-Currently this is 'cmsl1t/analyzers/offline_met_analyzer.py' but in the future it will likely get rolled into weekly_analyzer.py.
+Currently this is 'cmsl1t/analyzers/jetMet_analyzer.py' but in the future it will likely get rolled into weekly_analyzer.py.
 
 To run this, we want the config file 'configs/offline_met_studies.yaml'.
 
@@ -70,11 +70,11 @@ cmsl1t -c config/offline_met_studies.yaml -n <no_of_entries>
 
 Or, for large running you can run on lxbatch with the NTuple list broken up into many jobs. Files per job specifiable with -f <number>. Try to keep max ~1000 jobs else combining later is a nightmare.
 
-Also more than about 8 files per job will lead to some going over the walltime, since the bsub queue is 8nm... Edit bin/cmsl1t_dirty_batch to change 
-queue to 1nh or something 
+Also more than about 8 files per job will lead to some going over the walltime, since the bsub queue is 8nm... Edit bin/cmsl1t_dirty_batch to change
+queue to 1nh or something
 else if this happens a lot.
 
-For small runs I reccommend changing queue to 8nm and running ~4-6 files per job.
+For small runs I recommend changing queue to 8nm and running ~4-6 files per job.
 
 Once this submits the jobs it will tell you how to combine them together later :-)
 

--- a/bin/cmsl1t
+++ b/bin/cmsl1t
@@ -40,14 +40,9 @@ def process_tuples(config, nevents, analyzers):
         logger.info(input_files)
 
     from cmsl1t.playground.eventreader import EventReader
-    load_emu = config.try_get('analysis', 'do_emu', False)
-    load_reco = config.try_get('analysis', 'do_reco', True)
-    load_vertex = config.try_get('analysis', 'do_vertex', False)
-    load_gen = config.try_get('analysis', 'do_gen', False)
+    load_trees = config.try_get('analysis', 'load_trees', ['event', 'upgrade'])
     reader = EventReader(
-        input_files, events=nevents, load_emu_trees=load_emu,
-        load_reco_trees=load_reco, load_vertex_trees=load_vertex,
-        load_gen_trees=load_gen
+        input_files, events=nevents, load_trees=load_trees,
     )
 
     results = [analyzer.prepare_for_events(reader) for analyzer in analyzers]

--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -147,10 +147,11 @@ class Analyzer(BaseAnalyzer):
         self._lastRunAndLumi = (-1, -1)
         self._processLumi = True
 
-        self._doVertex = config.try_get('analysis', 'do_vertex', False)
-        self._doEmu = config.try_get('analysis', 'do_emu', False)
-        self._doReco = config.try_get('analysis', 'do_reco', True)
-        self._doGen = config.try_get('analysis', 'do_gen', False)
+        loaded_trees = config.try_get('analysis', 'load_trees')
+        self._doVertex = 'recoTree' in loaded_trees
+        self._doEmu = 'emuUpgrade' in loaded_trees
+        self._doReco = 'recoTree' in loaded_trees
+        self._doGen = 'genTree' in loaded_trees
 
         self._sumTypes, self._jetTypes = types(self._doEmu, self._doReco, self._doGen)
 

--- a/cmsl1t/playground/eventreader.py
+++ b/cmsl1t/playground/eventreader.py
@@ -32,18 +32,9 @@ ALL_TREE = {
 }
 
 
-def get_trees(load_emu_trees, load_reco_trees, load_vertex_trees, load_gen_trees):
-    selected_trees = ['event', 'upgrade']
-    if load_emu_trees:
-        selected_trees.extend(['emuCaloTowers', 'emuUpgrade'])
-    if load_reco_trees:
-        selected_trees.extend(['jetReco', 'metFilterReco', 'recoTree'])
-    if load_vertex_trees and not load_reco_trees:
-        selected_trees.extend(['recoTree'])
-    if load_gen_trees:
-        selected_trees.extend(['genTree'])
+def get_trees(tree_names):
     trees = {}
-    for name in selected_trees:
+    for name in tree_names:
         trees[name] = ALL_TREE[name]
     return trees
 
@@ -352,8 +343,7 @@ class EventReader(object):
         http://rootpy-log.readthedocs.io/en/latest/_modules/rootpy/tree/chain.html
     '''
 
-    def __init__(self, files, events=-1,
-                 load_emu_trees=False, load_reco_trees=True, load_vertex_trees=False, load_gen_trees=False):
+    def __init__(self, files, events=-1, load_trees=['event', 'upgrade']):
         from cmsl1t.utils.root_glob import glob
         input_files = []
         for f in files:
@@ -365,7 +355,7 @@ class EventReader(object):
         self._trees = []
         self._names = []
         load_ROOT_library('L1TAnalysisDataformats.so')
-        allTrees = get_trees(load_emu_trees, load_reco_trees, load_vertex_trees, load_gen_trees)
+        allTrees = get_trees(load_trees)
         for name, path in allTrees.iteritems():
             try:
                 chain = TreeChain(path, input_files, cache=True, events=events)

--- a/cmsl1t/playground/eventreader.py
+++ b/cmsl1t/playground/eventreader.py
@@ -248,6 +248,13 @@ class Event(object):
                 closestJet = l1Jet
         return closestJet
 
+    def passesMETFilter(self):
+        return pfMetFilter(self)
+
+    @property
+    def nVertex(self):
+        return self.nRecoVertex
+
     @property
     def nRecoVertex(self):
         return self._recoTree.Vertex.nVtx

--- a/config/all2017.yaml
+++ b/config/all2017.yaml
@@ -11,7 +11,7 @@ input:
 #      -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/treis/l1t-integration-v97p7-CMSSW-940pre3/SingleMuon/crab_l1t-integration-v97p7-CMSSW-940pre3__SingleMuon_Run2017E-17Nov2017-v1/180125_121715/0000/L1Ntuple_*.root
       -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/treis/l1t-integration-v97p7-CMSSW-940pre3/SingleMuon/crab_l1t-integration-v97p7-CMSSW-940pre3__SingleMuon_Run2017E-17Nov2017-v1/180125_121715/0001/L1Ntuple_*.root
 #      -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/treis/l1t-integration-v97p7-CMSSW-940pre3/SingleMuon/crab_l1t-integration-v97p7-CMSSW-940pre3__SingleMuon_Run2017F-17Nov2017-v1/180125_122032/0000/L1Ntuple_*.root
-#      -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/treis/l1t-integration-v97p7-CMSSW-940pre3/SingleMuon/crab_l1t-integration-v97p7-CMSSW-940pre3__SingleMuon_Run2017F-17Nov2017-v1/180125_122032/0001/L1Ntuple_*.root      
+#      -   root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/treis/l1t-integration-v97p7-CMSSW-940pre3/SingleMuon/crab_l1t-integration-v97p7-CMSSW-940pre3__SingleMuon_Run2017F-17Nov2017-v1/180125_122032/0001/L1Ntuple_*.root
 
   sample:
     name: Data
@@ -24,10 +24,10 @@ input:
   lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt"
 
 analysis:
-  do_emu: False
-  do_reco: True
-  do_vertex: False
-  do_gen: False
+  load_trees:
+    - event
+    - upgrade
+    - recoTree
   do_fit: True
   pu_type: 0PU24,25PU49,50PU
   pu_bins: [25,50,999]

--- a/config/demo.yaml
+++ b/config/demo.yaml
@@ -38,6 +38,10 @@ input:
   run_number: 276243
 
 analysis:
+  load_trees:
+    - event
+    - upgrade
+    - recoTree
   do_fit: False
   pu_type: 0PU12,13PU19,20PU
   pu_bins: 0,13,20,999

--- a/config/demo.yaml
+++ b/config/demo.yaml
@@ -42,6 +42,10 @@ analysis:
     - event
     - upgrade
     - recoTree
+    - metFilterReco
+    - caloTowers
+    - emuCaloTowers
+    - jetReco
   do_fit: False
   pu_type: 0PU12,13PU19,20PU
   pu_bins: 0,13,20,999

--- a/config/efficiencies.yaml
+++ b/config/efficiencies.yaml
@@ -13,13 +13,17 @@ input:
     title: Single Muon
   pileup_file: ""
   run_number: ""
-  lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt"  
+  lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt"
 
 analysis:
-  do_emu: True
-  do_reco: True
-  do_vertex: False
-  do_gen: False
+  load_trees:
+    - event
+    - upgrade
+    - emuCaloTowers
+    - emuUpgrade
+    - jetReco
+    - metFilterReco
+    - recoTree
   do_fit: True
   pu_type: 0PU24,25PU49,50PU
   pu_bins: [0,25,50,999]

--- a/config/energy_sums_efficiencies.yaml
+++ b/config/energy_sums_efficiencies.yaml
@@ -38,6 +38,12 @@ input:
   run_number: 276243
 
 analysis:
+  load_trees:
+    - event
+    - upgrade
+    - recoTree
+    - caloTowers
+    - emuCaloTowers
   do_fit: False
   pu_type: 0PU12,13PU19,20PU
   pu_bins: 0,13,20,999

--- a/config/gen.yaml
+++ b/config/gen.yaml
@@ -12,13 +12,16 @@ input:
     name: genJEC
     title: QCD
   pileup_file: ""
-  run_number: 
+  run_number:
 
 analysis:
-  do_emu: True
-  do_reco: False
-  do_vertex: False
-  do_gen: True
+  load_trees:
+    - event
+    - upgrade
+    - caloTowers
+    - emuCaloTowers
+    - emuUpgrade
+    - genTree
   do_fit: True
   pu_type: 0PU24,25PU49,50PU
   pu_bins: [0,25,50,999]
@@ -28,9 +31,9 @@ analysis:
     METBE: [80, 100, 120]
     METBE_Emu: [80, 100, 120]
     METHF: [80, 100, 120]
-    METHF_Emu: [80, 100, 120] 
+    METHF_Emu: [80, 100, 120]
     JetET: [35, 90, 120]
-    JetET_Emu: [35, 90, 120] 
+    JetET_Emu: [35, 90, 120]
   analyzers:
      - cmsl1t.analyzers.jetMet_analyzer
   modifiers: []

--- a/config/jet_efficiencies.yaml
+++ b/config/jet_efficiencies.yaml
@@ -38,6 +38,11 @@ input:
   run_number: 276243
 
 analysis:
+  load_trees:
+    - event
+    - upgrade
+    - jetReco
+    - recoTree
   do_fit: False
   pu_type: 0PU12,13PU19,20PU
   pu_bins: 0,13,20,999

--- a/config/jet_rates.yaml
+++ b/config/jet_rates.yaml
@@ -38,6 +38,11 @@ input:
   run_number: 276243
 
 analysis:
+  load_trees:
+    - event
+    - upgrade
+    - jetReco
+    - recoTree
   do_fit: False
   pu_type: 0PU12,13PU19,20PU
   pu_bins: 0,13,20,999

--- a/config/jet_resolutions.yaml
+++ b/config/jet_resolutions.yaml
@@ -38,6 +38,11 @@ input:
   run_number: 276243
 
 analysis:
+  load_trees:
+    - event
+    - upgrade
+    - jetReco
+    - recoTree
   do_fit: False
   pu_type: 0PU12,13PU19,20PU
   pu_bins: 0,13,20,999

--- a/config/offline_met_studies.yaml
+++ b/config/offline_met_studies.yaml
@@ -21,12 +21,17 @@ input:
   lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt"
 
 analysis:
-  do_emu: False
+  load_trees:
+    - event
+    - upgrade
+    - jetReco
+    - recoTree
+    - genTree
   do_fit: True
   pu_type: 0PU24,25PU49,50PU
   pu_bins: [0,25,50,999]
   analyzers:
-     - cmsl1t.analyzers.offline_met_analyzer
+     - cmsl1t.analyzers.jetMet_analyzer
   modifiers: []
   progress_bar:
     report_every: 1000

--- a/config/rateVsPU.yaml
+++ b/config/rateVsPU.yaml
@@ -12,14 +12,16 @@ input:
     name: zbMed
     title: Zero Bias
   pileup_file: ""
-  run_number: 
-  lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt"  
+  run_number:
+  lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt"
 
 analysis:
-  do_emu: True
-  do_reco: False
-  do_vertex: True
-  do_gen: False
+  load_trees:
+    - event
+    - emuCaloTowers
+    - emuUpgrade
+    - upgrade
+    - recoTree
   do_fit: True
   pu_type: 0PU24,25PU49,50PU
   pu_bins: [0,25,50,999]
@@ -29,7 +31,7 @@ analysis:
     METBE: [80, 100, 120]
     METBE_Emu: [80, 100, 120]
     METHF: [80, 100, 120]
-    METHF_Emu: [80, 100, 120] 
+    METHF_Emu: [80, 100, 120]
     JetET: [35, 90, 120]
     JetET_Emu: [35, 90, 120]
 
@@ -43,4 +45,3 @@ output:
   template:
      - output/zb_rates
      - "{date}_{run_number}_{sample_name}_{trigger_name}"
-

--- a/config/rates.yaml
+++ b/config/rates.yaml
@@ -12,14 +12,15 @@ input:
     name: zbNoLowEtSF
     title: Zero Bias
   pileup_file: ""
-  run_number: 
-  lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt"  
+  run_number:
+  lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt"
 
 analysis:
-  do_emu: True
-  do_reco: False
-  do_vertex: False
-  do_gen: False
+  load_trees:
+    - event
+    - emuCaloTowers
+    - emuUpgrade
+    - upgrade
   do_fit: True
   pu_type: 0PU24,25PU49,50PU
   pu_bins: [0,25,50,999]
@@ -39,4 +40,3 @@ output:
   template:
      - output/zb_rates
      - "{date}_{run_number}_{sample_name}_{trigger_name}"
-

--- a/config/study_tower28_met.yaml
+++ b/config/study_tower28_met.yaml
@@ -38,6 +38,14 @@ input:
   run_number: 276243
 
 analysis:
+  load_trees:
+    - event
+    - upgrade
+    - emuCaloTowers
+    - emuUpgrade
+    - jetReco
+    - metFilterReco
+    - recoTree
   do_fit: False
   pu_type: 0PU12,13PU19,20PU
   pu_bins: 0,13,20,999

--- a/config/weekly_checks.yaml
+++ b/config/weekly_checks.yaml
@@ -21,12 +21,20 @@ input:
   run_number: 6XXX
 
 analysis:
+  load_trees:
+    - event
+    - upgrade
+    - emuCaloTowers
+    - emuUpgrade
+    - jetReco
+    - metFilterReco
+    - recoTree
   do_fit: True
   pu_type: 0PU12,13PU19,20PU
   pu_bins: 0,13,20,999
   analyzers:
       - cmsl1t.analyzers.weekly_analyzer
-      - cmsl1t.analyzers.offline_met_analyzer
+      - cmsl1t.analyzers.jetMet_analyzer
   modifiers: []
   progress_bar:
     report_every: 1000

--- a/docs/tutorial/quickstart.rst
+++ b/docs/tutorial/quickstart.rst
@@ -74,7 +74,7 @@ Running the weekly checks:
 
 For the weekly checks of jets & sums efficiencies, 2D plots etc, we have an analyzer:
 
-Currently this is `cmsl1t/analyzers/offline_met_analyzer.py` but in the future it will likely get rolled into weekly_analyzer.py.
+Currently this is `cmsl1t/analyzers/jetMet_analyzer.py` but in the future it will likely get rolled into weekly_analyzer.py.
 
 To run this, we want the config file `configs/offline_met_studies.yaml`.
 


### PR DESCRIPTION
Relates to #122 ([comment](https://github.com/cms-l1t-offline/cms-l1t-analysis/pull/122#discussion_r184121668)).
Replaces 

```yaml
analysis:
  - do_emu: False
  -  do_reco: True
  -  do_vertex: False
  -  do_gen: False
```
with
```yaml
analysis:
  load_trees:
    - event
    - upgrade
    - recoTree
```

@bundocka would you be so kind to run one of your configs from this branch to check all is as expected?