### PR TITLE
Printout number of objects passing thresholds when estimating rates

### DIFF
--- a/cmsl1t/analyzers/HW_Emu_jetMet_rates.py
+++ b/cmsl1t/analyzers/HW_Emu_jetMet_rates.py
@@ -312,11 +312,9 @@ class Analyzer(BaseAnalyzer):
             all_stats[collection_type] += [plot.get_stats(summary_label=summary_label, summary_bins=summary_bins)]
 
         for collection_type in all_stats:
-            df = pd.concat(all_stats[collection_type])
+            df = pd.concat(all_stats[collection_type], sort=False)
             df.sort_values(by=['identifier'], inplace=True)
             df.fillna('------', inplace=True)
-            summary_columns = [c for c in df.columns.values if c not in ['identifier', 'total']]
-            df = df[['identifier', 'total'] + summary_columns]
             print('Histogram collection:', collection_type)
             print(tabulate(df, headers='keys', tablefmt='psql', showindex=False))
             df_output = os.path.join(self.output_folder, '{}_histogram_stats.csv'.format(collection_type))

--- a/cmsl1t/analyzers/HW_Emu_jetMet_rates.py
+++ b/cmsl1t/analyzers/HW_Emu_jetMet_rates.py
@@ -1,9 +1,11 @@
 """
 Study the MET distibutions and various PUS schemes
 """
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
+import pandas as pd
 import ROOT
+from tabulate import tabulate
 import os
 from cmsl1t.analyzers.BaseAnalyzer import BaseAnalyzer
 from cmsl1t.plotting.rates import RatesPlot
@@ -92,11 +94,10 @@ class Analyzer(BaseAnalyzer):
                         'Error: Please specify thresholds in the config .yaml in dictionary format')
 
             rates_plot = getattr(self, name + "_rates")
-            rates_plot.build(name, puBins, 200, 0, 200, ETA_RANGES.get(name))
+            rates_plot.build("L1 " + name, puBins, 200, 0, 200, ETA_RANGES.get(name))
 
             rate_vs_pileup_plot = getattr(self, name + "_rate_vs_pileup")
