### PR TITLE
Dynamic binning for efficiencies

### DIFF
--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -49,6 +49,7 @@ ALL_THRESHOLDS = dict(
     JetET=[35, 90, 120]
 )
 
+
 def extractSums(event, doEmu, doReco, doGen):
     offline = dict()
     online = dict()

--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -49,31 +49,6 @@ ALL_THRESHOLDS = dict(
     JetET=[35, 90, 120]
 )
 
-HIGH_RANGE_BINS = list(range(0, 100, 5)) + list(range(100, 300, 10))
-HIGH_RANGE_BINS += list(range(300, 400, 20)) + list(range(400, 600, 50))
-HIGH_RANGE_BINS += list(range(600, 800, 200)) + list(range(800, 1200, 200))
-HIGH_RANGE_BINS += list(range(1200, 2800, 800))
-HIGH_RANGE_BINS_MET = list(range(0, 100, 5)) + list(range(100, 300, 10))
-HIGH_RANGE_BINS_MET += list(range(300, 400, 20)) + list(range(400, 600, 50))
-HIGH_RANGE_BINS_MET += list(range(600, 800, 200)) + list(range(800, 1000, 200))
-HIGH_RANGE_BINS_MET += list(range(1000, 3000, 1000))
-HIGH_RANGE_BINS_FWD = list(range(20, 100, 5)) + list(range(100, 300, 10))
-HIGH_RANGE_BINS_FWD += list(range(300, 400, 20)) + list(range(400, 600, 50))
-HIGH_RANGE_BINS_FWD += list(range(600, 800, 100)) + \
-    list(range(800, 3200, 1200))
-HIGH_RANGE_BINS_HT = list(range(30, 100, 5)) + list(range(100, 300, 10))
-HIGH_RANGE_BINS_HT += list(range(300, 500, 20)) + list(range(500, 700, 50))
-HIGH_RANGE_BINS_HT += list(range(700, 1000, 100)) + \
-    list(range(1000, 1200, 200))
-HIGH_RANGE_BINS_HT += list(range(1200, 1500, 300)) + \
-    list(range(1500, 2500, 500))
-
-HIGH_RANGE_BINS = np.asarray(HIGH_RANGE_BINS, 'd')
-HIGH_RANGE_BINS_MET = np.asarray(HIGH_RANGE_BINS_MET, 'd')
-HIGH_RANGE_BINS_HT = np.asarray(HIGH_RANGE_BINS_HT, 'd')
-HIGH_RANGE_BINS_FWD = np.asarray(HIGH_RANGE_BINS_FWD, 'd')
-
-
 def extractSums(event, doEmu, doReco, doGen):
     offline = dict()
     online = dict()
@@ -317,25 +292,25 @@ class Analyzer(BaseAnalyzer):
             if high_range:
                 params = [
                     cfg.on_title, cfg.off_title + " (GeV)", puBins, thresholds,
-                    HIGH_RANGE_BINS.size - 1, HIGH_RANGE_BINS
+                    105, 0, 2100,
                 ]
                 if "HT" in cfg.name:
                     params = [
                         cfg.on_title, cfg.off_title +
                         " (GeV)", puBins, thresholds,
-                        HIGH_RANGE_BINS_HT.size - 1, HIGH_RANGE_BINS_HT
+                        105, 30, 2130,
                     ]
-                if "JetET_HF" in cfg.name:
+                if "JetET" in cfg.name:
                     params = [
                         cfg.on_title, cfg.off_title +
                         " (GeV)", puBins, thresholds,
-                        HIGH_RANGE_BINS_FWD.size - 1, HIGH_RANGE_BINS_FWD
+                        105, 20, 2120,
                     ]
                 if "MET" in cfg.name:
                     params = [
                         cfg.on_title, cfg.off_title +
                         " (GeV)", puBins, thresholds,
-                        HIGH_RANGE_BINS_MET.size - 1, HIGH_RANGE_BINS_MET
+                        100, 0, 2000,
                     ]
 
             eff_plot.build(*params, legend_title=etaRange)

