### PR TITLE
Global filters for events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,9 @@ endif
 run-benchmark:
 	@time python -m memory_profiler bin/run_benchmark
 
-test: test-code flake8
+test: lint test-code
 
-test-all: test-code-full flake8
+test-all: lint test-code-full
 
 test-code:
 	@pytest -v -m "not xrootdtest" test

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ pep8:
 flake8:
 	@python -m flake8 $(shell file -p bin/* |awk -F: '/python.*text/{print $$1}') cmsl1t test --max-line-length=120
 
+lint: flake8
+
 # benchmarks
 NTUPLE_CFG := "legacy/Config/ntuple_cfg.h"
 benchmark: clean-benchmark setup-benchmark run-benchmark

--- a/bin/cmsl1t
+++ b/bin/cmsl1t
@@ -3,15 +3,19 @@ from __future__ import print_function
 import ROOT
 import os
 from datetime import datetime
-from cmsl1t.utils.timers import timerfunc_log_to
-from cmsl1t.config import ConfigParser
-from cmsl1t.utils.module import load_L1TNTupleLibrary
-from cmsl1t.io.eventreader import EventReader
+from importlib import import_module
+
 import click
 import click_log
-from importlib import import_module
 import yaml
 import logging
+
+from cmsl1t.config import ConfigParser
+from cmsl1t.filters import create_event_mask
+from cmsl1t.io.eventreader import EventReader
+from cmsl1t.utils.module import load_L1TNTupleLibrary
+from cmsl1t.utils.timers import timerfunc_log_to
+
 logger = logging.getLogger(__name__)
 logging.getLogger("rootpy.tree.chain").setLevel(logging.WARNING)
 click_log.basic_config(logger)
@@ -26,7 +30,7 @@ section = '\n'.join(section)
 
 
 @timerfunc_log_to(logger.info)
-def process_tuples(config, nevents, analyzers, producers):
+def process_tuples(config, nevents, analyzers, producers, filters=None):
     # Open the data files
     logger.info(section.format("Loading data"))
 
@@ -70,6 +74,13 @@ def process_tuples(config, nevents, analyzers, producers):
                 logger.info("{} of <all>".format(entry))
         results = [p.produce(event) for p in producers]
         check(results, producers, 'produce')
+        # TODO: add filters
+        if filters:
+            mask = create_event_mask([f(event) for f in filters])
+            event = event.mask(mask)
+        if not event:
+            logger.debug('Event did not pass any of the filters')
+            continue
         results = [analyzer.process_event(entry, event)
                    for analyzer in analyzers]
         check(results, analyzers, 'process_event')
@@ -127,12 +138,15 @@ def run(config, nevents, reload_histograms):
     producers = [load_producer(producer, out_cfg) for producer in producers]
     _check_producer_outputs(producers)
 
+    filters = config.get('analysis', 'filters')
+    filters = [load_filter(f) for f in filters]
+
     if not reload_histograms:
         analysis_mode = config.try_get('analysis', 'mode', default='new')
         if analysis_mode == 'legacy':
             process_legacy(config, nevents, analyzers)
         else:
-            process_tuples(config, nevents, analyzers, producers)
+            process_tuples(config, nevents, analyzers, producers, filters)
     else:
         process_histogram_files(config, analyzers)
 
@@ -217,12 +231,27 @@ def load_producer(producer, output_cfg):
     logger.info("Try loading producer: {0} ({1})".format(name, module))
     module = import_module(module)
     logger.info("Successfully loaded producer: {0} ({1})".format(name, module))
+    # TODO: is this part needed for producers?
     cfg = dict(output_folder=output_cfg['folder'],
                plots_folder=output_cfg['plots_folder'],
                file_format=output_cfg.get('plot_format', 'pdf'),
                )
     cfg.update(producer)
     return module.Producer(**cfg)
+
+
+def load_filter(filter):
+    name = filter.pop('name')
+    module = filter.pop('module')
+    logger.info("Try loading filter: {0} ({1})".format(name, module))
+    tokens = module.split('.')
+    module_path = '.'.join(tokens[:-1])
+    module = import_module(module_path)
+    caller = getattr(module, tokens[-1])
+    logger.info("Successfully loaded filter: {0} ({1})".format(name, caller))
+    cfg = {}
+    cfg.update(filter)
+    return caller(**cfg)
 
 
 if __name__ == '__main__':

--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -126,14 +126,6 @@ class Analyzer(BaseAnalyzer):
                 lumiMuDict[(int(line[1]), int(line[2]))] = float(line[3])
         self._lumiMu = lumiMuDict
 
-        self._lumiFilter = None
-        self._lumiJson = self.params['lumiJson']
-        if self._lumiJson:
-            self._lumiFilter = LuminosityFilter(self._lumiJson)
-
-        self._lastRunAndLumi = (-1, -1)
-        self._processLumi = True
-
         # TODO: this needs changing, these should be analyser parameters
         # or even move out into separate calls of the same analyzer
         loaded_trees = self.params['load_trees']
@@ -355,10 +347,6 @@ class Analyzer(BaseAnalyzer):
             )
 
     def fill_histograms(self, entry, event):
-
-        if not self._passesLumiFilter(event.run, event.lumi):
-            return True
-
         offline, online = extractSums(
             event, self._doEmu, self._doReco, self._doGen)
 
@@ -370,7 +358,9 @@ class Analyzer(BaseAnalyzer):
         if self._doGen:
             genNVtx = event.Generator_nVtx
 
-        pileup = self._lumiMu[(event['run'], event['lumi'])]
+        # TODO: vectorize
+        # pileup = self._lumiMu[(event['run'], event['lumi'])]
+        pileup = 51
         # print pileup
         if pileup >= 60 or pileup < 50:
             return True
@@ -543,17 +533,6 @@ class Analyzer(BaseAnalyzer):
                         )
 
         return True
-
-    def _passesLumiFilter(self, run, lumi):
-        if self._lumiFilter is None:
-            return True
-        if (run, lumi) == self._lastRunAndLumi:
-            return self._processLumi
-
-        self._lastRunAndLumi = (run, lumi)
-        self._processLumi = self._lumiFilter(run, lumi)
-
-        return self._processLumi
 
     def make_plots(self):
         """

--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -7,7 +7,6 @@ import cmsl1t
 from .BaseAnalyzer import BaseAnalyzer
 from ..energySums import EnergySum, Met
 from ..filters import pfMetFilter
-from ..filters import LuminosityFilter
 from ..jet import match
 from ..plotting.efficiency import EfficiencyPlot
 from ..plotting.onlineVsOffline import OnlineVsOffline

--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -116,6 +116,7 @@ class ConfigParser(object):
         results += [self.validate_input_files()]
         results += [self.validate_analyzers()]
         results += [self.validate_producers()]
+        results += [self.validate_filters()]
         return all(results)
 
     def validate_sections(self):
@@ -163,6 +164,9 @@ class ConfigParser(object):
 
     def validate_producers(self):
         return self.__validate_module_imports(['analysis', 'producers'])
+
+    def validate_filters(self):
+        return self.__validate_module_imports(['analysis', 'filters'])
 
     def __validate_module_imports(self, config_keys):
         modules = deepcopy(self.config)
@@ -296,6 +300,10 @@ class ConfigParser(object):
         producers = [self.reduce_scope_for_producer(p) for p in producers]
         cfg['analysis']['producers'] = producers
 
+        filters = self.get('analysis', 'filters')
+        filters = [self.reduce_scope_for_filter(f) for f in filters]
+        cfg['analysis']['filters'] = filters
+
     def reduce_scope_for_analyzer(self, analyzer_name):
         analyzer_spec = self.get('analysis', 'analyzers')
         if isinstance(analyzer_spec, list):
@@ -319,6 +327,7 @@ class ConfigParser(object):
         analysis = deepcopy(self.config['analysis'])
         analysis.pop('analyzers')
         analysis.pop('producers')
+        analysis.pop('filters')
         global_settings.update(analysis)
 
         reduced_scope = {'name': analyzer_name}
@@ -336,6 +345,18 @@ class ConfigParser(object):
         producer_dict = producers_spec[producer]
         reduced_scope = {'name': producer}
         reduced_scope.update(producer_dict)
+
+        return reduced_scope
+
+    def reduce_scope_for_filter(self, filter):
+        filters_spec = self.get('analysis', 'filters')
+        if isinstance(filters_spec, list):
+            # Already reduced to a list
+            return filter
+
+        filter_dict = filters_spec[filter]
+        reduced_scope = {'name': filter}
+        reduced_scope.update(filter_dict)
 
         return reduced_scope
 

--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -348,14 +348,14 @@ class ConfigParser(object):
 
         return reduced_scope
 
-    def reduce_scope_for_filter(self, filter):
+    def reduce_scope_for_filter(self, current_filter):
         filters_spec = self.get('analysis', 'filters')
         if isinstance(filters_spec, list):
             # Already reduced to a list
-            return filter
+            return current_filter
 
-        filter_dict = filters_spec[filter]
-        reduced_scope = {'name': filter}
+        filter_dict = filters_spec[current_filter]
+        reduced_scope = {'name': current_filter}
         reduced_scope.update(filter_dict)
 
         return reduced_scope

--- a/cmsl1t/filters/__init__.py
+++ b/cmsl1t/filters/__init__.py
@@ -1,8 +1,52 @@
+import numpy as np
+
 from .muonfilter import muonfilter
 from .luminosity import LuminosityFilter
 from .pfMetFilter import pfMetFilter
 
+
+def __combine_with_AND_vectorized(filters, size):
+    # for vectorized filters, this dimension are events
+    for f in filters:
+        yield np.all(f)
+
+
+def __combine_with_OR_vectorized(filters, size):
+    # for vectorized filters, this dimension are events
+    for f in filters:
+        yield np.any(f)
+
+
+def combine_with_AND(filters):
+    size = np.size(filters[0])
+    if size > 1:
+        return list(__combine_with_AND_vectorized(filters, size))
+    result = True
+    for f in filters:
+        result = result & f
+    return result
+
+
+def combine_with_OR(filters):
+    size = np.size(filters[0])
+    if size > 1:
+        return list(__combine_with_OR_vectorized(filters, size))
+    result = False
+    for f in filters:
+        result = result | f
+    return result
+
+
+def create_event_mask(filters, method=combine_with_AND):
+    if not filters:
+        return []
+    return method(filters)
+
+
 __all__ = [
+    'combine_with_AND',
+    'combine_with_OR',
+    'create_event_mask',
     'muonfilter',
     'LuminosityFilter',
     'pfMetFilter',

--- a/cmsl1t/filters/jets_vectorized.py
+++ b/cmsl1t/filters/jets_vectorized.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+
+def _pfJetID(jet):
+    abs_eta = np.absolute(jet.eta)
+    isInnerJet = abs_eta <= 2.4
+    isCentralJet = abs_eta <= 2.7
+    isForwardCentralJet = (abs_eta > 2.7) & (abs_eta <= 3.0)
+    isForwardJet = abs_eta > 3.0
+    reject_if = \
+        (jet.muMult != 0) | \
+        (isCentralJet & (jet.nhef >= 0.9)) | \
+        (isCentralJet & (jet.nemef >= 0.9)) | \
+        (isCentralJet & ((jet.cMult + jet.nMult) <= 1)) | \
+        (isCentralJet & (jet.mef >= 0.8)) | \
+        (isInnerJet & (jet.chef <= 0)) | \
+        (isInnerJet & (jet.cMult <= 0)) | \
+        (isInnerJet & (jet.cemef >= 0.9)) | \
+        (isForwardCentralJet & (jet.nhef >= 0.98)) | \
+        (isForwardCentralJet & (jet.nemef <= 0.01)) | \
+        (isForwardCentralJet & (jet.nMult <= 2)) | \
+        (isForwardJet & (jet.nemef >= 0.9)) | \
+        (isForwardJet & (jet.nMult <= 10))
+
+    return jet.select(~reject_if)
+
+
+def pfJetFilter(jets):
+    return _pfJetID(jets)

--- a/cmsl1t/filters/luminosity.py
+++ b/cmsl1t/filters/luminosity.py
@@ -44,16 +44,8 @@ class LuminosityFilter(object):
         self.valid_lumi_sections = np.array(self.valid_lumi_sections)
 
     def __call__(self, event):
-        # TODO: wrong way around!
-        # need to create a new array from the event.run and event.lumi
-        # https://stackoverflow.com/questions/35091879/merge-2-arrays-vertical-to-tuple-numpy
-        # https://docs.scipy.org/doc/numpy/reference/generated/numpy.isin.html
         to_test = np.array(list(zip(event.run, event.lumi)))
-        # print(np.size(to_test), np.size(self.valid_lumi_sections))
-        # print(self.valid_lumi_sections)
-        # mask = np.isin(self.valid_lumi_sections, to_test, assume_unique=True)
         mask = filter_lumis(to_test, self.valid_lumi_sections)
-        print('Lumi filter', to_test, mask, '({})'.format(np.size(mask)))
         return mask
 
 

--- a/cmsl1t/filters/luminosity.py
+++ b/cmsl1t/filters/luminosity.py
@@ -1,6 +1,7 @@
 import json
 import six
 import six.moves.urllib as urllib
+import numba
 import numpy as np
 
 
@@ -40,7 +41,29 @@ class LuminosityFilter(object):
             lumis = _expand_lumi_ranges(lumi_ranges)
             tuples = map(lambda x: (int(run), x), lumis)
             self.valid_lumi_sections.extend(tuples)
-        self.valid_lumi_sections = set(self.valid_lumi_sections)
+        self.valid_lumi_sections = np.array(self.valid_lumi_sections)
 
-    def __call__(self, run, lumi):
-        return (run, lumi) in self.valid_lumi_sections
+    def __call__(self, event):
+        # TODO: wrong way around!
+        # need to create a new array from the event.run and event.lumi
+        # https://stackoverflow.com/questions/35091879/merge-2-arrays-vertical-to-tuple-numpy
+        # https://docs.scipy.org/doc/numpy/reference/generated/numpy.isin.html
+        to_test = np.array(list(zip(event.run, event.lumi)))
+        # print(np.size(to_test), np.size(self.valid_lumi_sections))
+        # print(self.valid_lumi_sections)
+        # mask = np.isin(self.valid_lumi_sections, to_test, assume_unique=True)
+        mask = filter_lumis(to_test, self.valid_lumi_sections)
+        print('Lumi filter', to_test, mask, '({})'.format(np.size(mask)))
+        return mask
+
+
+@numba.jit(nopython=True, parallel=True)
+def filter_lumis(ranges_to_test, valid_lumi_sections):
+    result = np.zeros(ranges_to_test.shape[0], dtype=np.uint8)
+    for i in range(valid_lumi_sections.shape[0]):
+        valid_section = valid_lumi_sections[i, :]
+        for j in range(ranges_to_test.shape[0]):
+            to_test = ranges_to_test[j, :]
+            if np.equal(to_test, valid_section).all():
+                result[j] = 1
+    return result

--- a/cmsl1t/jet.py
+++ b/cmsl1t/jet.py
@@ -1,16 +1,28 @@
 from __future__ import absolute_import
 import numpy as np
 
+import uproot_methods
+import awkward
+
 
 class Jet(object):
     __slots__ = ['et', 'eta', 'phi', 'etCorr']
 
     def __init__(self, *args):
-        self.et, self.eta, self.phi = args
-        self.etCorr = self.et
+        if len(args) == 3:
+            self.et, self.eta, self.phi = args
+            self.etCorr = self.et
+        else:
+            self.et, self.eta, self.phi, self.etCorr = args
 
     def __getitem__(self, name):
+        # TODO: check if "name" is a list
+        # if yes --> to selection
         return object.__getattribute__(self, name)
+
+    def select(self, mask):
+        selected_values = [self[v][mask] for v in self.__slots__]
+        return self.__class__(*selected_values)
 
 
 class L1Jet(Jet):

--- a/cmsl1t/jet.py
+++ b/cmsl1t/jet.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 import numpy as np
 
-import uproot_methods
-import awkward
-
 
 class Jet(object):
     __slots__ = ['et', 'eta', 'phi', 'etCorr']

--- a/cmsl1t/producers/jets_vectorized.py
+++ b/cmsl1t/producers/jets_vectorized.py
@@ -58,11 +58,12 @@ class Producer(BaseProducer):
 
     def produce(self, event):
         variables = [event[i] for i in self._inputs]
-        # self.awkward.ObjectArray.__init__(self, table, lambda row: TLorentzVector(row["fX"], row["fY"], row["fZ"], row["fE"]))
+        # self.awkward.ObjectArray.__init__(self, table, lambda row:
+        # TLorentzVector(row["fX"], row["fY"], row["fZ"], row["fE"]))
         jets = self._jetClass(*variables)
         # jets = [self._jetClass(*args) for args in zip(*variables)]
         if 'L1' in self._jetType:
-            jets = jets.select(jets.bx== 0)
+            jets = jets.select(jets.bx == 0)
         if self._jetFilter:
             jets = self._jetFilter(jets)
 

--- a/cmsl1t/producers/jets_vectorized.py
+++ b/cmsl1t/producers/jets_vectorized.py
@@ -1,0 +1,77 @@
+from importlib import import_module
+from ..jet import Jet, L1Jet, CaloJet, PFJet
+from .base import BaseProducer
+
+# TODO:
+# 1. good reco jets (use jet filters)
+# 2. matched L1 jets
+
+
+def _load_filter_module(filterPath):
+    print(filterPath)
+    if filterPath is None:
+        return None
+    tokens = filterPath.split('.')
+    module_path = '.'.join(tokens[:-1])
+    function = tokens[-1]
+    mod = import_module(module_path)
+    return getattr(mod, function)
+
+
+class Producer(BaseProducer):
+
+    def __init__(self, inputs, outputs, **kwargs):
+        self.__set_jetType(kwargs)
+        super(Producer, self).__init__(inputs, outputs, **kwargs)
+
+    def __set_jetType(self, params):
+        if params and 'jetType' in params:
+            self._jetType = params['jetType']
+        else:
+            self._jetType = 'Calo'
+        self._init_jet_class()
+
+        if params and 'filter' in params:
+            self._jetFilter = _load_filter_module(params['filter'])
+        else:
+            self._jetFilter = None
+
+    def _init_jet_class(self):
+        if self._jetType == 'PF':
+            self._expected_input_order = [
+                'et', 'eta', 'phi', 'etCorr', 'cemef', 'chef',
+                'cMult', 'mef', 'muMult', 'nemef', 'nhef', 'nMult',
+            ]
+            self._jetClass = PFJet
+        elif self._jetType == 'Calo':
+            self._expected_input_order = ['et', 'eta', 'phi', 'etCorr', ]
+            self._jetClass = CaloJet
+        elif self._jetType == 'Gen':
+            self._expected_input_order = ['pt', 'eta', 'phi']
+            self._jetClass = Jet
+        elif self._jetType == 'L1':
+            self._expected_input_order = ['et', 'eta', 'phi', 'bx']
+            self._jetClass = L1Jet
+        else:
+            self._expected_input_order = []
+            self._jetClass = None
+
+    def produce(self, event):
+        variables = [event[i] for i in self._inputs]
+        # self.awkward.ObjectArray.__init__(self, table, lambda row: TLorentzVector(row["fX"], row["fY"], row["fZ"], row["fE"]))
+        jets = self._jetClass(*variables)
+        # jets = [self._jetClass(*args) for args in zip(*variables)]
+        if 'L1' in self._jetType:
+            jets = jets.select(jets.bx== 0)
+        if self._jetFilter:
+            jets = self._jetFilter(jets)
+
+        # sort by ET, largest first
+        # sorted_jets = sorted(
+        #     jets,
+        #     key=lambda jet: jet.etCorr if jet.etCorr else jet.et,
+        #     reverse=True,
+        # )
+
+        setattr(event, self._outputs[0], jets)
+        return True

--- a/cmsl1t/producers/l1sums_vectorized.py
+++ b/cmsl1t/producers/l1sums_vectorized.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+import ROOT
+
+from cmsl1t.energySums import EnergySum, Mex, Mey, Met
+from .base import BaseProducer
+
+
+class Producer(BaseProducer):
+    sumTypes = ROOT.l1t.EtSum
+    energySumTypes = {
+        sumTypes.kTotalEt: {'name': 'Ett', 'type': EnergySum},
+        sumTypes.kTotalEtHF: {'name': 'EttHF', 'type': EnergySum},
+        sumTypes.kTotalHt: {'name': 'Htt', 'type': EnergySum},
+        sumTypes.kTotalHtHF: {'name': 'HttHF', 'type': Met},
+        sumTypes.kMissingEt: {'name': 'Met', 'type': Met},
+        sumTypes.kMissingEtHF: {'name': 'MetHF', 'type': Met},
+        sumTypes.kMissingHt: {'name': 'Mht', 'type': Met},
+        sumTypes.kTotalEtx: {'name': 'Mex', 'type': Mex},
+        sumTypes.kTotalEty: {'name': 'Mey', 'type': Mey},
+    }
+
+    def __init__(self, inputs, outputs, **kwargs):
+        self._expected_input_order = ['sumBx', 'type', 'et', 'phi']
+        super(Producer, self).__init__(inputs, outputs, **kwargs)
+
+    def produce(self, event):
+        variables = [event[i] for i in self._inputs]
+        energySumTypes = Producer.energySumTypes
+        prefix = self._outputs[0] + '_'
+
+        for sumBx, sumType, et, phi in zip(*variables):
+            bx_mask = sumBx == 0
+            for energyType in energySumTypes:
+                type_mask = sumType == energyType
+                if not any(type_mask):
+                    continue
+                name = energySumTypes[energyType]['name']
+                obj = energySumTypes[energyType]['type']
+                if obj == Met:
+                    setattr(event, prefix + name, obj(et[bx_mask], phi[bx_mask]))
+                else:
+                    setattr(event, prefix + name, obj(et[bx_mask]))
+
+        return True

--- a/config/all2017.yaml
+++ b/config/all2017.yaml
@@ -24,9 +24,11 @@ input:
     title: Single Muon
   pileup_file: ""
   run_number: 2017
-  lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt"
+  # lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt"
 
 analysis:
+  vectorized: True
+  batch_size: 1000
   load_trees:
     - event
     - upgrade
@@ -39,9 +41,13 @@ analysis:
   analyzers:
     jetMet_analyzer:
       module: cmsl1t.analyzers.jetMet_analyzer
+  filters:
+    lumi_filter:
+      module: cmsl1t.filters.LuminosityFilter
+      lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt"
   producers:
     l1Sums:
-      module: cmsl1t.producers.l1sums
+      module: cmsl1t.producers.l1sums_vectorized
       inputs:
         - L1Upgrade_sumBx
         - L1Upgrade_sumType
@@ -50,7 +56,7 @@ analysis:
       outputs:
         - l1Sums
     goodPFJets:
-      module: cmsl1t.producers.jets
+      module: cmsl1t.producers.jets_vectorized
       inputs:
         - Jet_et
         - Jet_eta
@@ -65,11 +71,11 @@ analysis:
         - Jet_nhef
         - Jet_nMult
       jetType: PF
-      filter: cmsl1t.filters.jets.pfJetFilter
+      filter: cmsl1t.filters.jets_vectorized.pfJetFilter
       outputs:
         - goodPFJets
     caloJets:
-      module: cmsl1t.producers.jets
+      module: cmsl1t.producers.jets_vectorized
       inputs:
         - Jet_caloEt
         - Jet_caloEta
@@ -80,7 +86,7 @@ analysis:
       outputs:
         - caloJets
     l1Jets:
-      module: cmsl1t.producers.jets
+      module: cmsl1t.producers.jets_vectorized
       inputs:
         - L1Upgrade_jetEt
         - L1Upgrade_jetEta

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ mock
 requests
 plumbum
 six
+numba

--- a/test/filters/test_luminosity.py
+++ b/test/filters/test_luminosity.py
@@ -1,9 +1,10 @@
+from collections import namedtuple
 from mock import patch
+import numpy as np
 import unittest
 from cmsl1t.filters.luminosity import _load_json, _expand_lumi_range, \
     _expand_lumi_ranges, LuminosityFilter
 import json
-import numpy as np
 
 EXAMPLE_JSON = {"273158": [[1, 12]], "273302": [[1, 4]]}
 
@@ -54,16 +55,14 @@ class TestLumiFilter(unittest.TestCase):
     def test_lumifilter(self):
         self.urlopen_mock.return_value = MockResponse(json.dumps(EXAMPLE_JSON))
         lumiFilter = LuminosityFilter('dummy')
-        self.assertTrue(lumiFilter(273158, 1))
-        self.assertTrue(lumiFilter(273158, 2))
-        self.assertTrue(lumiFilter(273158, 3))
-        self.assertTrue(lumiFilter(273158, 12))
-
-        self.assertTrue(lumiFilter(273302, 1))
-        self.assertTrue(lumiFilter(273302, 2))
-        self.assertTrue(lumiFilter(273302, 4))
-
-        self.assertFalse(lumiFilter(273302, 5))
+        Event = namedtuple('Event', ['run', 'lumi'])
+        runs = [273158, 273158, 273158, 273158, 273302, 273302, 273302, 273302]
+        lumis = [1, 2, 3, 12, 1, 2, 4, 5]
+        events = Event(runs, lumis)
+        expected = np.ones(len(runs), dtype=np.int8)
+        expected[-1] = 0
+        results = lumiFilter(events)
+        self.assertTrue((results == expected).all())
 
     def tearDown(self):
         self.patcher.stop()

--- a/test/filters/test_masks.py
+++ b/test/filters/test_masks.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from cmsl1t.filters import create_event_mask, combine_with_AND, combine_with_OR
+from cmsl1t.filters import combine_with_AND, combine_with_OR
 
 
 scalar_filters_all_passing = [True, True, True]

--- a/test/filters/test_masks.py
+++ b/test/filters/test_masks.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+
+from cmsl1t.filters import create_event_mask, combine_with_AND, combine_with_OR
+
+
+scalar_filters_all_passing = [True, True, True]
+scalar_filters_all_failing = [False, False, False]
+scalar_filters_all_but_one_failing = [False, True, False]
+vector_filters_all_passing = [
+    np.array([True, True, True]),
+    np.array([True, True, True]),
+    np.array([True, True, True]),
+    np.array([True, True, True]),
+]
+vector_filters_all_failing = [
+    np.array([False, False, False]),
+    np.array([False, False, False]),
+    np.array([False, False, False]),
+    np.array([False, False, False]),
+]
+
+vector_filters_all_but_one_failing = [
+    np.array([False, False, False]),
+    np.array([False, True, False]),
+    np.array([False, False, False]),
+    np.array([False, False, False]),
+]
+
+
+@pytest.mark.parametrize('filters, expected', [
+    (scalar_filters_all_passing, True),
+    (scalar_filters_all_failing, False),
+    (scalar_filters_all_but_one_failing, False),
+    (vector_filters_all_passing, [True, True, True, True]),
+    (vector_filters_all_failing, [False, False, False, False]),
+    (vector_filters_all_but_one_failing, [False, False, False, False]),
+]
+)
+def test_combine_with_AND(filters, expected):
+    result = combine_with_AND(filters)
+    assert np.size(result) == np.size(expected)
+    assert result == expected
+
+
+@pytest.mark.parametrize('filters, expected', [
+    (scalar_filters_all_passing, True),
+    (scalar_filters_all_failing, False),
+    (scalar_filters_all_but_one_failing, True),
+    (vector_filters_all_passing, [True, True, True, True]),
+    (vector_filters_all_failing, [False, False, False, False]),
+    (vector_filters_all_but_one_failing, [False, True, False, False]),
+]
+)
+def test_combine_with_OR(filters, expected):
+    result = combine_with_OR(filters)
+    assert np.size(result) == np.size(expected)
+    assert result == expected

--- a/test/io/test_uproot_event.py
+++ b/test/io/test_uproot_event.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+
+from cmsl1t.io.eventreader import UprootEvent
+
+
+@pytest.fixture
+def data_and_mapping():
+    data = dict(
+        exampleTree=dict(
+            a=np.array([1, 3, 5]),
+        )
+    )
+    m = {
+        'a': ('exampleTree', 'a'),
+    }
+    return data, m
+
+
+@pytest.fixture
+def event(data_and_mapping):
+    data, mapping = data_and_mapping
+    return UprootEvent(data, mapping, batch_size=3)
+
+
+@pytest.mark.parametrize(
+    "mask",
+    [
+        ([True, True, True]),
+        ([True, False, True]),
+        ([False, False, False]),
+    ])
+def test_mask(event, data_and_mapping, mask):
+    data, mapping = data_and_mapping
+
+    expected = data['exampleTree']['a'][mask].tolist()
+    result = event.mask(mask).a.tolist()
+
+    assert result == expected
+
+def test_invalid_mask(event, data_and_mapping):
+    data, mapping = data_and_mapping
+    with pytest.raises(ValueError):
+        event.mask(True)
+
+    with pytest.raises(ValueError):
+        event.mask([True])

--- a/test/io/test_uproot_event.py
+++ b/test/io/test_uproot_event.py
@@ -38,6 +38,7 @@ def test_mask(event, data_and_mapping, mask):
 
     assert result == expected
 
+
 def test_invalid_mask(event, data_and_mapping):
     data, mapping = data_and_mapping
     with pytest.raises(ValueError):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -46,6 +46,7 @@ analysis:
         - caloTowers
       outputs:
         - l1MetNot28HF
+  filters: []
   progress_bar:
     report_every: 1000
   # or to switch it off

--- a/test/test_jet_vectorized.py
+++ b/test/test_jet_vectorized.py
@@ -1,0 +1,43 @@
+import pytest
+
+import awkward
+import numpy as np
+
+from cmsl1t.jet import Jet
+
+
+@pytest.fixture
+def jetArray():
+    ets = awkward.fromiter([
+        np.random.poisson(30, 5),
+        np.random.poisson(30, 2),
+        np.random.poisson(30, 3),
+    ]
+    )
+    etas = awkward.fromiter(
+        [
+            np.random.normal(0, size=5) * 2.0,
+            np.random.normal(0, size=2) * 2.0,
+            np.random.normal(0, size=3) * 2.0,
+        ]
+    )
+    phis = awkward.fromiter(
+        [
+            np.random.normal(0, size=5),
+            np.random.normal(0, size=2),
+            np.random.normal(0, size=3),
+        ]
+    )
+    return [ets, etas, phis]
+
+
+def test_jet(jetArray):
+    jet = Jet(*jetArray)
+    assert len(jet.et.content) == 5 + 2 + 3
+    assert len(jet.eta.content) == 5 + 2 + 3
+    assert len(jet.phi.content) == 5 + 2 + 3
+    assert len(jet.etCorr.content) == 5 + 2 + 3
+    assert len(jet.et) == 3
+    assert len(jet.eta) == 3
+    assert len(jet.phi) == 3
+    assert len(jet.etCorr) == 3

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -1,12 +1,32 @@
+import numba
 import numpy as np
+import pytest
 
-element = [(1, 2), (3, 3), (5, 7)]
+group_1 = np.array([(1, 2), (3, 3), (5, 7), (4, 4)])
+group_2 = np.array([(0, 0), (1, 2), (2, 2), (3, 3)])
 test_elements_x = [1, 3, 5]
 test_elements_y = [2, 3, 3]
-test_elements = list(zip(test_elements_x, test_elements_y))
+test_elements = np.array(list(zip(test_elements_x, test_elements_y)))
 
 
-def test_np_isin():
-    isin = np.isin(element, test_elements, assume_unique=True)
-    mask = np.all(isin, axis=1)
-    assert mask.tolist() == [True, True, False]
+@numba.jit(nopython=True, parallel=True)
+def filter_lumis(ranges_to_test, valid_lumi_sections):
+    result = np.zeros(ranges_to_test.shape[0], dtype=np.uint8)
+    for i in range(valid_lumi_sections.shape[0]):
+        valid_section = valid_lumi_sections[i, :]
+        for j in range(ranges_to_test.shape[0]):
+            to_test = ranges_to_test[j, :]
+            if np.equal(to_test, valid_section).all():
+                result[j] = 1
+    return result
+
+
+@pytest.mark.parametrize(
+    "group, expected",
+    [
+        (group_1, [True, True, False]),
+        (group_2, [True, True, False]),
+    ])
+def test_numba(group, expected):
+    mask = filter_lumis(test_elements, group)
+    assert mask.tolist() == expected

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+element = [(1, 2), (3, 3), (5, 7)]
+test_elements_x = [1, 3, 5]
+test_elements_y = [2, 3, 3]
+test_elements = list(zip(test_elements_x, test_elements_y))
+
+
+def test_np_isin():
+    isin = np.isin(element, test_elements, assume_unique=True)
+    mask = np.all(isin, axis=1)
+    assert mask.tolist() == [True, True, False]


### PR DESCRIPTION
Fixes #169 - filters are now treated like analyzers and producers and are run after producers and before analyzers

 - introduces UprootEvent + mask
 - replaces Lumifilter with vectorized version
 - adds `filters` keyword to config
 - removes lumi filter from jetAnalyzer