-            rate_vs_pileup_plot.build(
-                "L1 " + name, trig_thresholds, 16, 0, 80, ETA_RANGES.get(name))
+            rate_vs_pileup_plot.build("L1 " + name, trig_thresholds, 16, 0, 80, ETA_RANGES.get(name))
 
         '''
         self.rates = HistogramsByPileUpCollection(

--- a/cmsl1t/analyzers/HW_Emu_jetMet_rates.py
+++ b/cmsl1t/analyzers/HW_Emu_jetMet_rates.py
@@ -295,16 +295,6 @@ class Analyzer(BaseAnalyzer):
         return True
 
     def __print_histogram_statistics(self):
-        summary = dict(
-            RateVsPileupPlot=dict(
-                label='PU',
-                bins=self.puBins,
-            ),
-            RatesPlot=dict(
-                label='threshold',
-                bins=self.thresholds,
-            ),
-        )
         all_stats = {}
         for plot in self.all_plots:
             # different hist collection will have different stats formats!
@@ -315,7 +305,7 @@ class Analyzer(BaseAnalyzer):
             summary_label = 'PU'
             summary_bins = self.puBins
             if collection_type == 'RatesPlot':
-                summary_label = 'threshold'
+                summary_label = 'bin'
                 for var, thresholds in self.thresholds.items():
                     if "L1 " + var in plot.online_title:
                         summary_bins = thresholds

--- a/cmsl1t/analyzers/HW_Emu_jetMet_rates.py
+++ b/cmsl1t/analyzers/HW_Emu_jetMet_rates.py
@@ -315,7 +315,8 @@ class Analyzer(BaseAnalyzer):
             df = pd.concat(all_stats[collection_type])
             df.sort_values(by=['identifier'], inplace=True)
             df.fillna('------', inplace=True)
-            # df = pd.DataFrame(all_stats, columns=['identifier', 'statistics'])
+            summary_columns = [c for c in df.columns.values if c not in ['identifier', 'total']]
+            df = df[['identifier', 'total'] + summary_columns]
             print('Histogram collection:', collection_type)
             print(tabulate(df, headers='keys', tablefmt='psql', showindex=False))
             df_output = os.path.join(self.output_folder, '{}_histogram_stats.csv'.format(collection_type))

--- a/cmsl1t/plotting/base.py
+++ b/cmsl1t/plotting/base.py
@@ -102,3 +102,16 @@ class BasePlotter(object):
         Use self.save_canvas() to actually save the plot
         """
         raise NotImplementedError("draw() needs to be implemented")
+
+
+    def get_stats(self, summary_bins=[], summary_label=''):
+        """
+        Has to be overloaded by users code.
+
+        Return the statistics in each histogram on a canvas.
+        Should return a Dataframe
+
+        :param summary_bins bins to summarise the stats into
+        :param summary_label label to assign to summary columns
+        """
+        raise NotImplementedError("get_stats() needs to be implemented")

--- a/cmsl1t/plotting/base.py
+++ b/cmsl1t/plotting/base.py
@@ -103,7 +103,6 @@ class BasePlotter(object):
         """
         raise NotImplementedError("draw() needs to be implemented")
 
-
     def get_stats(self, summary_bins=[], summary_label=''):
         """
         Has to be overloaded by users code.

--- a/cmsl1t/plotting/rate_vs_pileup.py
+++ b/cmsl1t/plotting/rate_vs_pileup.py
@@ -176,7 +176,6 @@ class RateVsPileupPlot(BasePlotter):
             human_readable_threshold = '{0} > {1} GeV'.format(self.online_title, self.thresholds.bins[threshold])
             rhist = hist.rebinned(summary_bins)
             stats = {}
-            edges = list(rhist.xedges())
             summary_columns = self._summary_columns(summary_bins, summary_label)
             for i, summary_column in enumerate(summary_columns):
                 stats[summary_column] = rhist.integral(i, i + 1) * normalisation

--- a/cmsl1t/plotting/rate_vs_pileup.py
+++ b/cmsl1t/plotting/rate_vs_pileup.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+import pandas as pd
+
 from cmsl1t.plotting.base import BasePlotter
 from cmsl1t.hist.hist_collection import HistogramCollection
 import cmsl1t.hist.binning as bn
@@ -10,6 +12,7 @@ from rootpy.plotting import Legend
 
 
 class RateVsPileupPlot(BasePlotter):
+
     def __init__(self, online_name):
         name = ["rate_vs_pileup", online_name]
         super(RateVsPileupPlot, self).__init__("__".join(name))
@@ -156,3 +159,28 @@ class RateVsPileupPlot(BasePlotter):
         """
         self.plots += other.plots
         return self.plots
+
+    def get_stats(self, summary_bins=[], summary_label=''):
+        summary_columns = list(self._summary_columns(summary_bins, summary_label))
+        stats = list(self._collect_stats(summary_bins, summary_label))
+        df = pd.DataFrame(stats)
+        return df[['identifier', 'total'] + summary_columns]
+
+    def _summary_columns(self, summary_bins, summary_label):
+        for lower, upper in zip(summary_bins[:-1], summary_bins[1:]):
+            yield '{} {}-{}'.format(summary_label, lower, upper)
+
+    def _collect_stats(self, summary_bins, summary_label):
+        normalisation = self.plots.get_bin_contents([bn.Base.everything]).integral(overflow=True)
+        for (threshold, ), hist in self.plots.flat_items():
+            human_readable_threshold = '{0} > {1} GeV'.format(self.online_title, self.thresholds.bins[threshold])
+            rhist = hist.rebinned(summary_bins)
+            stats = {}
+            edges = list(rhist.xedges())
+            summary_columns = self._summary_columns(summary_bins, summary_label)
+            for i, summary_column in enumerate(summary_columns):
+                stats[summary_column] = rhist.integral(i, i + 1) * normalisation
+            total = sum(stats.values())
+            header = dict(identifier=human_readable_threshold, total=total)
+            header.update(stats)
+            yield header

--- a/cmsl1t/plotting/rate_vs_pileup.py
+++ b/cmsl1t/plotting/rate_vs_pileup.py
@@ -164,7 +164,7 @@ class RateVsPileupPlot(BasePlotter):
         summary_columns = list(self._summary_columns(summary_bins, summary_label))
         stats = list(self._collect_stats(summary_bins, summary_label))
         df = pd.DataFrame(stats)
-        return df[['identifier', 'total'] + summary_columns]
+        return df[['identifier', 'total', 'overflow'] + summary_columns]
 
     def _summary_columns(self, summary_bins, summary_label):
         for lower, upper in zip(summary_bins[:-1], summary_bins[1:]):
@@ -180,6 +180,7 @@ class RateVsPileupPlot(BasePlotter):
             for summary_column, y in zip(summary_columns, rhist.y()):
                 stats[summary_column] = y * normalisation
             total = sum(stats.values())
-            header = dict(identifier=human_readable_threshold, total=total)
+            overflow = rhist.integral(overflow=True) * normalisation - total
+            header = dict(identifier=human_readable_threshold, total=total, overflow=overflow)
             header.update(stats)
             yield header

--- a/cmsl1t/plotting/rate_vs_pileup.py
+++ b/cmsl1t/plotting/rate_vs_pileup.py
@@ -177,8 +177,8 @@ class RateVsPileupPlot(BasePlotter):
             rhist = hist.rebinned(summary_bins)
             stats = {}
             summary_columns = self._summary_columns(summary_bins, summary_label)
-            for i, summary_column in enumerate(summary_columns):
-                stats[summary_column] = rhist.integral(i, i + 1) * normalisation
+            for summary_column, y in zip(summary_columns, rhist.y()):
+                stats[summary_column] = y * normalisation
             total = sum(stats.values())
             header = dict(identifier=human_readable_threshold, total=total)
             header.update(stats)

--- a/cmsl1t/plotting/rates.py
+++ b/cmsl1t/plotting/rates.py
@@ -153,7 +153,7 @@ class RatesPlot(BasePlotter):
         summary_columns = list(self._summary_columns(summary_bins, summary_label))
         stats = list(self._collect_stats(summary_bins, summary_label))
         df = pd.DataFrame(stats)
-        return df[['identifier', 'total'] + summary_columns]
+        return df[['identifier', 'total', 'overflow'] + summary_columns]
 
     def _summary_columns(self, summary_bins, summary_label):
         for lower, upper in zip(summary_bins[:-1], summary_bins[1:]):
@@ -168,6 +168,7 @@ class RatesPlot(BasePlotter):
             for summary_column, y in zip(summary_columns, rhist.y()):
                 stats[summary_column] = y
             total = sum(stats.values())
-            header = dict(identifier=human_readable_threshold, total=total)
+            overflow = rhist.integral(overflow=True) - total
+            header = dict(identifier=human_readable_threshold, total=total, overflow=overflow)
             header.update(stats)
             yield header

--- a/cmsl1t/plotting/rates.py
+++ b/cmsl1t/plotting/rates.py
@@ -165,8 +165,8 @@ class RatesPlot(BasePlotter):
             rhist = hist.rebinned(summary_bins)
             stats = {}
             summary_columns = self._summary_columns(summary_bins, summary_label)
-            for i, summary_column in enumerate(summary_columns):
-                stats[summary_column] = rhist.integral(i, i + 1)
+            for summary_column, y in zip(summary_columns, rhist.y()):
+                stats[summary_column] = y
             total = sum(stats.values())
             header = dict(identifier=human_readable_threshold, total=total)
             header.update(stats)

--- a/cmsl1t/plotting/rates.py
+++ b/cmsl1t/plotting/rates.py
@@ -164,7 +164,6 @@ class RatesPlot(BasePlotter):
             human_readable_threshold = '{0}; PU > {1}'.format(self.online_title, self.pileup_bins.bins[pileup])
             rhist = hist.rebinned(summary_bins)
             stats = {}
-            edges = list(rhist.xedges())
             summary_columns = self._summary_columns(summary_bins, summary_label)
             for i, summary_column in enumerate(summary_columns):
                 stats[summary_column] = rhist.integral(i, i + 1)

--- a/cmsl1t/plotting/rates.py
+++ b/cmsl1t/plotting/rates.py
@@ -1,5 +1,6 @@
 from __future__ import division
 import numpy as np
+import pandas as pd
 from cmsl1t.plotting.base import BasePlotter
 from cmsl1t.hist.hist_collection import HistogramCollection
 from cmsl1t.hist.factory import HistFactory
@@ -147,3 +148,27 @@ class RatesPlot(BasePlotter):
         """
         self.plots += other.plots
         return self.plots
+
+    def get_stats(self, summary_bins=[], summary_label=''):
+        summary_columns = list(self._summary_columns(summary_bins, summary_label))
+        stats = list(self._collect_stats(summary_bins, summary_label))
+        df = pd.DataFrame(stats)
+        return df[['identifier', 'total'] + summary_columns]
+
+    def _summary_columns(self, summary_bins, summary_label):
+        for lower, upper in zip(summary_bins[:-1], summary_bins[1:]):
+            yield '{} {}-{}'.format(summary_label, lower, upper)
+
+    def _collect_stats(self, summary_bins, summary_label):
+        for (pileup, ), hist in self.plots.flat_items():
+            human_readable_threshold = '{0}; PU > {1}'.format(self.online_title, self.pileup_bins.bins[pileup])
+            rhist = hist.rebinned(summary_bins)
+            stats = {}
+            edges = list(rhist.xedges())
+            summary_columns = self._summary_columns(summary_bins, summary_label)
+            for i, summary_column in enumerate(summary_columns):
+                stats[summary_column] = rhist.integral(i, i + 1)
+            total = sum(stats.values())
+            header = dict(identifier=human_readable_threshold, total=total)
+            header.update(stats)
+            yield header


### PR DESCRIPTION
Fixes #150

This was harder than expected.
 - implemented new Plotter function `get_stats` which returns a DataFrame
 - added printout to `HW_Emu_jetMet_rates.finalize()`
 - histogram statistics are stored in CSV files for future use

### Output from 1000 events
```
Histogram collection: RatesPlot
+--------------------------+---------+------------+---------------+---------------+--------------+---------------+-------------+--------------+
| identifier               |   total |   overflow | bin 120-200   | bin 200-320   | bin 80-100   | bin 100-120   | bin 35-90   | bin 90-120   |
|--------------------------+---------+------------+---------------+---------------+--------------+---------------+-------------+--------------|
| L1 HT; PU > 0            |      76 |        816 | 76.0          | 0.0           | ------       | ------        | ------      | ------       |
| L1 HT; PU > 25           |       0 |          0 | 0.0           | 0.0           | ------       | ------        | ------      | ------       |
| L1 HT; PU > 50           |       0 |          0 | 0.0           | 0.0           | ------       | ------        | ------      | ------       |
| L1 HT_Emu; PU > 0        |      76 |        816 | 76.0          | 0.0           | ------       | ------        | ------      | ------       |
| L1 HT_Emu; PU > 25       |       0 |          0 | 0.0           | 0.0           | ------       | ------        | ------      | ------       |
| L1 HT_Emu; PU > 50       |       0 |          0 | 0.0           | 0.0           | ------       | ------        | ------      | ------       |
| L1 JetET_BE; PU > 0      |     376 |        585 | ------        | ------        | ------       | ------        | 323.0       | 53.0         |
| L1 JetET_BE; PU > 25     |       0 |          0 | ------        | ------        | ------       | ------        | 0.0         | 0.0          |
| L1 JetET_BE; PU > 50     |       0 |          0 | ------        | ------        | ------       | ------        | 0.0         | 0.0          |
| L1 JetET_BE_Emu; PU > 0  |     298 |        663 | ------        | ------        | ------       | ------        | 245.0       | 53.0         |
| L1 JetET_BE_Emu; PU > 25 |       0 |          0 | ------        | ------        | ------       | ------        | 0.0         | 0.0          |
| L1 JetET_BE_Emu; PU > 50 |       0 |          0 | ------        | ------        | ------       | ------        | 0.0         | 0.0          |
| L1 JetET_HF; PU > 0      |      46 |        953 | ------        | ------        | ------       | ------        | 45.0        | 1.0          |
| L1 JetET_HF; PU > 25     |       0 |          0 | ------        | ------        | ------       | ------        | 0.0         | 0.0          |
| L1 JetET_HF; PU > 50     |       0 |          0 | ------        | ------        | ------       | ------        | 0.0         | 0.0          |
| L1 JetET_HF_Emu; PU > 0  |      38 |        961 | ------        | ------        | ------       | ------        | 37.0        | 1.0          |
| L1 JetET_HF_Emu; PU > 25 |       0 |          0 | ------        | ------        | ------       | ------        | 0.0         | 0.0          |
| L1 JetET_HF_Emu; PU > 50 |       0 |          0 | ------        | ------        | ------       | ------        | 0.0         | 0.0          |
| L1 METBE; PU > 0         |      40 |        956 | ------        | ------        | 22.0         | 18.0          | ------      | ------       |
| L1 METBE; PU > 25        |       0 |          0 | ------        | ------        | 0.0          | 0.0           | ------      | ------       |
| L1 METBE; PU > 50        |       0 |          0 | ------        | ------        | 0.0          | 0.0           | ------      | ------       |
| L1 METBE_Emu; PU > 0     |      40 |        956 | ------        | ------        | 22.0         | 18.0          | ------      | ------       |
| L1 METBE_Emu; PU > 25    |       0 |          0 | ------        | ------        | 0.0          | 0.0           | ------      | ------       |
| L1 METBE_Emu; PU > 50    |       0 |          0 | ------        | ------        | 0.0          | 0.0           | ------      | ------       |
| L1 METHF; PU > 0         |      47 |        948 | ------        | ------        | 25.0         | 22.0          | ------      | ------       |
| L1 METHF; PU > 25        |       0 |          0 | ------        | ------        | 0.0          | 0.0           | ------      | ------       |
| L1 METHF; PU > 50        |       0 |          0 | ------        | ------        | 0.0          | 0.0           | ------      | ------       |
| L1 METHF_Emu; PU > 0     |      47 |        948 | ------        | ------        | 25.0         | 22.0          | ------      | ------       |
| L1 METHF_Emu; PU > 25    |       0 |          0 | ------        | ------        | 0.0          | 0.0           | ------      | ------       |
| L1 METHF_Emu; PU > 50    |       0 |          0 | ------        | ------        | 0.0          | 0.0           | ------      | ------       |
+--------------------------+---------+------------+---------------+---------------+--------------+---------------+-------------+--------------+
Saved histogram statistics to /code/output/zb_rates/20180823_None_Data_zbNoLowEtSF-v16/RatesPlot_histogram_stats.csv
Histogram collection: RateVsPileupPlot
+---------------------------+---------+------------+-----------+------------+-------------+
| identifier                |   total |   overflow |   PU 0-25 |   PU 25-50 |   PU 50-999 |
|---------------------------+---------+------------+-----------+------------+-------------|
| L1 HT > 120 GeV           |     184 |          0 |       184 |          0 |           0 |
| L1 HT > 200 GeV           |     108 |          0 |       108 |          0 |           0 |
| L1 HT > 320 GeV           |      51 |          0 |        51 |          0 |           0 |
| L1 HT_Emu > 120 GeV       |     184 |          0 |       184 |          0 |           0 |
| L1 HT_Emu > 200 GeV       |     108 |          0 |       108 |          0 |           0 |
| L1 HT_Emu > 320 GeV       |      51 |          0 |        51 |          0 |           0 |
| L1 JetET_BE > 120 GeV     |      99 |          0 |        99 |          0 |           0 |
| L1 JetET_BE > 35 GeV      |     475 |          0 |       475 |          0 |           0 |
| L1 JetET_BE > 90 GeV      |     152 |          0 |       152 |          0 |           0 |
| L1 JetET_BE_Emu > 120 GeV |      96 |          0 |        96 |          0 |           0 |
| L1 JetET_BE_Emu > 35 GeV  |     394 |          0 |       394 |          0 |           0 |
| L1 JetET_BE_Emu > 90 GeV  |     149 |          0 |       149 |          0 |           0 |
| L1 JetET_HF > 120 GeV     |       1 |          0 |         1 |          0 |           0 |
| L1 JetET_HF > 35 GeV      |      47 |          0 |        47 |          0 |           0 |
| L1 JetET_HF > 90 GeV      |       2 |          0 |         2 |          0 |           0 |
| L1 JetET_HF_Emu > 120 GeV |       1 |          0 |         1 |          0 |           0 |
| L1 JetET_HF_Emu > 35 GeV  |      39 |          0 |        39 |          0 |           0 |
| L1 JetET_HF_Emu > 90 GeV  |       2 |          0 |         2 |          0 |           0 |
| L1 METBE > 100 GeV        |      37 |          0 |        37 |          0 |           0 |
| L1 METBE > 120 GeV        |      19 |          0 |        19 |          0 |           0 |
| L1 METBE > 80 GeV         |      59 |          0 |        59 |          0 |           0 |
| L1 METBE_Emu > 100 GeV    |      37 |          0 |        37 |          0 |           0 |
| L1 METBE_Emu > 120 GeV    |      19 |          0 |        19 |          0 |           0 |
| L1 METBE_Emu > 80 GeV     |      59 |          0 |        59 |          0 |           0 |
| L1 METHF > 100 GeV        |      37 |          0 |        37 |          0 |           0 |
| L1 METHF > 120 GeV        |      15 |          0 |        15 |          0 |           0 |
| L1 METHF > 80 GeV         |      62 |          0 |        62 |          0 |           0 |
| L1 METHF_Emu > 100 GeV    |      37 |          0 |        37 |          0 |           0 |
| L1 METHF_Emu > 120 GeV    |      15 |          0 |        15 |          0 |           0 |
| L1 METHF_Emu > 80 GeV     |      62 |          0 |        62 |          0 |           0 |
+---------------------------+---------+------------+-----------+------------+-------------+
Saved histogram statistics to /code/output/zb_rates/20180823_None_Data_zbNoLowEtSF-v16/RateVsPileupPlot_histogram_stats.csv
```