--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -222,29 +222,29 @@ class Analyzer(BaseAnalyzer):
         cfgs = []
         if self._doReco:
             cfgs.extend([
-                Config("caloHT", "Offline Calo HT", "L1 HT", 30, 800),
-                Config("pfHT", "Offline PF HT", "L1 HT", 30, 800),
+                Config("caloHT", "Offline Calo HT", "L1 HT", 30, 830),
+                Config("pfHT", "Offline PF HT", "L1 HT", 30, 830),
                 Config("caloMETHF", "Offline Calo MET HF", "L1 MET HF", 0, 400),
                 Config("caloMETBE", "Offline Calo MET BE", "L1 MET BE", 0, 400),
                 Config("pfMET_NoMu", "Offline PF MET NoMu", "L1 MET HF", 0, 400),
                 Config("caloJetET_BE", "Offline Central Calo Jet ET",
-                       "L1 Jet ET", 20, 400),
+                       "L1 Jet ET", 20, 420),
                 Config("caloJetET_HF", "Offline Forward Calo Jet ET",
-                       "L1 Jet ET", 20, 400),
+                       "L1 Jet ET", 20, 420),
                 Config("pfJetET_BE", "Offline Central PF Jet ET",
-                       "L1 Jet ET", 20, 400),
+                       "L1 Jet ET", 20, 420),
                 Config("pfJetET_HF", "Offline Forward PF Jet ET",
-                       "L1 Jet ET", 20, 400),
+                       "L1 Jet ET", 20, 420),
             ])
         if self._doGen:
             cfgs.extend([
-                Config("genHT", "Gen HT", "L1 HT", 30, 800),
-                Config("genMETHF", "Gen MET HF", "L1 MET HF", 0, 400),
-                Config("genMETBE", "Gen MET BE", "L1 MET BE", 0, 400),
+                Config("genHT", "Gen HT", "L1 HT", 30, 830),
+                Config("genMETHF", "Gen MET HF", "L1 MET HF", 0, 420),
+                Config("genMETBE", "Gen MET BE", "L1 MET BE", 0, 420),
                 Config("genJetET_BE", "Central Gen Jet ET",
-                       "L1 Jet ET", 20, 400),
+                       "L1 Jet ET", 20, 420),
                 Config("genJetET_HF", "Forward Gen Jet ET",
-                       "L1 Jet ET", 20, 400),
+                       "L1 Jet ET", 20, 420),
             ])
 
         self._plots_from_cfgs(cfgs, puBins)

