### PR TITLE
BaseProducer, input & output checks

### DIFF
--- a/bin/cmsl1t_future
+++ b/bin/cmsl1t_future
@@ -44,7 +44,7 @@ def process_tuples(config, nevents, analyzers, producers):
 
     ntuple_map_file = 'config/ntuple_content.yaml'
     with open(ntuple_map_file) as f:
-       ntuple_map = yaml.load(f)
+        ntuple_map = yaml.load(f)
     load_L1TNTupleLibrary()
     reader = EventReader(input_files, ntuple_map, nevents=nevents)
 
@@ -118,6 +118,7 @@ def run(config, nevents, reload_histograms):
 
     producers = config.get('analysis', 'producers')
     producers = [load_producer(producer, config) for producer in producers]
+    _check_producer_outputs(producers)
 
     if not reload_histograms:
         analysis_mode = config.try_get('analysis', 'mode', default='new')
@@ -143,6 +144,17 @@ def run(config, nevents, reload_histograms):
     check(results, analyzers, 'finalize')
 
     return all(results)
+
+
+def _check_producer_outputs(producers):
+    outputs = []
+    for p in producers:
+        for o in p._outputs:
+            if o in outputs:
+                msg = 'Producer output {} already defined by other producers'.format(o)
+                logger.error(msg)
+                raise AttributeError(msg)
+        outputs += p._outputs
 
 
 def check(results, analyzers, method):

--- a/cmsl1t/producers/base.py
+++ b/cmsl1t/producers/base.py
@@ -1,0 +1,30 @@
+import logging
+logger = logging.getLogger(__name__)
+
+
+def _check_inputs(inputs, expected_input_order):
+    for i, o in zip(inputs, expected_input_order):
+        if not i.endswith(o):
+            return False
+    return True
+
+
+class BaseProducer(object):
+
+    def __init__(self, inputs, outputs, params):
+        self._inputs = inputs
+        self._params = params
+        self._outputs = outputs
+        self._checked_content = False
+
+        if not _check_inputs(self._inputs, self._expected_input_order):
+            logger.error('Unexpected input order.')
+            logger.error('Expected order' +
+                         ','.join(self._expected_input_order))
+            logger.error('Got' + ','.join(self._inputs))
+            raise ValueError('Unexpected input order in {}'.format(
+                self.__class__.__name__))
+
+    def produce(self, event):
+        raise NotImplementedError(
+            'Producer does not have a "produce(self, event)" method!')


### PR DESCRIPTION
Fixes #134

After some thinking decided to leave as much of the current config structure intact as possible.
Instead, checks are now included when producers are initialised (e.g. input order) and right after to eliminate duplicates in outputs.

The first producer to migrate is MET and others will follow.