### PR TITLE
Sort reco jets by etCorr, check jet bx == 0, fix batch sub

### DIFF
--- a/cmsl1t/io/eventreader.py
+++ b/cmsl1t/io/eventreader.py
@@ -59,9 +59,6 @@ class EventReader(object):
         self.input_files = _get_input_files(input_files)
         self.nevents = nevents
         self._trees = {}
-        for alias in self._aliasMap:
-            if 'vertex' in alias.lower():
-                print(alias)
 
         self._load_trees()
 


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/cms-l1t-offline/cms-l1t-analysis/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->


#### What does this pull request implement/fix? Explain your changes.

- Sort reco jets by etCorr
- Check jet bx == 0,
- Fix batch sub by loading ntuple library,
- Add merge command printout at end of batch submission,
- Remove vertex debug printout
- Include most common use case ntuple maps, RAWEMU, and AODRAWEMU

#### Any other comments?
An example would be if you require another pull request to be merged before this one.
If you do, please reference it.