--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -215,8 +215,8 @@ class Analyzer(BaseAnalyzer):
         if self._doGen:
             cfgs.extend([
                 Config("genHT", "Gen HT", "L1 HT", 30, 830),
-                Config("genMETHF", "Gen MET HF", "L1 MET HF", 0, 420),
-                Config("genMETBE", "Gen MET BE", "L1 MET BE", 0, 420),
+                Config("genMETHF", "Gen MET HF", "L1 MET HF", 0, 400),
+                Config("genMETBE", "Gen MET BE", "L1 MET BE", 0, 400),
                 Config("genJetET_BE", "Central Gen Jet ET",
                        "L1 Jet ET", 20, 420),
                 Config("genJetET_HF", "Forward Gen Jet ET",

--- a/cmsl1t/plotting/efficiency.py
+++ b/cmsl1t/plotting/efficiency.py
@@ -320,7 +320,6 @@ class EfficiencyPlot(BasePlotter):
         self.efficiencies += other.efficiencies
         return self.efficiencies
 
-
     def _dynamic_bin(self, eff):
         """
         Re-build efficiency plots so that there are no bins with < min_ entries
@@ -336,17 +335,17 @@ class EfficiencyPlot(BasePlotter):
         merge_total = 0
         merge_passed = 0
 
-        for bin in range(1,nbins+1):
+        for bin in range(1, nbins + 1):
 
-            next_bin_total = eff.GetTotalHistogram().GetBinContent(bin+1)
+            next_bin_total = eff.GetTotalHistogram().GetBinContent(bin + 1)
             merge_total += eff.GetTotalHistogram().GetBinContent(bin)
             merge_passed += eff.GetPassedHistogram().GetBinContent(bin)
             if bin == nbins:
-                merge_total += eff.GetTotalHistogram().GetBinContent(bin+1)
-                merge_passed += eff.GetPassedHistogram().GetBinContent(bin+1)
+                merge_total += eff.GetTotalHistogram().GetBinContent(bin + 1)
+                merge_passed += eff.GetPassedHistogram().GetBinContent(bin + 1)
 
             if (next_bin_total > min_ and merge_total > min_) or bin == nbins:
-                bins.append(eff.GetTotalHistogram().GetBinLowEdge(bin+1))
+                bins.append(eff.GetTotalHistogram().GetBinLowEdge(bin + 1))
                 total.append(merge_total)
                 passed.append(merge_passed)
                 merge_total = 0
@@ -354,15 +353,15 @@ class EfficiencyPlot(BasePlotter):
 
         npbins = np.asarray(bins)
 
-        hist_total = asrootpy(ROOT.TH1I("total","total",len(bins)-1,npbins))
-        hist_passed = asrootpy(ROOT.TH1I("passed","passed",len(bins)-1,npbins))
+        hist_total = asrootpy(ROOT.TH1I("total", "total", len(bins) - 1, npbins))
+        hist_passed = asrootpy(ROOT.TH1I("passed", "passed", len(bins) - 1, npbins))
 
-        for bin in range(1,len(bins)):
-            hist_total.SetBinContent(bin,total[bin-1])
-            hist_passed.SetBinContent(bin,passed[bin-1])
+        for bin in range(1, len(bins)):
+            hist_total.SetBinContent(bin, total[bin - 1])
+            hist_passed.SetBinContent(bin, passed[bin - 1])
 
         hist_total.Sumw2(False)
         hist_passed.Sumw2(False)
 
-        eff.SetTotalHistogram(hist_total,"f")
-        eff.SetPassedHistogram(hist_passed,"f")
+        eff.SetTotalHistogram(hist_total, "f")
+        eff.SetPassedHistogram(hist_passed, "f")

--- a/cmsl1t/plotting/efficiency.py
+++ b/cmsl1t/plotting/efficiency.py
@@ -326,7 +326,7 @@ class EfficiencyPlot(BasePlotter):
         Re-build efficiency plots so that there are no bins with < min_ entries
         """
 
-        min_ = 8
+        min_ = 10
         total = []
         passed = []
         bins = []
@@ -341,6 +341,9 @@ class EfficiencyPlot(BasePlotter):
             next_bin_total = eff.GetTotalHistogram().GetBinContent(bin+1)
             merge_total += eff.GetTotalHistogram().GetBinContent(bin)
             merge_passed += eff.GetPassedHistogram().GetBinContent(bin)
+            if bin == nbins:
+                merge_total += eff.GetTotalHistogram().GetBinContent(bin+1)
+                merge_passed += eff.GetPassedHistogram().GetBinContent(bin+1)
 
             if (next_bin_total > min_ and merge_total > min_) or bin == nbins:
                 bins.append(eff.GetTotalHistogram().GetBinLowEdge(bin+1))

--- a/cmsl1t/plotting/efficiency.py
+++ b/cmsl1t/plotting/efficiency.py
@@ -325,7 +325,7 @@ class EfficiencyPlot(BasePlotter):
         Re-build efficiency plots so that there are no bins with < min_ entries
         """
 
-        min_ = 10
+        min_ = 20
         total = []
         passed = []
         bins = []

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -4,5 +4,5 @@ numpy
 matplotlib
 pytables
 rootpy
-pandas
+pandas==0.22.0
 psutil


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/cms-l1t-offline/cms-l1t-analysis/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->


#### What does this pull request implement/fix? Explain your changes.

- Add _dynamic_bin member function to efficiency class that automatically merges bins such that all bins have more than n total events
- Remove high range bin arrays from jetMet_analyzer
- Tidy up binning
- Checked that the efficiencies are the same as before adding this functionality for 10k events, and when setting min events to -1 

#### Any other comments?
An example would be if you require another pull request to be merged before this one.
If you do, please reference it.