### PR TITLE
Enabling new event reader in cmsl1t_future

### DIFF
--- a/bin/cmsl1t_future
+++ b/bin/cmsl1t_future
@@ -5,6 +5,8 @@ import os
 from datetime import datetime
 from cmsl1t.utils.timers import timerfunc_log_to
 from cmsl1t.config import ConfigParser
+from cmsl1t.utils.module import load_L1TNTupleLibrary
+from cmsl1t.io.eventreader import EventReader
 import click
 import click_log
 from importlib import import_module
@@ -40,11 +42,11 @@ def process_tuples(config, nevents, analyzers, producers):
     else:
         logger.info(input_files)
 
-    from cmsl1t.playground.eventreader import EventReader
-    load_trees = config.try_get('analysis', 'load_trees', ['event', 'upgrade'])
-    reader = EventReader(
-        input_files, events=nevents, load_trees=load_trees,
-    )
+    ntuple_map_file = 'config/ntuple_content.yaml'
+    with open(ntuple_map_file) as f:
+       ntuple_map = yaml.load(f)
+    load_L1TNTupleLibrary()
+    reader = EventReader(input_files, ntuple_map, nevents=nevents)
 
     results = [analyzer.prepare_for_events(reader) for analyzer in analyzers]
     check(results, analyzers, 'prepare_for_events')

