### PR TITLE
Improving "make release" scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ test-code-full:
 	@pytest -v test
 
 changelog:
-	@github_changelog_generator -u cms-l1t-offline -p cms-l1t-analysis --base docs/initial_changelog.md
+	@github_changelog_generator -u cms-l1t-offline -p cms-l1t-analysis
 
 docs-html:
 	cd docs; make html; cd -

--- a/update_release.py
+++ b/update_release.py
@@ -16,7 +16,7 @@ def update_readme(release):
             break
 
     content = ''.join(content)
-    with open('README.md', 'w+') as f:
+    with open(input_file, 'w+') as f:
         f.write(content)
 
 
@@ -29,7 +29,40 @@ def update_changelog(release):
     with open(input_file, 'w+') as f:
         f.write(content)
 
+
+def update_package_version(release):
+    input_file = 'cmsl1t/__init__.py'
+    with open(input_file) as f:
+        content = f.readlines()
+
+    for i, line in enumerate(content):
+        pattern = "(\d+\.)?(\d+\.)?(\*|\d+)"
+        if '__version__' in line:
+            line = re.sub(pattern, 'v' + release, line)
+            content[i] = line
+            break
+
+    content = ''.join(content)
+    with open(input_file, 'w+') as f:
+        f.write(content)
+
+
+def append_histoical_log():
+    input_file = 'CHANGELOG.md'
+    with open(input_file) as f:
+        content = f.readlines()
+    historical_changelog = 'docs/initial_changelog.md'
+    with open(historical_changelog) as f:
+        historical_content = f.readlines()
+
+    content.insert(-2, ''.join(historical_content))
+    content = ''.join(content)
+    with open(input_file, 'w+') as f:
+        f.write(content)
+
 if __name__ == '__main__':
     release = os.environ.get('RELEASE', 'unreleased')
     update_readme(release)
     update_changelog(release)
+    update_package_version(release)
+    append_histoical_log()


### PR DESCRIPTION
Noticed that the package version is not updated when we make release &rarr; fixed.
Also, since github_changelog slightly changed how it handles the base file, updated our script for doing it instead.