### PR TITLE
Sort reco jets by etCorr, check jet bx == 0, fix batch sub

### DIFF
--- a/bin/cmsl1t_batch
+++ b/bin/cmsl1t_batch
@@ -13,6 +13,8 @@ from cmsl1t.batch import Batch, condor_submit, lsf_submit
 from cmsl1t.batch import prepare_output_folders, get_config_name_template
 
 from cmsl1t.batch import create_run_script, create_info_file, prepare_jobs
+from cmsl1t.utils.module import load_L1TNTupleLibrary
+load_L1TNTupleLibrary()
 
 logger = logging.getLogger(__name__)
 click_log.basic_config(logger)

--- a/bin/cmsl1t_batch
+++ b/bin/cmsl1t_batch
@@ -71,6 +71,18 @@ def run(config_file, debug, batch, files_per_job):
 
       cmsl1t_batch_status -i {1}""".format(batch_dir, info_file)))
 
+    # Finally dump the commands needed to run the next steps to screen:
+    next_steps = """
+    when all jobs are done, you can combine all results together with:
+
+        cmsl1t -c {cfg} -r --hist-files '{outdir}/*.root'
+
+    ie. use the same config file given here, but reload hists from the intermediate root files.
+    """
+
+    logger.info(next_steps.format(cfg=config_file.name,
+                                  outdir=outdir.format(index="*")))
+
 
 if __name__ == '__main__':
     run()

--- a/bin/cmsl1t_dirty_batch
+++ b/bin/cmsl1t_dirty_batch
@@ -13,6 +13,8 @@ from textwrap import dedent
 import logging
 import subprocess
 import pandas as pd
+from cmsl1t.utils.module import load_L1TNTupleLibrary
+load_L1TNTupleLibrary()
 logger = logging.getLogger(__name__)
 click_log.basic_config(logger)
 

--- a/cmsl1t/io/eventreader.py
+++ b/cmsl1t/io/eventreader.py
@@ -59,9 +59,6 @@ class EventReader(object):
         self.input_files = _get_input_files(input_files)
         self.nevents = nevents
         self._trees = {}
-        for alias in self._aliasMap:
-            if 'vertex' in alias.lower():
-                print(alias)
 
         self._load_trees()
 

--- a/cmsl1t/producers/jets.py
+++ b/cmsl1t/producers/jets.py
@@ -59,13 +59,15 @@ class Producer(BaseProducer):
     def produce(self, event):
         variables = [event[i] for i in self._inputs]
         jets = [self._jetClass(*args) for args in zip(*variables)]
+        if 'L1' in self._jetType:
+            jets = [jet for jet in jets if jet.bx == 0]
         if self._jetFilter:
             jets = self._jetFilter(jets)
 
         # sort by ET, largest first
         sorted_jets = sorted(
             jets,
-            key=lambda jet: jet.et,
+            key=lambda jet: jet.etCorr if jet.etCorr else jet.et,
             reverse=True,
         )
 

--- a/config/efficiencies.yaml
+++ b/config/efficiencies.yaml
@@ -16,7 +16,8 @@ input:
     title: Single Muon
   pileup_file: ""
   run_number: ""
-  lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt"
+  lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions18/13TeV/PromptReco/Cert_314472-325175_13TeV_PromptReco_Collisions18_JSON.txt"
+  ntuple_map_file: config/ntuple_content_AODRAWEMU.yaml
 
 analysis:
   load_trees:

--- a/config/ntuple_content_AODRAWEMU.yaml
+++ b/config/ntuple_content_AODRAWEMU.yaml
@@ -1,0 +1,1099 @@
+version: vvv0.5.1
+content:
+  l1CaloTowerEmuTree/L1CaloTowerTree:
+    name: L1CaloTowerTree
+    optional: false
+    branches:
+      CaloTP.ecalTPCaliphi:
+        aliases:
+        - event.emu_CaloTP_ecalTPCaliphi
+      CaloTP.ecalTPcompEt:
+        aliases:
+        - event.emu_CaloTP_ecalTPcompEt
+      CaloTP.ecalTPet:
+        aliases:
+        - event.emu_CaloTP_ecalTPet
+      CaloTP.ecalTPfineGrain:
+        aliases:
+        - event.emu_CaloTP_ecalTPfineGrain
+      CaloTP.ecalTPieta:
+        aliases:
+        - event.emu_CaloTP_ecalTPieta
+      CaloTP.ecalTPiphi:
+        aliases:
+        - event.emu_CaloTP_ecalTPiphi
+      CaloTP.hcalTPCaliphi:
+        aliases:
+        - event.emu_CaloTP_hcalTPCaliphi
+      CaloTP.hcalTPcompEt:
+        aliases:
+        - event.emu_CaloTP_hcalTPcompEt
+      CaloTP.hcalTPet:
+        aliases:
+        - event.emu_CaloTP_hcalTPet
+      CaloTP.hcalTPfineGrain:
+        aliases:
+        - event.emu_CaloTP_hcalTPfineGrain
+      CaloTP.hcalTPieta:
+        aliases:
+        - event.emu_CaloTP_hcalTPieta
+      CaloTP.hcalTPiphi:
+        aliases:
+        - event.emu_CaloTP_hcalTPiphi
+      CaloTP.nECALTP:
+        aliases:
+        - event.emu_CaloTP_nECALTP
+      CaloTP.nHCALTP:
+        aliases:
+        - event.emu_CaloTP_nHCALTP
+      L1CaloCluster.et:
+        aliases:
+        - event.emu_L1CaloCluster_et
+      L1CaloCluster.eta:
+        aliases:
+        - event.emu_L1CaloCluster_eta
+      L1CaloCluster.iet:
+        aliases:
+        - event.emu_L1CaloCluster_iet
+      L1CaloCluster.ieta:
+        aliases:
+        - event.emu_L1CaloCluster_ieta
+      L1CaloCluster.iphi:
+        aliases:
+        - event.emu_L1CaloCluster_iphi
+      L1CaloCluster.iqual:
+        aliases:
+        - event.emu_L1CaloCluster_iqual
+      L1CaloCluster.nCluster:
+        aliases:
+        - event.emu_L1CaloCluster_nCluster
+      L1CaloCluster.phi:
+        aliases:
+        - event.emu_L1CaloCluster_phi
+      L1CaloTower.et:
+        aliases:
+        - event.emu_L1CaloTower_et
+      L1CaloTower.eta:
+        aliases:
+        - event.emu_L1CaloTower_eta
+      L1CaloTower.iem:
+        aliases:
+        - event.emu_L1CaloTower_iem
+      L1CaloTower.iet:
+        aliases:
+        - event.emu_L1CaloTower_iet
+      L1CaloTower.ieta:
+        aliases:
+        - event.emu_L1CaloTower_ieta
+      L1CaloTower.ihad:
+        aliases:
+        - event.emu_L1CaloTower_ihad
+      L1CaloTower.iphi:
+        aliases:
+        - event.emu_L1CaloTower_iphi
+      L1CaloTower.iqual:
+        aliases:
+        - event.emu_L1CaloTower_iqual
+      L1CaloTower.iratio:
+        aliases:
+        - event.emu_L1CaloTower_iratio
+      L1CaloTower.nTower:
+        aliases:
+        - event.emu_L1CaloTower_nTower
+      L1CaloTower.phi:
+        aliases:
+        - event.emu_L1CaloTower_phi
+  l1CaloTowerTree/L1CaloTowerTree:
+    name: L1CaloTowerTree
+    optional: false
+    branches:
+      CaloTP.ecalTPCaliphi:
+        aliases:
+        - event.CaloTP_ecalTPCaliphi
+      CaloTP.ecalTPcompEt:
+        aliases:
+        - event.CaloTP_ecalTPcompEt
+      CaloTP.ecalTPet:
+        aliases:
+        - event.CaloTP_ecalTPet
+      CaloTP.ecalTPfineGrain:
+        aliases:
+        - event.CaloTP_ecalTPfineGrain
+      CaloTP.ecalTPieta:
+        aliases:
+        - event.CaloTP_ecalTPieta
+      CaloTP.ecalTPiphi:
+        aliases:
+        - event.CaloTP_ecalTPiphi
+      CaloTP.hcalTPCaliphi:
+        aliases:
+        - event.CaloTP_hcalTPCaliphi
+      CaloTP.hcalTPcompEt:
+        aliases:
+        - event.CaloTP_hcalTPcompEt
+      CaloTP.hcalTPet:
+        aliases:
+        - event.CaloTP_hcalTPet
+      CaloTP.hcalTPfineGrain:
+        aliases:
+        - event.CaloTP_hcalTPfineGrain
+      CaloTP.hcalTPieta:
+        aliases:
+        - event.CaloTP_hcalTPieta
+      CaloTP.hcalTPiphi:
+        aliases:
+        - event.CaloTP_hcalTPiphi
+      CaloTP.nECALTP:
+        aliases:
+        - event.CaloTP_nECALTP
+      CaloTP.nHCALTP:
+        aliases:
+        - event.CaloTP_nHCALTP
+      L1CaloTower.et:
+        aliases:
+        - event.L1CaloTower_et
+      L1CaloTower.eta:
+        aliases:
+        - event.L1CaloTower_eta
+      L1CaloTower.iem:
+        aliases:
+        - event.L1CaloTower_iem
+      L1CaloTower.iet:
+        aliases:
+        - event.L1CaloTower_iet
+      L1CaloTower.ieta:
+        aliases:
+        - event.L1CaloTower_ieta
+      L1CaloTower.ihad:
+        aliases:
+        - event.L1CaloTower_ihad
+      L1CaloTower.iphi:
+        aliases:
+        - event.L1CaloTower_iphi
+      L1CaloTower.iqual:
+        aliases:
+        - event.L1CaloTower_iqual
+      L1CaloTower.iratio:
+        aliases:
+        - event.L1CaloTower_iratio
+      L1CaloTower.nTower:
+        aliases:
+        - event.L1CaloTower_nTower
+      L1CaloTower.phi:
+        aliases:
+        - event.L1CaloTower_phi
+  l1ElectronRecoTree/ElectronRecoTree:
+    name: ElectronRecoTree
+    optional: true
+    branches:
+      Electron.charge:
+        aliases:
+        - event.Electron_charge
+      Electron.e:
+        aliases:
+        - event.Electron_e
+      Electron.e_ECAL:
+        aliases:
+        - event.Electron_e_ECAL
+      Electron.e_SC:
+        aliases:
+        - event.Electron_e_SC
+      Electron.et:
+        aliases:
+        - event.Electron_et
+      Electron.eta:
+        aliases:
+        - event.Electron_eta
+      Electron.eta_SC:
+        aliases:
+        - event.Electron_eta_SC
+      Electron.isLooseElectron:
+        aliases:
+        - event.Electron_isLooseElectron
+      Electron.isMediumElectron:
+        aliases:
+        - event.Electron_isMediumElectron
+      Electron.isTightElectron:
+        aliases:
+        - event.Electron_isTightElectron
+      Electron.isVetoElectron:
+        aliases:
+        - event.Electron_isVetoElectron
+      Electron.iso:
+        aliases:
+        - event.Electron_iso
+      Electron.nElectrons:
+        aliases:
+        - event.Electron_nElectrons
+      Electron.phi:
+        aliases:
+        - event.Electron_phi
+      Electron.phi_SC:
+        aliases:
+        - event.Electron_phi_SC
+      Electron.pt:
+        aliases:
+        - event.Electron_pt
+  l1EventTree/L1EventTree:
+    name: L1EventTree
+    optional: false
+    branches:
+      Event.bx:
+        aliases:
+        - event.bx
+      Event.event:
+        aliases:
+        - event.event
+      Event.hlt:
+        aliases:
+        - event.hlt
+      Event.lumi:
+        aliases:
+        - event.lumi
+      Event.nPV:
+        aliases:
+        - event.nPV
+      Event.nPV_True:
+        aliases:
+        - event.nPV_True
+      Event.orbit:
+        aliases:
+        - event.orbit
+      Event.puWeight:
+        aliases:
+        - event.puWeight
+      Event.run:
+        aliases:
+        - event.run
+      Event.time:
+        aliases:
+        - event.time
+  l1JetRecoTree/JetRecoTree:
+    name: JetRecoTree
+    optional: true
+    branches:
+      Jet.cMult:
+        aliases:
+        - event.Jet_cMult
+      Jet.caloCorrFactor:
+        aliases:
+        - event.Jet_caloCorrFactor
+      Jet.caloE:
+        aliases:
+        - event.Jet_caloE
+      Jet.caloEt:
+        aliases:
+        - event.Jet_caloEt
+      Jet.caloEtCorr:
+        aliases:
+        - event.Jet_caloEtCorr
+      Jet.caloEta:
+        aliases:
+        - event.Jet_caloEta
+      Jet.caloPhi:
+        aliases:
+        - event.Jet_caloPhi
+      Jet.cemef:
+        aliases:
+        - event.Jet_cemef
+      Jet.chMult:
+        aliases:
+        - event.Jet_chMult
+      Jet.chef:
+        aliases:
+        - event.Jet_chef
+      Jet.cmef:
+        aliases:
+        - event.Jet_cmef
+      Jet.corrFactor:
+        aliases:
+        - event.Jet_corrFactor
+      Jet.e:
+        aliases:
+        - event.Jet_e
+      Jet.eEMF:
+        aliases:
+        - event.Jet_eEMF
+      Jet.eEmEB:
+        aliases:
+        - event.Jet_eEmEB
+      Jet.eEmEE:
+        aliases:
+        - event.Jet_eEmEE
+      Jet.eEmHF:
+        aliases:
+        - event.Jet_eEmHF
+      Jet.eHadHB:
+        aliases:
+        - event.Jet_eHadHB
+      Jet.eHadHE:
+        aliases:
+        - event.Jet_eHadHE
+      Jet.eHadHF:
+        aliases:
+        - event.Jet_eHadHF
+      Jet.eHadHO:
+        aliases:
+        - event.Jet_eHadHO
+      Jet.eMaxEcalTow:
+        aliases:
+        - event.Jet_eMaxEcalTow
+      Jet.eMaxHcalTow:
+        aliases:
+        - event.Jet_eMaxHcalTow
+      Jet.eef:
+        aliases:
+        - event.Jet_eef
+      Jet.elMult:
+        aliases:
+        - event.Jet_elMult
+      Jet.et:
+        aliases:
+        - event.Jet_et
+      Jet.etCorr:
+        aliases:
+        - event.Jet_etCorr
+      Jet.eta:
+        aliases:
+        - event.Jet_eta
+      Jet.fHPD:
+        aliases:
+        - event.Jet_fHPD
+      Jet.fRBX:
+        aliases:
+        - event.Jet_fRBX
+      Jet.hfemMult:
+        aliases:
+        - event.Jet_hfemMult
+      Jet.hfemef:
+        aliases:
+        - event.Jet_hfemef
+      Jet.hfhMult:
+        aliases:
+        - event.Jet_hfhMult
+      Jet.hfhef:
+        aliases:
+        - event.Jet_hfhef
+      Jet.mef:
+        aliases:
+        - event.Jet_mef
+      Jet.muMult:
+        aliases:
+        - event.Jet_muMult
+      Jet.n60:
+        aliases:
+        - event.Jet_n60
+      Jet.n90:
+        aliases:
+        - event.Jet_n90
+      Jet.n90hits:
+        aliases:
+        - event.Jet_n90hits
+      Jet.nCaloJets:
+        aliases:
+        - event.Jet_nCaloJets
+      Jet.nJets:
+        aliases:
+        - event.Jet_nJets
+      Jet.nMult:
+        aliases:
+        - event.Jet_nMult
+      Jet.nemef:
+        aliases:
+        - event.Jet_nemef
+      Jet.nhMult:
+        aliases:
+        - event.Jet_nhMult
+      Jet.nhef:
+        aliases:
+        - event.Jet_nhef
+      Jet.pef:
+        aliases:
+        - event.Jet_pef
+      Jet.phMult:
+        aliases:
+        - event.Jet_phMult
+      Jet.phi:
+        aliases:
+        - event.Jet_phi
+      Jet.towerArea:
+        aliases:
+        - event.Jet_towerArea
+      Jet.towerSize:
+        aliases:
+        - event.Jet_towerSize
+      Sums.Ht:
+        aliases:
+        - event.Sums_Ht
+      Sums.caloHt:
+        aliases:
+        - event.Sums_caloHt
+      Sums.caloMet:
+        aliases:
+        - event.Sums_caloMet
+      Sums.caloMetBE:
+        aliases:
+        - event.Sums_caloMetBE
+      Sums.caloMetPhi:
+        aliases:
+        - event.Sums_caloMetPhi
+      Sums.caloMetPhiBE:
+        aliases:
+        - event.Sums_caloMetPhiBE
+      Sums.caloSumEt:
+        aliases:
+        - event.Sums_caloSumEt
+      Sums.caloSumEtBE:
+        aliases:
+        - event.Sums_caloSumEtBE
+      Sums.ecalFlag:
+        aliases:
+        - event.Sums_ecalFlag
+      Sums.hcalFlag:
+        aliases:
+        - event.Sums_hcalFlag
+      Sums.mHt:
+        aliases:
+        - event.Sums_mHt
+      Sums.mHtPhi:
+        aliases:
+        - event.Sums_mHtPhi
+      Sums.met:
+        aliases:
+        - event.Sums_met
+      Sums.metPhi:
+        aliases:
+        - event.Sums_metPhi
+      Sums.metPx:
+        aliases:
+        - event.Sums_metPx
+      Sums.metPy:
+        aliases:
+        - event.Sums_metPy
+      Sums.pfMetNoMu:
+        aliases:
+        - event.Sums_pfMetNoMu
+      Sums.pfMetNoMuPhi:
+        aliases:
+        - event.Sums_pfMetNoMuPhi
+      Sums.pfMetNoMuPx:
+        aliases:
+        - event.Sums_pfMetNoMuPx
+      Sums.pfMetNoMuPy:
+        aliases:
+        - event.Sums_pfMetNoMuPy
+      Sums.sumEt:
+        aliases:
+        - event.Sums_sumEt
+  l1MetFilterRecoTree/MetFilterRecoTree:
+    name: MetFilterRecoTree
+    optional: true
+    branches:
+      MetFilters.badChCandFilter:
+        aliases:
+        - event.MetFilters_badChCandFilter
+      MetFilters.badPFMuonFilter:
+        aliases:
+        - event.MetFilters_badPFMuonFilter
+      MetFilters.chHadTrackResFilter:
+        aliases:
+        - event.MetFilters_chHadTrackResFilter
+      MetFilters.cscTightHalo2015Filter:
+        aliases:
+        - event.MetFilters_cscTightHalo2015Filter
+      MetFilters.ecalDeadCellTPFilter:
+        aliases:
+        - event.MetFilters_ecalDeadCellTPFilter
+      MetFilters.eeBadScFilter:
+        aliases:
+        - event.MetFilters_eeBadScFilter
+      MetFilters.globalSuperTightHalo2016Filter:
+        aliases:
+        - event.MetFilters_globalSuperTightHalo2016Filter
+      MetFilters.goodVerticesFilter:
+        aliases:
+        - event.MetFilters_goodVerticesFilter
+      MetFilters.hbheNoiseFilter:
+        aliases:
+        - event.MetFilters_hbheNoiseFilter
+      MetFilters.hbheNoiseIsoFilter:
+        aliases:
+        - event.MetFilters_hbheNoiseIsoFilter
+      MetFilters.muonBadTrackFilter:
+        aliases:
+        - event.MetFilters_muonBadTrackFilter
+  l1RecoTree/RecoTree:
+    name: RecoTree
+    optional: true
+    branches:
+      Vertex.NDoF:
+        aliases:
+        - event.Vertex_NDoF
+      Vertex.Rho:
+        aliases:
+        - event.Vertex_Rho
+      Vertex.Z:
+        aliases:
+        - event.Vertex_Z
+      Vertex.nVtx:
+        aliases:
+        - event.Vertex_nVtx
+  l1TauRecoTree/TauRecoTree:
+    name: TauRecoTree
+    optional: true
+    branches:
+      Tau.DMFindingNewDMs:
+        aliases:
+        - event.Tau_DMFindingNewDMs
+      Tau.DMFindingOldDMs:
+        aliases:
+        - event.Tau_DMFindingOldDMs
+      Tau.LooseAntiElectronFlag:
+        aliases:
+        - event.Tau_LooseAntiElectronFlag
+      Tau.LooseAntiMuonFlag:
+        aliases:
+        - event.Tau_LooseAntiMuonFlag
+      Tau.LooseIsoFlag:
+        aliases:
+        - event.Tau_LooseIsoFlag
+      Tau.RawIso:
+        aliases:
+        - event.Tau_RawIso
+      Tau.TightAntiElectronFlag:
+        aliases:
+        - event.Tau_TightAntiElectronFlag
+      Tau.TightAntiMuonFlag:
+        aliases:
+        - event.Tau_TightAntiMuonFlag
+      Tau.TightIsoFlag:
+        aliases:
+        - event.Tau_TightIsoFlag
+      Tau.VLooseAntiElectronFlag:
+        aliases:
+        - event.Tau_VLooseAntiElectronFlag
+      Tau.charge:
+        aliases:
+        - event.Tau_charge
+      Tau.e:
+        aliases:
+        - event.Tau_e
+      Tau.et:
+        aliases:
+        - event.Tau_et
+      Tau.eta:
+        aliases:
+        - event.Tau_eta
+      Tau.nTaus:
+        aliases:
+        - event.Tau_nTaus
+      Tau.phi:
+        aliases:
+        - event.Tau_phi
+      Tau.pt:
+        aliases:
+        - event.Tau_pt
+  l1UpgradeEmuTree/L1UpgradeTree:
+    name: L1UpgradeTree
+    optional: false
+    branches:
+      L1Upgrade.egBx:
+        aliases:
+        - event.emu_L1Upgrade_egBx
+      L1Upgrade.egEt:
+        aliases:
+        - event.emu_L1Upgrade_egEt
+      L1Upgrade.egEta:
+        aliases:
+        - event.emu_L1Upgrade_egEta
+      L1Upgrade.egFootprintEt:
+        aliases:
+        - event.emu_L1Upgrade_egFootprintEt
+      L1Upgrade.egHwQual:
+        aliases:
+        - event.emu_L1Upgrade_egHwQual
+      L1Upgrade.egIEt:
+        aliases:
+        - event.emu_L1Upgrade_egIEt
+      L1Upgrade.egIEta:
+        aliases:
+        - event.emu_L1Upgrade_egIEta
+      L1Upgrade.egIPhi:
+        aliases:
+        - event.emu_L1Upgrade_egIPhi
+      L1Upgrade.egIso:
+        aliases:
+        - event.emu_L1Upgrade_egIso
+      L1Upgrade.egIsoEt:
+        aliases:
+        - event.emu_L1Upgrade_egIsoEt
+      L1Upgrade.egNTT:
+        aliases:
+        - event.emu_L1Upgrade_egNTT
+      L1Upgrade.egPhi:
+        aliases:
+        - event.emu_L1Upgrade_egPhi
+      L1Upgrade.egRawEt:
+        aliases:
+        - event.emu_L1Upgrade_egRawEt
+      L1Upgrade.egShape:
+        aliases:
+        - event.emu_L1Upgrade_egShape
+      L1Upgrade.egTowerHoE:
+        aliases:
+        - event.emu_L1Upgrade_egTowerHoE
+      L1Upgrade.egTowerIEta:
+        aliases:
+        - event.emu_L1Upgrade_egTowerIEta
+      L1Upgrade.egTowerIPhi:
+        aliases:
+        - event.emu_L1Upgrade_egTowerIPhi
+      L1Upgrade.jetBx:
+        aliases:
+        - event.emu_L1Upgrade_jetBx
+      L1Upgrade.jetEt:
+        aliases:
+        - event.emu_L1Upgrade_jetEt
+      L1Upgrade.jetEta:
+        aliases:
+        - event.emu_L1Upgrade_jetEta
+      L1Upgrade.jetIEt:
+        aliases:
+        - event.emu_L1Upgrade_jetIEt
+      L1Upgrade.jetIEta:
+        aliases:
+        - event.emu_L1Upgrade_jetIEta
+      L1Upgrade.jetIPhi:
+        aliases:
+        - event.emu_L1Upgrade_jetIPhi
+      L1Upgrade.jetPUDonutEt0:
+        aliases:
+        - event.emu_L1Upgrade_jetPUDonutEt0
+      L1Upgrade.jetPUDonutEt1:
+        aliases:
+        - event.emu_L1Upgrade_jetPUDonutEt1
+      L1Upgrade.jetPUDonutEt2:
+        aliases:
+        - event.emu_L1Upgrade_jetPUDonutEt2
+      L1Upgrade.jetPUDonutEt3:
+        aliases:
+        - event.emu_L1Upgrade_jetPUDonutEt3
+      L1Upgrade.jetPUEt:
+        aliases:
+        - event.emu_L1Upgrade_jetPUEt
+      L1Upgrade.jetPhi:
+        aliases:
+        - event.emu_L1Upgrade_jetPhi
+      L1Upgrade.jetRawEt:
+        aliases:
+        - event.emu_L1Upgrade_jetRawEt
+      L1Upgrade.jetSeedEt:
+        aliases:
+        - event.emu_L1Upgrade_jetSeedEt
+      L1Upgrade.jetTowerIEta:
+        aliases:
+        - event.emu_L1Upgrade_jetTowerIEta
+      L1Upgrade.jetTowerIPhi:
+        aliases:
+        - event.emu_L1Upgrade_jetTowerIPhi
+      L1Upgrade.muonBx:
+        aliases:
+        - event.emu_L1Upgrade_muonBx
+      L1Upgrade.muonChg:
+        aliases:
+        - event.emu_L1Upgrade_muonChg
+      L1Upgrade.muonEt:
+        aliases:
+        - event.emu_L1Upgrade_muonEt
+      L1Upgrade.muonEta:
+        aliases:
+        - event.emu_L1Upgrade_muonEta
+      L1Upgrade.muonEtaAtVtx:
+        aliases:
+        - event.emu_L1Upgrade_muonEtaAtVtx
+      L1Upgrade.muonIDEta:
+        aliases:
+        - event.emu_L1Upgrade_muonIDEta
+      L1Upgrade.muonIDPhi:
+        aliases:
+        - event.emu_L1Upgrade_muonIDPhi
+      L1Upgrade.muonIEt:
+        aliases:
+        - event.emu_L1Upgrade_muonIEt
+      L1Upgrade.muonIEta:
+        aliases:
+        - event.emu_L1Upgrade_muonIEta
+      L1Upgrade.muonIEtaAtVtx:
+        aliases:
+        - event.emu_L1Upgrade_muonIEtaAtVtx
+      L1Upgrade.muonIPhi:
+        aliases:
+        - event.emu_L1Upgrade_muonIPhi
+      L1Upgrade.muonIPhiAtVtx:
+        aliases:
+        - event.emu_L1Upgrade_muonIPhiAtVtx
+      L1Upgrade.muonIso:
+        aliases:
+        - event.emu_L1Upgrade_muonIso
+      L1Upgrade.muonPhi:
+        aliases:
+        - event.emu_L1Upgrade_muonPhi
+      L1Upgrade.muonPhiAtVtx:
+        aliases:
+        - event.emu_L1Upgrade_muonPhiAtVtx
+      L1Upgrade.muonQual:
+        aliases:
+        - event.emu_L1Upgrade_muonQual
+      L1Upgrade.muonTfMuonIdx:
+        aliases:
+        - event.emu_L1Upgrade_muonTfMuonIdx
+      L1Upgrade.nEGs:
+        aliases:
+        - event.emu_L1Upgrade_nEGs
+      L1Upgrade.nJets:
+        aliases:
+        - event.emu_L1Upgrade_nJets
+      L1Upgrade.nMuons:
+        aliases:
+        - event.emu_L1Upgrade_nMuons
+      L1Upgrade.nSums:
+        aliases:
+        - event.emu_L1Upgrade_nSums
+      L1Upgrade.nTaus:
+        aliases:
+        - event.emu_L1Upgrade_nTaus
+      L1Upgrade.sumBx:
+        aliases:
+        - event.emu_L1Upgrade_sumBx
+      L1Upgrade.sumEt:
+        aliases:
+        - event.emu_L1Upgrade_sumEt
+      L1Upgrade.sumIEt:
+        aliases:
+        - event.emu_L1Upgrade_sumIEt
+      L1Upgrade.sumIPhi:
+        aliases:
+        - event.emu_L1Upgrade_sumIPhi
+      L1Upgrade.sumPhi:
+        aliases:
+        - event.emu_L1Upgrade_sumPhi
+      L1Upgrade.sumType:
+        aliases:
+        - event.emu_L1Upgrade_sumType
+      L1Upgrade.tauBx:
+        aliases:
+        - event.emu_L1Upgrade_tauBx
+      L1Upgrade.tauEt:
+        aliases:
+        - event.emu_L1Upgrade_tauEt
+      L1Upgrade.tauEta:
+        aliases:
+        - event.emu_L1Upgrade_tauEta
+      L1Upgrade.tauHasEM:
+        aliases:
+        - event.emu_L1Upgrade_tauHasEM
+      L1Upgrade.tauHwQual:
+        aliases:
+        - event.emu_L1Upgrade_tauHwQual
+      L1Upgrade.tauIEt:
+        aliases:
+        - event.emu_L1Upgrade_tauIEt
+      L1Upgrade.tauIEta:
+        aliases:
+        - event.emu_L1Upgrade_tauIEta
+      L1Upgrade.tauIPhi:
+        aliases:
+        - event.emu_L1Upgrade_tauIPhi
+      L1Upgrade.tauIsMerged:
+        aliases:
+        - event.emu_L1Upgrade_tauIsMerged
+      L1Upgrade.tauIso:
+        aliases:
+        - event.emu_L1Upgrade_tauIso
+      L1Upgrade.tauIsoEt:
+        aliases:
+        - event.emu_L1Upgrade_tauIsoEt
+      L1Upgrade.tauNTT:
+        aliases:
+        - event.emu_L1Upgrade_tauNTT
+      L1Upgrade.tauPhi:
+        aliases:
+        - event.emu_L1Upgrade_tauPhi
+      L1Upgrade.tauRawEt:
+        aliases:
+        - event.emu_L1Upgrade_tauRawEt
+      L1Upgrade.tauTowerIEta:
+        aliases:
+        - event.emu_L1Upgrade_tauTowerIEta
+      L1Upgrade.tauTowerIPhi:
+        aliases:
+        - event.emu_L1Upgrade_tauTowerIPhi
+  l1UpgradeTree/L1UpgradeTree:
+    name: L1UpgradeTree
+    optional: false
+    branches:
+      L1Upgrade.egBx:
+        aliases:
+        - event.L1Upgrade_egBx
+      L1Upgrade.egEt:
+        aliases:
+        - event.L1Upgrade_egEt
+      L1Upgrade.egEta:
+        aliases:
+        - event.L1Upgrade_egEta
+      L1Upgrade.egFootprintEt:
+        aliases:
+        - event.L1Upgrade_egFootprintEt
+      L1Upgrade.egHwQual:
+        aliases:
+        - event.L1Upgrade_egHwQual
+      L1Upgrade.egIEt:
+        aliases:
+        - event.L1Upgrade_egIEt
+      L1Upgrade.egIEta:
+        aliases:
+        - event.L1Upgrade_egIEta
+      L1Upgrade.egIPhi:
+        aliases:
+        - event.L1Upgrade_egIPhi
+      L1Upgrade.egIso:
+        aliases:
+        - event.L1Upgrade_egIso
+      L1Upgrade.egIsoEt:
+        aliases:
+        - event.L1Upgrade_egIsoEt
+      L1Upgrade.egNTT:
+        aliases:
+        - event.L1Upgrade_egNTT
+      L1Upgrade.egPhi:
+        aliases:
+        - event.L1Upgrade_egPhi
+      L1Upgrade.egRawEt:
+        aliases:
+        - event.L1Upgrade_egRawEt
+      L1Upgrade.egShape:
+        aliases:
+        - event.L1Upgrade_egShape
+      L1Upgrade.egTowerHoE:
+        aliases:
+        - event.L1Upgrade_egTowerHoE
+      L1Upgrade.egTowerIEta:
+        aliases:
+        - event.L1Upgrade_egTowerIEta
+      L1Upgrade.egTowerIPhi:
+        aliases:
+        - event.L1Upgrade_egTowerIPhi
+      L1Upgrade.jetBx:
+        aliases:
+        - event.L1Upgrade_jetBx
+      L1Upgrade.jetEt:
+        aliases:
+        - event.L1Upgrade_jetEt
+      L1Upgrade.jetEta:
+        aliases:
+        - event.L1Upgrade_jetEta
+      L1Upgrade.jetIEt:
+        aliases:
+        - event.L1Upgrade_jetIEt
+      L1Upgrade.jetIEta:
+        aliases:
+        - event.L1Upgrade_jetIEta
+      L1Upgrade.jetIPhi:
+        aliases:
+        - event.L1Upgrade_jetIPhi
+      L1Upgrade.jetPUDonutEt0:
+        aliases:
+        - event.L1Upgrade_jetPUDonutEt0
+      L1Upgrade.jetPUDonutEt1:
+        aliases:
+        - event.L1Upgrade_jetPUDonutEt1
+      L1Upgrade.jetPUDonutEt2:
+        aliases:
+        - event.L1Upgrade_jetPUDonutEt2
+      L1Upgrade.jetPUDonutEt3:
+        aliases:
+        - event.L1Upgrade_jetPUDonutEt3
+      L1Upgrade.jetPUEt:
+        aliases:
+        - event.L1Upgrade_jetPUEt
+      L1Upgrade.jetPhi:
+        aliases:
+        - event.L1Upgrade_jetPhi
+      L1Upgrade.jetRawEt:
+        aliases:
+        - event.L1Upgrade_jetRawEt
+      L1Upgrade.jetSeedEt:
+        aliases:
+        - event.L1Upgrade_jetSeedEt
+      L1Upgrade.jetTowerIEta:
+        aliases:
+        - event.L1Upgrade_jetTowerIEta
+      L1Upgrade.jetTowerIPhi:
+        aliases:
+        - event.L1Upgrade_jetTowerIPhi
+      L1Upgrade.muonBx:
+        aliases:
+        - event.L1Upgrade_muonBx
+      L1Upgrade.muonChg:
+        aliases:
+        - event.L1Upgrade_muonChg
+      L1Upgrade.muonEt:
+        aliases:
+        - event.L1Upgrade_muonEt
+      L1Upgrade.muonEta:
+        aliases:
+        - event.L1Upgrade_muonEta
+      L1Upgrade.muonEtaAtVtx:
+        aliases:
+        - event.L1Upgrade_muonEtaAtVtx
+      L1Upgrade.muonIDEta:
+        aliases:
+        - event.L1Upgrade_muonIDEta
+      L1Upgrade.muonIDPhi:
+        aliases:
+        - event.L1Upgrade_muonIDPhi
+      L1Upgrade.muonIEt:
+        aliases:
+        - event.L1Upgrade_muonIEt
+      L1Upgrade.muonIEta:
+        aliases:
+        - event.L1Upgrade_muonIEta
+      L1Upgrade.muonIEtaAtVtx:
+        aliases:
+        - event.L1Upgrade_muonIEtaAtVtx
+      L1Upgrade.muonIPhi:
+        aliases:
+        - event.L1Upgrade_muonIPhi
+      L1Upgrade.muonIPhiAtVtx:
+        aliases:
+        - event.L1Upgrade_muonIPhiAtVtx
+      L1Upgrade.muonIso:
+        aliases:
+        - event.L1Upgrade_muonIso
+      L1Upgrade.muonPhi:
+        aliases:
+        - event.L1Upgrade_muonPhi
+      L1Upgrade.muonPhiAtVtx:
+        aliases:
+        - event.L1Upgrade_muonPhiAtVtx
+      L1Upgrade.muonQual:
+        aliases:
+        - event.L1Upgrade_muonQual
+      L1Upgrade.muonTfMuonIdx:
+        aliases:
+        - event.L1Upgrade_muonTfMuonIdx
+      L1Upgrade.nEGs:
+        aliases:
+        - event.L1Upgrade_nEGs
+      L1Upgrade.nJets:
+        aliases:
+        - event.L1Upgrade_nJets
+      L1Upgrade.nMuons:
+        aliases:
+        - event.L1Upgrade_nMuons
+      L1Upgrade.nSums:
+        aliases:
+        - event.L1Upgrade_nSums
+      L1Upgrade.nTaus:
+        aliases:
+        - event.L1Upgrade_nTaus
+      L1Upgrade.sumBx:
+        aliases:
+        - event.L1Upgrade_sumBx
+      L1Upgrade.sumEt:
+        aliases:
+        - event.L1Upgrade_sumEt
+      L1Upgrade.sumIEt:
+        aliases:
+        - event.L1Upgrade_sumIEt
+      L1Upgrade.sumIPhi:
+        aliases:
+        - event.L1Upgrade_sumIPhi
+      L1Upgrade.sumPhi:
+        aliases:
+        - event.L1Upgrade_sumPhi
+      L1Upgrade.sumType:
+        aliases:
+        - event.L1Upgrade_sumType
+      L1Upgrade.tauBx:
+        aliases:
+        - event.L1Upgrade_tauBx
+      L1Upgrade.tauEt:
+        aliases:
+        - event.L1Upgrade_tauEt
+      L1Upgrade.tauEta:
+        aliases:
+        - event.L1Upgrade_tauEta
+      L1Upgrade.tauHasEM:
+        aliases:
+        - event.L1Upgrade_tauHasEM
+      L1Upgrade.tauHwQual:
+        aliases:
+        - event.L1Upgrade_tauHwQual
+      L1Upgrade.tauIEt:
+        aliases:
+        - event.L1Upgrade_tauIEt
+      L1Upgrade.tauIEta:
+        aliases:
+        - event.L1Upgrade_tauIEta
+      L1Upgrade.tauIPhi:
+        aliases:
+        - event.L1Upgrade_tauIPhi
+      L1Upgrade.tauIsMerged:
+        aliases:
+        - event.L1Upgrade_tauIsMerged
+      L1Upgrade.tauIso:
+        aliases:
+        - event.L1Upgrade_tauIso
+      L1Upgrade.tauIsoEt:
+        aliases:
+        - event.L1Upgrade_tauIsoEt
+      L1Upgrade.tauNTT:
+        aliases:
+        - event.L1Upgrade_tauNTT
+      L1Upgrade.tauPhi:
+        aliases:
+        - event.L1Upgrade_tauPhi
+      L1Upgrade.tauRawEt:
+        aliases:
+        - event.L1Upgrade_tauRawEt
+      L1Upgrade.tauTowerIEta:
+        aliases:
+        - event.L1Upgrade_tauTowerIEta
+      L1Upgrade.tauTowerIPhi:
+        aliases:
+        - event.L1Upgrade_tauTowerIPhi
+  l1uGTTree/L1uGTTree:
+    name: L1uGTTree
+    optional: false
+    branches:
+      L1uGT.m_algoDecisionFinal:
+        aliases:
+        - event.L1uGT_m_algoDecisionFinal
+      L1uGT.m_algoDecisionInitial:
+        aliases:
+        - event.L1uGT_m_algoDecisionInitial
+      L1uGT.m_algoDecisionPreScaled:
+        aliases:
+        - event.L1uGT_m_algoDecisionPreScaled
+      L1uGT.m_bxInEvent:
+        aliases:
+        - event.m_bxInEvent
+      L1uGT.m_bxNr:
+        aliases:
+        - event.L1uGT_m_bxNr
+      L1uGT.m_finalOR:
+        aliases:
+        - event.L1uGT_m_finalOR
+      L1uGT.m_finalORPreVeto:
+        aliases:
+        - event.L1uGT_m_finalORPreVeto
+      L1uGT.m_finalORVeto:
+        aliases:
+        - event.L1uGT_m_finalORVeto
+      L1uGT.m_orbitNr:
+        aliases:
+        - event.L1uGT_m_orbitNr
+      L1uGT.m_preScColumn:
+        aliases:
+        - event.L1uGT_m_preScColumn

--- a/config/ntuple_content_RAWEMU.yaml
+++ b/config/ntuple_content_RAWEMU.yaml
@@ -1,0 +1,722 @@
+version: vvv0.5.1
+content:
+  l1CaloTowerEmuTree/L1CaloTowerTree:
+    name: L1CaloTowerTree
+    optional: false
+    branches:
+      CaloTP.ecalTPCaliphi:
+        aliases:
+        - event.emu_CaloTP_ecalTPCaliphi
+      CaloTP.ecalTPcompEt:
+        aliases:
+        - event.emu_CaloTP_ecalTPcompEt
+      CaloTP.ecalTPet:
+        aliases:
+        - event.emu_CaloTP_ecalTPet
+      CaloTP.ecalTPfineGrain:
+        aliases:
+        - event.emu_CaloTP_ecalTPfineGrain
+      CaloTP.ecalTPieta:
+        aliases:
+        - event.emu_CaloTP_ecalTPieta
+      CaloTP.ecalTPiphi:
+        aliases:
+        - event.emu_CaloTP_ecalTPiphi
+      CaloTP.hcalTPCaliphi:
+        aliases:
+        - event.emu_CaloTP_hcalTPCaliphi
+      CaloTP.hcalTPcompEt:
+        aliases:
+        - event.emu_CaloTP_hcalTPcompEt
+      CaloTP.hcalTPet:
+        aliases:
+        - event.emu_CaloTP_hcalTPet
+      CaloTP.hcalTPfineGrain:
+        aliases:
+        - event.emu_CaloTP_hcalTPfineGrain
+      CaloTP.hcalTPieta:
+        aliases:
+        - event.emu_CaloTP_hcalTPieta
+      CaloTP.hcalTPiphi:
+        aliases:
+        - event.emu_CaloTP_hcalTPiphi
+      CaloTP.nECALTP:
+        aliases:
+        - event.emu_CaloTP_nECALTP
+      CaloTP.nHCALTP:
+        aliases:
+        - event.emu_CaloTP_nHCALTP
+      L1CaloCluster.et:
+        aliases:
+        - event.emu_L1CaloCluster_et
+      L1CaloCluster.eta:
+        aliases:
+        - event.emu_L1CaloCluster_eta
+      L1CaloCluster.iet:
+        aliases:
+        - event.emu_L1CaloCluster_iet
+      L1CaloCluster.ieta:
+        aliases:
+        - event.emu_L1CaloCluster_ieta
+      L1CaloCluster.iphi:
+        aliases:
+        - event.emu_L1CaloCluster_iphi
+      L1CaloCluster.iqual:
+        aliases:
+        - event.emu_L1CaloCluster_iqual
+      L1CaloCluster.nCluster:
+        aliases:
+        - event.emu_L1CaloCluster_nCluster
+      L1CaloCluster.phi:
+        aliases:
+        - event.emu_L1CaloCluster_phi
+      L1CaloTower.et:
+        aliases:
+        - event.emu_L1CaloTower_et
+      L1CaloTower.eta:
+        aliases:
+        - event.emu_L1CaloTower_eta
+      L1CaloTower.iem:
+        aliases:
+        - event.emu_L1CaloTower_iem
+      L1CaloTower.iet:
+        aliases:
+        - event.emu_L1CaloTower_iet
+      L1CaloTower.ieta:
+        aliases:
+        - event.emu_L1CaloTower_ieta
+      L1CaloTower.ihad:
+        aliases:
+        - event.emu_L1CaloTower_ihad
+      L1CaloTower.iphi:
+        aliases:
+        - event.emu_L1CaloTower_iphi
+      L1CaloTower.iqual:
+        aliases:
+        - event.emu_L1CaloTower_iqual
+      L1CaloTower.iratio:
+        aliases:
+        - event.emu_L1CaloTower_iratio
+      L1CaloTower.nTower:
+        aliases:
+        - event.emu_L1CaloTower_nTower
+      L1CaloTower.phi:
+        aliases:
+        - event.emu_L1CaloTower_phi
+  l1CaloTowerTree/L1CaloTowerTree:
+    name: L1CaloTowerTree
+    optional: false
+    branches:
+      CaloTP.ecalTPCaliphi:
+        aliases:
+        - event.CaloTP_ecalTPCaliphi
+      CaloTP.ecalTPcompEt:
+        aliases:
+        - event.CaloTP_ecalTPcompEt
+      CaloTP.ecalTPet:
+        aliases:
+        - event.CaloTP_ecalTPet
+      CaloTP.ecalTPfineGrain:
+        aliases:
+        - event.CaloTP_ecalTPfineGrain
+      CaloTP.ecalTPieta:
+        aliases:
+        - event.CaloTP_ecalTPieta
+      CaloTP.ecalTPiphi:
+        aliases:
+        - event.CaloTP_ecalTPiphi
+      CaloTP.hcalTPCaliphi:
+        aliases:
+        - event.CaloTP_hcalTPCaliphi
+      CaloTP.hcalTPcompEt:
+        aliases:
+        - event.CaloTP_hcalTPcompEt
+      CaloTP.hcalTPet:
+        aliases:
+        - event.CaloTP_hcalTPet
+      CaloTP.hcalTPfineGrain:
+        aliases:
+        - event.CaloTP_hcalTPfineGrain
+      CaloTP.hcalTPieta:
+        aliases:
+        - event.CaloTP_hcalTPieta
+      CaloTP.hcalTPiphi:
+        aliases:
+        - event.CaloTP_hcalTPiphi
+      CaloTP.nECALTP:
+        aliases:
+        - event.CaloTP_nECALTP
+      CaloTP.nHCALTP:
+        aliases:
+        - event.CaloTP_nHCALTP
+      L1CaloTower.et:
+        aliases:
+        - event.L1CaloTower_et
+      L1CaloTower.eta:
+        aliases:
+        - event.L1CaloTower_eta
+      L1CaloTower.iem:
+        aliases:
+        - event.L1CaloTower_iem
+      L1CaloTower.iet:
+        aliases:
+        - event.L1CaloTower_iet
+      L1CaloTower.ieta:
+        aliases:
+        - event.L1CaloTower_ieta
+      L1CaloTower.ihad:
+        aliases:
+        - event.L1CaloTower_ihad
+      L1CaloTower.iphi:
+        aliases:
+        - event.L1CaloTower_iphi
+      L1CaloTower.iqual:
+        aliases:
+        - event.L1CaloTower_iqual
+      L1CaloTower.iratio:
+        aliases:
+        - event.L1CaloTower_iratio
+      L1CaloTower.nTower:
+        aliases:
+        - event.L1CaloTower_nTower
+      L1CaloTower.phi:
+        aliases:
+        - event.L1CaloTower_phi
+  l1EventTree/L1EventTree:
+    name: L1EventTree
+    optional: false
+    branches:
+      Event.bx:
+        aliases:
+        - event.bx
+      Event.event:
+        aliases:
+        - event.event
+      Event.hlt:
+        aliases:
+        - event.hlt
+      Event.lumi:
+        aliases:
+        - event.lumi
+      Event.nPV:
+        aliases:
+        - event.nPV
+      Event.nPV_True:
+        aliases:
+        - event.nPV_True
+      Event.orbit:
+        aliases:
+        - event.orbit
+      Event.puWeight:
+        aliases:
+        - event.puWeight
+      Event.run:
+        aliases:
+        - event.run
+      Event.time:
+        aliases:
+        - event.time
+  l1UpgradeEmuTree/L1UpgradeTree:
+    name: L1UpgradeTree
+    optional: false
+    branches:
+      L1Upgrade.egBx:
+        aliases:
+        - event.emu_L1Upgrade_egBx
+      L1Upgrade.egEt:
+        aliases:
+        - event.emu_L1Upgrade_egEt
+      L1Upgrade.egEta:
+        aliases:
+        - event.emu_L1Upgrade_egEta
+      L1Upgrade.egFootprintEt:
+        aliases:
+        - event.emu_L1Upgrade_egFootprintEt
+      L1Upgrade.egHwQual:
+        aliases:
+        - event.emu_L1Upgrade_egHwQual
+      L1Upgrade.egIEt:
+        aliases:
+        - event.emu_L1Upgrade_egIEt
+      L1Upgrade.egIEta:
+        aliases:
+        - event.emu_L1Upgrade_egIEta
+      L1Upgrade.egIPhi:
+        aliases:
+        - event.emu_L1Upgrade_egIPhi
+      L1Upgrade.egIso:
+        aliases:
+        - event.emu_L1Upgrade_egIso
+      L1Upgrade.egIsoEt:
+        aliases:
+        - event.emu_L1Upgrade_egIsoEt
+      L1Upgrade.egNTT:
+        aliases:
+        - event.emu_L1Upgrade_egNTT
+      L1Upgrade.egPhi:
+        aliases:
+        - event.emu_L1Upgrade_egPhi
+      L1Upgrade.egRawEt:
+        aliases:
+        - event.emu_L1Upgrade_egRawEt
+      L1Upgrade.egShape:
+        aliases:
+        - event.emu_L1Upgrade_egShape
+      L1Upgrade.egTowerHoE:
+        aliases:
+        - event.emu_L1Upgrade_egTowerHoE
+      L1Upgrade.egTowerIEta:
+        aliases:
+        - event.emu_L1Upgrade_egTowerIEta
+      L1Upgrade.egTowerIPhi:
+        aliases:
+        - event.emu_L1Upgrade_egTowerIPhi
+      L1Upgrade.jetBx:
+        aliases:
+        - event.emu_L1Upgrade_jetBx
+      L1Upgrade.jetEt:
+        aliases:
+        - event.emu_L1Upgrade_jetEt
+      L1Upgrade.jetEta:
+        aliases:
+        - event.emu_L1Upgrade_jetEta
+      L1Upgrade.jetIEt:
+        aliases:
+        - event.emu_L1Upgrade_jetIEt
+      L1Upgrade.jetIEta:
+        aliases:
+        - event.emu_L1Upgrade_jetIEta
+      L1Upgrade.jetIPhi:
+        aliases:
+        - event.emu_L1Upgrade_jetIPhi
+      L1Upgrade.jetPUDonutEt0:
+        aliases:
+        - event.emu_L1Upgrade_jetPUDonutEt0
+      L1Upgrade.jetPUDonutEt1:
+        aliases:
+        - event.emu_L1Upgrade_jetPUDonutEt1
+      L1Upgrade.jetPUDonutEt2:
+        aliases:
+        - event.emu_L1Upgrade_jetPUDonutEt2
+      L1Upgrade.jetPUDonutEt3:
+        aliases:
+        - event.emu_L1Upgrade_jetPUDonutEt3
+      L1Upgrade.jetPUEt:
+        aliases:
+        - event.emu_L1Upgrade_jetPUEt
+      L1Upgrade.jetPhi:
+        aliases:
+        - event.emu_L1Upgrade_jetPhi
+      L1Upgrade.jetRawEt:
+        aliases:
+        - event.emu_L1Upgrade_jetRawEt
+      L1Upgrade.jetSeedEt:
+        aliases:
+        - event.emu_L1Upgrade_jetSeedEt
+      L1Upgrade.jetTowerIEta:
+        aliases:
+        - event.emu_L1Upgrade_jetTowerIEta
+      L1Upgrade.jetTowerIPhi:
+        aliases:
+        - event.emu_L1Upgrade_jetTowerIPhi
+      L1Upgrade.muonBx:
+        aliases:
+        - event.emu_L1Upgrade_muonBx
+      L1Upgrade.muonChg:
+        aliases:
+        - event.emu_L1Upgrade_muonChg
+      L1Upgrade.muonEt:
+        aliases:
+        - event.emu_L1Upgrade_muonEt
+      L1Upgrade.muonEta:
+        aliases:
+        - event.emu_L1Upgrade_muonEta
+      L1Upgrade.muonEtaAtVtx:
+        aliases:
+        - event.emu_L1Upgrade_muonEtaAtVtx
+      L1Upgrade.muonIDEta:
+        aliases:
+        - event.emu_L1Upgrade_muonIDEta
+      L1Upgrade.muonIDPhi:
+        aliases:
+        - event.emu_L1Upgrade_muonIDPhi
+      L1Upgrade.muonIEt:
+        aliases:
+        - event.emu_L1Upgrade_muonIEt
+      L1Upgrade.muonIEta:
+        aliases:
+        - event.emu_L1Upgrade_muonIEta
+      L1Upgrade.muonIEtaAtVtx:
+        aliases:
+        - event.emu_L1Upgrade_muonIEtaAtVtx
+      L1Upgrade.muonIPhi:
+        aliases:
+        - event.emu_L1Upgrade_muonIPhi
+      L1Upgrade.muonIPhiAtVtx:
+        aliases:
+        - event.emu_L1Upgrade_muonIPhiAtVtx
+      L1Upgrade.muonIso:
+        aliases:
+        - event.emu_L1Upgrade_muonIso
+      L1Upgrade.muonPhi:
+        aliases:
+        - event.emu_L1Upgrade_muonPhi
+      L1Upgrade.muonPhiAtVtx:
+        aliases:
+        - event.emu_L1Upgrade_muonPhiAtVtx
+      L1Upgrade.muonQual:
+        aliases:
+        - event.emu_L1Upgrade_muonQual
+      L1Upgrade.muonTfMuonIdx:
+        aliases:
+        - event.emu_L1Upgrade_muonTfMuonIdx
+      L1Upgrade.nEGs:
+        aliases:
+        - event.emu_L1Upgrade_nEGs
+      L1Upgrade.nJets:
+        aliases:
+        - event.emu_L1Upgrade_nJets
+      L1Upgrade.nMuons:
+        aliases:
+        - event.emu_L1Upgrade_nMuons
+      L1Upgrade.nSums:
+        aliases:
+        - event.emu_L1Upgrade_nSums
+      L1Upgrade.nTaus:
+        aliases:
+        - event.emu_L1Upgrade_nTaus
+      L1Upgrade.sumBx:
+        aliases:
+        - event.emu_L1Upgrade_sumBx
+      L1Upgrade.sumEt:
+        aliases:
+        - event.emu_L1Upgrade_sumEt
+      L1Upgrade.sumIEt:
+        aliases:
+        - event.emu_L1Upgrade_sumIEt
+      L1Upgrade.sumIPhi:
+        aliases:
+        - event.emu_L1Upgrade_sumIPhi
+      L1Upgrade.sumPhi:
+        aliases:
+        - event.emu_L1Upgrade_sumPhi
+      L1Upgrade.sumType:
+        aliases:
+        - event.emu_L1Upgrade_sumType
+      L1Upgrade.tauBx:
+        aliases:
+        - event.emu_L1Upgrade_tauBx
+      L1Upgrade.tauEt:
+        aliases:
+        - event.emu_L1Upgrade_tauEt
+      L1Upgrade.tauEta:
+        aliases:
+        - event.emu_L1Upgrade_tauEta
+      L1Upgrade.tauHasEM:
+        aliases:
+        - event.emu_L1Upgrade_tauHasEM
+      L1Upgrade.tauHwQual:
+        aliases:
+        - event.emu_L1Upgrade_tauHwQual
+      L1Upgrade.tauIEt:
+        aliases:
+        - event.emu_L1Upgrade_tauIEt
+      L1Upgrade.tauIEta:
+        aliases:
+        - event.emu_L1Upgrade_tauIEta
+      L1Upgrade.tauIPhi:
+        aliases:
+        - event.emu_L1Upgrade_tauIPhi
+      L1Upgrade.tauIsMerged:
+        aliases:
+        - event.emu_L1Upgrade_tauIsMerged
+      L1Upgrade.tauIso:
+        aliases:
+        - event.emu_L1Upgrade_tauIso
+      L1Upgrade.tauIsoEt:
+        aliases:
+        - event.emu_L1Upgrade_tauIsoEt
+      L1Upgrade.tauNTT:
+        aliases:
+        - event.emu_L1Upgrade_tauNTT
+      L1Upgrade.tauPhi:
+        aliases:
+        - event.emu_L1Upgrade_tauPhi
+      L1Upgrade.tauRawEt:
+        aliases:
+        - event.emu_L1Upgrade_tauRawEt
+      L1Upgrade.tauTowerIEta:
+        aliases:
+        - event.emu_L1Upgrade_tauTowerIEta
+      L1Upgrade.tauTowerIPhi:
+        aliases:
+        - event.emu_L1Upgrade_tauTowerIPhi
+  l1UpgradeTree/L1UpgradeTree:
+    name: L1UpgradeTree
+    optional: false
+    branches:
+      L1Upgrade.egBx:
+        aliases:
+        - event.L1Upgrade_egBx
+      L1Upgrade.egEt:
+        aliases:
+        - event.L1Upgrade_egEt
+      L1Upgrade.egEta:
+        aliases:
+        - event.L1Upgrade_egEta
+      L1Upgrade.egFootprintEt:
+        aliases:
+        - event.L1Upgrade_egFootprintEt
+      L1Upgrade.egHwQual:
+        aliases:
+        - event.L1Upgrade_egHwQual
+      L1Upgrade.egIEt:
+        aliases:
+        - event.L1Upgrade_egIEt
+      L1Upgrade.egIEta:
+        aliases:
+        - event.L1Upgrade_egIEta
+      L1Upgrade.egIPhi:
+        aliases:
+        - event.L1Upgrade_egIPhi
+      L1Upgrade.egIso:
+        aliases:
+        - event.L1Upgrade_egIso
+      L1Upgrade.egIsoEt:
+        aliases:
+        - event.L1Upgrade_egIsoEt
+      L1Upgrade.egNTT:
+        aliases:
+        - event.L1Upgrade_egNTT
+      L1Upgrade.egPhi:
+        aliases:
+        - event.L1Upgrade_egPhi
+      L1Upgrade.egRawEt:
+        aliases:
+        - event.L1Upgrade_egRawEt
+      L1Upgrade.egShape:
+        aliases:
+        - event.L1Upgrade_egShape
+      L1Upgrade.egTowerHoE:
+        aliases:
+        - event.L1Upgrade_egTowerHoE
+      L1Upgrade.egTowerIEta:
+        aliases:
+        - event.L1Upgrade_egTowerIEta
+      L1Upgrade.egTowerIPhi:
+        aliases:
+        - event.L1Upgrade_egTowerIPhi
+      L1Upgrade.jetBx:
+        aliases:
+        - event.L1Upgrade_jetBx
+      L1Upgrade.jetEt:
+        aliases:
+        - event.L1Upgrade_jetEt
+      L1Upgrade.jetEta:
+        aliases:
+        - event.L1Upgrade_jetEta
+      L1Upgrade.jetIEt:
+        aliases:
+        - event.L1Upgrade_jetIEt
+      L1Upgrade.jetIEta:
+        aliases:
+        - event.L1Upgrade_jetIEta
+      L1Upgrade.jetIPhi:
+        aliases:
+        - event.L1Upgrade_jetIPhi
+      L1Upgrade.jetPUDonutEt0:
+        aliases:
+        - event.L1Upgrade_jetPUDonutEt0
+      L1Upgrade.jetPUDonutEt1:
+        aliases:
+        - event.L1Upgrade_jetPUDonutEt1
+      L1Upgrade.jetPUDonutEt2:
+        aliases:
+        - event.L1Upgrade_jetPUDonutEt2
+      L1Upgrade.jetPUDonutEt3:
+        aliases:
+        - event.L1Upgrade_jetPUDonutEt3
+      L1Upgrade.jetPUEt:
+        aliases:
+        - event.L1Upgrade_jetPUEt
+      L1Upgrade.jetPhi:
+        aliases:
+        - event.L1Upgrade_jetPhi
+      L1Upgrade.jetRawEt:
+        aliases:
+        - event.L1Upgrade_jetRawEt
+      L1Upgrade.jetSeedEt:
+        aliases:
+        - event.L1Upgrade_jetSeedEt
+      L1Upgrade.jetTowerIEta:
+        aliases:
+        - event.L1Upgrade_jetTowerIEta
+      L1Upgrade.jetTowerIPhi:
+        aliases:
+        - event.L1Upgrade_jetTowerIPhi
+      L1Upgrade.muonBx:
+        aliases:
+        - event.L1Upgrade_muonBx
+      L1Upgrade.muonChg:
+        aliases:
+        - event.L1Upgrade_muonChg
+      L1Upgrade.muonEt:
+        aliases:
+        - event.L1Upgrade_muonEt
+      L1Upgrade.muonEta:
+        aliases:
+        - event.L1Upgrade_muonEta
+      L1Upgrade.muonEtaAtVtx:
+        aliases:
+        - event.L1Upgrade_muonEtaAtVtx
+      L1Upgrade.muonIDEta:
+        aliases:
+        - event.L1Upgrade_muonIDEta
+      L1Upgrade.muonIDPhi:
+        aliases:
+        - event.L1Upgrade_muonIDPhi
+      L1Upgrade.muonIEt:
+        aliases:
+        - event.L1Upgrade_muonIEt
+      L1Upgrade.muonIEta:
+        aliases:
+        - event.L1Upgrade_muonIEta
+      L1Upgrade.muonIEtaAtVtx:
+        aliases:
+        - event.L1Upgrade_muonIEtaAtVtx
+      L1Upgrade.muonIPhi:
+        aliases:
+        - event.L1Upgrade_muonIPhi
+      L1Upgrade.muonIPhiAtVtx:
+        aliases:
+        - event.L1Upgrade_muonIPhiAtVtx
+      L1Upgrade.muonIso:
+        aliases:
+        - event.L1Upgrade_muonIso
+      L1Upgrade.muonPhi:
+        aliases:
+        - event.L1Upgrade_muonPhi
+      L1Upgrade.muonPhiAtVtx:
+        aliases:
+        - event.L1Upgrade_muonPhiAtVtx
+      L1Upgrade.muonQual:
+        aliases:
+        - event.L1Upgrade_muonQual
+      L1Upgrade.muonTfMuonIdx:
+        aliases:
+        - event.L1Upgrade_muonTfMuonIdx
+      L1Upgrade.nEGs:
+        aliases:
+        - event.L1Upgrade_nEGs
+      L1Upgrade.nJets:
+        aliases:
+        - event.L1Upgrade_nJets
+      L1Upgrade.nMuons:
+        aliases:
+        - event.L1Upgrade_nMuons
+      L1Upgrade.nSums:
+        aliases:
+        - event.L1Upgrade_nSums
+      L1Upgrade.nTaus:
+        aliases:
+        - event.L1Upgrade_nTaus
+      L1Upgrade.sumBx:
+        aliases:
+        - event.L1Upgrade_sumBx
+      L1Upgrade.sumEt:
+        aliases:
+        - event.L1Upgrade_sumEt
+      L1Upgrade.sumIEt:
+        aliases:
+        - event.L1Upgrade_sumIEt
+      L1Upgrade.sumIPhi:
+        aliases:
+        - event.L1Upgrade_sumIPhi
+      L1Upgrade.sumPhi:
+        aliases:
+        - event.L1Upgrade_sumPhi
+      L1Upgrade.sumType:
+        aliases:
+        - event.L1Upgrade_sumType
+      L1Upgrade.tauBx:
+        aliases:
+        - event.L1Upgrade_tauBx
+      L1Upgrade.tauEt:
+        aliases:
+        - event.L1Upgrade_tauEt
+      L1Upgrade.tauEta:
+        aliases:
+        - event.L1Upgrade_tauEta
+      L1Upgrade.tauHasEM:
+        aliases:
+        - event.L1Upgrade_tauHasEM
+      L1Upgrade.tauHwQual:
+        aliases:
+        - event.L1Upgrade_tauHwQual
+      L1Upgrade.tauIEt:
+        aliases:
+        - event.L1Upgrade_tauIEt
+      L1Upgrade.tauIEta:
+        aliases:
+        - event.L1Upgrade_tauIEta
+      L1Upgrade.tauIPhi:
+        aliases:
+        - event.L1Upgrade_tauIPhi
+      L1Upgrade.tauIsMerged:
+        aliases:
+        - event.L1Upgrade_tauIsMerged
+      L1Upgrade.tauIso:
+        aliases:
+        - event.L1Upgrade_tauIso
+      L1Upgrade.tauIsoEt:
+        aliases:
+        - event.L1Upgrade_tauIsoEt
+      L1Upgrade.tauNTT:
+        aliases:
+        - event.L1Upgrade_tauNTT
+      L1Upgrade.tauPhi:
+        aliases:
+        - event.L1Upgrade_tauPhi
+      L1Upgrade.tauRawEt:
+        aliases:
+        - event.L1Upgrade_tauRawEt
+      L1Upgrade.tauTowerIEta:
+        aliases:
+        - event.L1Upgrade_tauTowerIEta
+      L1Upgrade.tauTowerIPhi:
+        aliases:
+        - event.L1Upgrade_tauTowerIPhi
+  l1uGTTree/L1uGTTree:
+    name: L1uGTTree
+    optional: false
+    branches:
+      L1uGT.m_algoDecisionFinal:
+        aliases:
+        - event.L1uGT_m_algoDecisionFinal
+      L1uGT.m_algoDecisionInitial:
+        aliases:
+        - event.L1uGT_m_algoDecisionInitial
+      L1uGT.m_algoDecisionPreScaled:
+        aliases:
+        - event.L1uGT_m_algoDecisionPreScaled
+      L1uGT.m_bxInEvent:
+        aliases:
+        - event.m_bxInEvent
+      L1uGT.m_bxNr:
+        aliases:
+        - event.L1uGT_m_bxNr
+      L1uGT.m_finalOR:
+        aliases:
+        - event.L1uGT_m_finalOR
+      L1uGT.m_finalORPreVeto:
+        aliases:
+        - event.L1uGT_m_finalORPreVeto
+      L1uGT.m_finalORVeto:
+        aliases:
+        - event.L1uGT_m_finalORVeto
+      L1uGT.m_orbitNr:
+        aliases:
+        - event.L1uGT_m_orbitNr
+      L1uGT.m_preScColumn:
+        aliases:
+        - event.L1uGT_m_preScColumn

--- a/config/rates.yaml
+++ b/config/rates.yaml
@@ -15,7 +15,8 @@ input:
     title: Zero Bias
   pileup_file: ""
   run_number:
-  lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt"
+  lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions18/13TeV/PromptReco/Cert_314472-325175_13TeV_PromptReco_Collisions18_JSON.txt"
+  ntuple_map_file: config/ntuple_content_RAWEMU.yaml
 
 analysis:
   load_trees:


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/cms-l1t-offline/cms-l1t-analysis/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->


#### What does this pull request implement/fix? Explain your changes.

- Sort reco jets by etCorr
- Check jet bx == 0,
- Fix batch sub by loading ntuple library,
- Add merge command printout at end of batch submission,
- Remove vertex debug printout
- Include most common use case ntuple maps, RAWEMU, and AODRAWEMU

#### Any other comments?
An example would be if you require another pull request to be merged before this one.
If you do, please reference it.