--- a/bin/cmsl1t_future
+++ b/bin/cmsl1t_future
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import ROOT
+import os
+from datetime import datetime
+from cmsl1t.utils.timers import timerfunc_log_to
+from cmsl1t.config import ConfigParser
+import click
+import click_log
+from importlib import import_module
+import logging
+logger = logging.getLogger(__name__)
+logging.getLogger("rootpy.tree.chain").setLevel(logging.WARNING)
+click_log.basic_config(logger)
+
+TODAY = datetime.now().timetuple()
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+ROOT.gROOT.SetBatch(1)
+ROOT.TH1.SetDefaultSumw2(True)
+separator = '=' * 80
+section = [separator, '{0}', separator]
+section = '\n'.join(section)
+
+
+@timerfunc_log_to(logger.info)
+def process_tuples(config, nevents, analyzers):
+    # Open the data files
+    logger.info(section.format("Loading data"))
+
+    input_files = config.get('input', 'files')
+    logger.info("Input files:")
+
+    if len(input_files) > 10:
+        file_msg = [input_files[:10], "... and",
+                    len(input_files) - 10, "more files"]
+        file_msg = map(str, file_msg)
+        file_msg = " ".join(file_msg)
+        logger.info(file_msg)
+    else:
+        logger.info(input_files)
+
+    from cmsl1t.playground.eventreader import EventReader
+    load_trees = config.try_get('analysis', 'load_trees', ['event', 'upgrade'])
+    reader = EventReader(
+        input_files, events=nevents, load_trees=load_trees,
+    )
+
+    results = [analyzer.prepare_for_events(reader) for analyzer in analyzers]
+    check(results, analyzers, 'prepare_for_events')
+
+    logger.info(section.format("Processing events"))
+    # Fill the histograms from the tuples
+    counter_rate = 1000
+    if nevents <= 10000 and not nevents < 0:
+        counter_rate = nevents / 10
+    for entry, event in enumerate(reader):
+        if entry % counter_rate == 0:
+            if nevents > 0:
+                logger.info("{} of {}".format(entry, nevents))
+            else:
+                logger.info("{} of <all>".format(entry))
+        results = [analyzer.process_event(entry, event)
+                   for analyzer in analyzers]
+        check(results, analyzers, 'process_event')
+        if all(results) is not True:
+            break
+
+
+@timerfunc_log_to(logger.info)
+def process_histogram_files(config, analyzers):
+    # Open the histogram files
+    logger.info(section.format("Reading back histograms"))
+
+    inputs = config.get('input', 'hist_files')
+    logger.info("Inputs:")
+    if len(inputs) > 10:
+        msg = inputs[:10], "... and " + str(len(inputs) - 10) + " more"
+        logger.info(msg)
+    else:
+        logger.info(inputs)
+
+    # Open the histogram file
+    results = {}
+    for filename in inputs:
+        for analyzer in analyzers:
+            if analyzer not in results:
+                results[analyzer] = True
+            if analyzer.might_contain_histograms(filename):
+                results[analyzer] &= bool(analyzer.reload_histograms(filename))
+
+    # Check for errors
+    return check(results.values(), results.keys(), 'process_histogram_files')
+
+
+@timerfunc_log_to(logger.info)
+def process_legacy(config, nevents, analyzers):
+    logger.info(section.format("Running in legacy mode"))
+    results = [analyzer.prepare_for_events(None) for analyzer in analyzers]
+    check(results, analyzers, 'prepare_for_events')
+
+    # setting entry = nevents  is ugly
+    results = [analyzer.process_event(nevents, None) for analyzer in analyzers]
+    check(results, analyzers, 'process_event')
+
+    return all(results)
+
+
+def run(config, nevents, reload_histograms):
+    results = [False]
+    # Fetch the analyzer
+    analyzers = config.get('analysis', 'analyzers')
+    analyzers = [load_analyzer(analyzer, config) for analyzer in analyzers]
+
+    if not reload_histograms:
+        analysis_mode = config.try_get('analysis', 'mode', default='new')
+        if analysis_mode == 'legacy':
+            process_legacy(config, nevents, analyzers)
+        else:
+            process_tuples(config, nevents, analyzers)
+    else:
+        process_histogram_files(config, analyzers)
+
+    # Write out the histograms
+    for analyzer in analyzers:
+        analyzer.write_histograms()
+
+    # Turn the histograms to plots
+    logger.info(section.format("Making plots"))
+    results = [analyzer.make_plots() for analyzer in analyzers]
+    check(results, analyzers, 'make_plots')
+
+    # Finalize
+    print(section.format("Finalizing things"))
+    results = [analyzer.finalize() for analyzer in analyzers]
+    check(results, analyzers, 'finalize')
+
+    return all(results)
+
+
+def check(results, analyzers, method):
+    msg = 'Problem during {method}() with analyzer "{analyzer}"'
+    is_ok = all(results)
+    if not is_ok:
+        for i, r in enumerate(results):
+            if r is not True:
+                logger.error(msg.format(method=method, analyzer=analyzers[i]))
+    return is_ok
+
+
+@click.command()
+@click.option('-c', '--config_file', help='YAML style config file', type=click.File(), required=True)
+@click.option('-n', '--nevents', default=-1, help='Number of events to process.')
+@click.option('-r', '--reload-histograms', is_flag=True,
+              help="Reload histograms from a file and skip the input tuples")
+@click.option('--hist-files', default=None,
+              help="Provide a list of files to reload histograms from")
+@click_log.simple_verbosity_option(logger)
+def analyze(config_file, nevents, reload_histograms, hist_files):
+    logger.info(section.format("Starting CMS L1T Analysis"))
+    config = ConfigParser()
+    config.read(config_file, reload_histograms, hist_files)
+
+    isok = run(config, nevents, reload_histograms)
+
+    print('\n' + separator + '\n')
+    if isok is not True:
+        logger.info("There were errors during running:")
+        logger.info(isok)
+        logger.info('\n' + separator + '\n')
+
+
+def load_analyzer(analyzer, config):
+    name = analyzer
+    params = {}
+    if isinstance(analyzer, dict):
+        name = analyzer.keys()[0]
+        params = analyzer[name]
+    logger.info("Try loading analyzer:" + name)
+    module = import_module(name)
+    logger.info("Successfully loaded analyzer:" + name)
+    return module.Analyzer(config, **params)
+
+
+if __name__ == '__main__':
+    analyze()

--- a/bin/cmsl1t_future
+++ b/bin/cmsl1t_future
@@ -8,6 +8,7 @@ from cmsl1t.config import ConfigParser
 import click
 import click_log
 from importlib import import_module
+import yaml
 import logging
 logger = logging.getLogger(__name__)
 logging.getLogger("rootpy.tree.chain").setLevel(logging.WARNING)
@@ -23,7 +24,7 @@ section = '\n'.join(section)
 
 
 @timerfunc_log_to(logger.info)
-def process_tuples(config, nevents, analyzers):
+def process_tuples(config, nevents, analyzers, producers):
     # Open the data files
     logger.info(section.format("Loading data"))
 
@@ -59,6 +60,8 @@ def process_tuples(config, nevents, analyzers):
                 logger.info("{} of {}".format(entry, nevents))
             else:
                 logger.info("{} of <all>".format(entry))
+        results = [p.produce(event) for p in producers]
+        check(results, producers, 'produce')
         results = [analyzer.process_event(entry, event)
                    for analyzer in analyzers]
         check(results, analyzers, 'process_event')
@@ -111,12 +114,15 @@ def run(config, nevents, reload_histograms):
     analyzers = config.get('analysis', 'analyzers')
     analyzers = [load_analyzer(analyzer, config) for analyzer in analyzers]
 
+    producers = config.get('analysis', 'producers')
+    producers = [load_producer(producer, config) for producer in producers]
+
     if not reload_histograms:
         analysis_mode = config.try_get('analysis', 'mode', default='new')
         if analysis_mode == 'legacy':
             process_legacy(config, nevents, analyzers)
         else:
-            process_tuples(config, nevents, analyzers)
+            process_tuples(config, nevents, analyzers, producers)
     else:
         process_histogram_files(config, analyzers)
 
@@ -180,6 +186,19 @@ def load_analyzer(analyzer, config):
     logger.info("Successfully loaded analyzer:" + name)
     return module.Analyzer(config, **params)
 
+
+def load_producer(producer, config):
+    name = producer
+    params = {}
+    if isinstance(producer, dict):
+        name = producer.keys()[0]
+        params = producer[name]
+    if 'params' not in params:
+        params['params'] = None
+    logger.info("Try loading producer:" + name)
+    module = import_module(name)
+    logger.info("Successfully loaded producer:" + name)
+    return module.Producer(**params)
 
 if __name__ == '__main__':
     analyze()

--- a/cmsl1t/analyzers/demo_analyzer.py
+++ b/cmsl1t/analyzers/demo_analyzer.py
@@ -1,7 +1,8 @@
 """
 Study the MET distibutions and various PUS schemes
 """
-
+from functools import partial
+import numpy as np
 from BaseAnalyzer import BaseAnalyzer
 from cmsl1t.collections import EfficiencyCollection
 from functools import partial
@@ -16,10 +17,10 @@ class Analyzer(BaseAnalyzer):
         self.met_calcs = dict(
             RecalcL1EmuMETNot28=dict(
                 title="Emulated MET, |ieta|<28",
-                calculate=recalc.l1MetNot28),
+                attr='l1MetNot28'),
             RecalcL1EmuMETNot28HF=dict(
                 title="Emulated MET, |ieta|!=28",
-                calculate=recalc.l1MetNot28HF),
+                attr='l1MetNot28HF'),
         )
 
     def prepare_for_events(self, reader):
@@ -40,14 +41,14 @@ class Analyzer(BaseAnalyzer):
         return True
 
     def fill_histograms(self, entry, event):
-        pileup = event.nVertex
-        if pileup < 5 or not event.passesMETFilter():
+        pileup = event['Vertex_nVtx']
+        if pileup < 5 or not event.MetFilters_hbheNoiseFilter:
             return True
         self.efficiencies.set_pileup(pileup)
 
-        offlineMetBE = event.sums.caloMetBE
+        offlineMetBE = event.Sums_caloMetBE
         for name, config in self.met_calcs.items():
-            onlineMet = config['calculate'](event.caloTowers)
+            onlineMet = event[config['attr']]
             onlineMet = onlineMet.mag
             self.efficiencies.fill(name, offlineMetBE, onlineMet)
         return True

--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -103,7 +103,7 @@ class ConfigParser(object):
         results = [self.validate_sections()]
         results += [self.validate_input_files()]
         results += [self.validate_analyzers()]
-        results += [self.validate_modifiers()]
+        results += [self.validate_producers()]
         return all(results)
 
     def validate_sections(self):
@@ -149,8 +149,8 @@ class ConfigParser(object):
     def validate_analyzers(self):
         return self.__validate_module_imports(['analysis', 'analyzers'])
 
-    def validate_modifiers(self):
-        return self.__validate_module_imports(['analysis', 'modifiers'])
+    def validate_producers(self):
+        return self.__validate_module_imports(['analysis', 'producers'])
 
     def __validate_module_imports(self, config_keys):
         modules = deepcopy(self.config)

--- a/config/all2017.yaml
+++ b/config/all2017.yaml
@@ -33,7 +33,7 @@ analysis:
   pu_bins: [25,50,999]
   analyzers:
      - cmsl1t.analyzers.jetMet_analyzer
-  modifiers: []
+  producers: []
   progress_bar:
     report_every: 1000
 

--- a/config/demo.yaml
+++ b/config/demo.yaml
@@ -43,7 +43,7 @@ analysis:
   pu_bins: 0,13,20,999
   analyzers:
     - cmsl1t.analyzers.demo_analyzer
-  modifiers:
+  producers:
     - cmsl1t.recalc.met.l1MetNot28:
         in: event.caloTowers
         out: event.l1MetNot28

--- a/config/demo.yaml
+++ b/config/demo.yaml
@@ -1,29 +1,5 @@
-# replicating
-# ntuple_cfg benchmark_cfg()
-# {
-#   ntuple_cfg config;
-#   config.sampleName   = "Data";
-#   config.sampleTitle  = "2016 Data";
-#   config.triggerName  = "SingleMu";
-#   config.triggerTitle = "Single Muon";
-#   config.puFilename   = "";
-#   config.run          = "276243";
-#   config.outDirBase   = "{{BENCHMARK_OUTPUT_FOLDER}}";
-#   config.doFit        = false;
-#   config.puType       = {"0PU12","13PU19","20PU"};
-#   config.puBins       = {0,13,20,999};
-#   config.inFiles      = {"{{BENCHMARK_DATA}}}/*.root"};
-#   config.baseOWdir    = config.outDirBase +
-#       "/20161101_"+config.sampleName+"_run-"+config.run+"_"+\
-#       config.triggerName+"_hadd/";
-#   config.outDir       = config.outDirBase+"/"+TL1DateTime::GetDate()+"_"+\
-#   config.sampleName+"_run-"+config.run+"_"+config.triggerName;
-#   return config;
-# }
-
-
-version: 0.0.1
-name: Benchmark
+version: 1
+name: Demo
 
 input:
   files:
@@ -44,20 +20,27 @@ analysis:
   analyzers:
     - cmsl1t.analyzers.demo_analyzer
   producers:
-    - cmsl1t.recalc.met.l1MetNot28:
-        in: event.caloTowers
-        out: event.l1MetNot28
-    - cmsl1t.recalc.met.l1MetNot28HF:
-        in: event.caloTowers
-        out: event.l1MetNot28HF
-  progress_bar:
-    report_every: 1000
-  # or to switch it off
-  # progress_bar:
-  #   enable: False
+    - cmsl1t.producers.met:
+        inputs:
+          - L1CaloTower_iphi
+          - L1CaloTower_ieta
+          - L1CaloTower_iet
+        outputs:
+          - l1MetNot28
+        params:
+          method: l1MetNot28
+    - cmsl1t.producers.met:
+        inputs:
+          - L1CaloTower_iphi
+          - L1CaloTower_ieta
+          - L1CaloTower_iet
+        outputs:
+          - l1MetNot28HF
+        params:
+          method: l1MetNot28HF
 
 output:
   # template is a list here that is joined (os.path.join) in the config parser
   template:
-     - benchmark/new
+     - output/demo
      - "{date}_{sample_name}_run-{run_number}_{trigger_name}"

--- a/config/efficiencies.yaml
+++ b/config/efficiencies.yaml
@@ -35,7 +35,7 @@ analysis:
 
   analyzers:
      - cmsl1t.analyzers.jetMet_analyzer
-  modifiers: []
+  producers: []
   progress_bar:
     report_every: 1000
 

--- a/config/gen.yaml
+++ b/config/gen.yaml
@@ -33,7 +33,7 @@ analysis:
     JetET_Emu: [35, 90, 120] 
   analyzers:
      - cmsl1t.analyzers.jetMet_analyzer
-  modifiers: []
+  producers: []
   progress_bar:
     report_every: 1000
 

--- a/config/jet_rates.yaml
+++ b/config/jet_rates.yaml
@@ -86,7 +86,7 @@ analysis:
   pu_bins: [0,13,20,999]
   analyzers:
      - cmsl1t.analyzers.jet_rates
-  modifiers: []
+  producers: []
   progress_bar:
     report_every: 1000
 

--- a/config/legacy/demo.yaml
+++ b/config/legacy/demo.yaml
@@ -49,7 +49,7 @@ analysis:
     - cmsl1t.analyzers.legacy_analyzer:
         macro: 'legacy/MakePlots/studyTower28MET.cxx'
         name: legacy_study_tower28MET
-  modifiers: []
+  producers: []
 
 
   progress_bar:


### PR DESCRIPTION
In order to finish the port of #85 and fix issue #80 this PR includes
 - new `bin/cmsl1t_future`, a copy of `bin/cmsl1t` which uses the new reader
 - update to config: `modifiers` &rarr; `producers` (does not affect existing configs)
 - update to `demo.yml` and `demo_analyzer` to use the new eventreader

To test run
```
cmsl1t_future -c config/demo.yaml -n 1000
```
@bundocka please have a look at demo analyzer if you would be happy to access the event variables like it. This is a preview to the new functionality coming in version 0.3 and meant as a replacement for `playground.eventreader`.
If you are happy, I can migrate the remaining configs and analysers in future PRs.