### PR TITLE
New histogram collection: VectorizedHistCollection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
 language: python
 
 python:
-  - "2.7"
   - "3.6"
 
 env:

--- a/cmsl1t/__init__.py
+++ b/cmsl1t/__init__.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 import logging
 import os
 from os import path
-import sys
 
 
 __version__ = '0.5.1'
@@ -30,5 +29,3 @@ if 'PROJECT_ROOT' not in os.environ:
     PROJECT_ROOT = path.abspath(path.join(HERE, path.pardir))
 else:
     PROJECT_ROOT = os.environ['PROJECT_ROOT']
-
-PY3 = sys.version_info[0] == 3

--- a/cmsl1t/__init__.py
+++ b/cmsl1t/__init__.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
+import logging
 import os
 from os import path
-import logging
+import sys
+
 
 __version__ = '0.5.1'
 
@@ -28,3 +30,5 @@ if 'PROJECT_ROOT' not in os.environ:
     PROJECT_ROOT = path.abspath(path.join(HERE, path.pardir))
 else:
     PROJECT_ROOT = os.environ['PROJECT_ROOT']
+
+PY3 = sys.version_info[0] == 3

--- a/cmsl1t/__init__.py
+++ b/cmsl1t/__init__.py
@@ -22,8 +22,8 @@ ch.setFormatter(formatter)
 logger.addHandler(ch)
 
 if 'PROJECT_ROOT' not in os.environ:
-    logger.warn("Could not find environmental variable 'PROJECT_ROOT'")
-    logger.warn("You should to run 'source setup.sh' first!")
+    logger.warning("Could not find environmental variable 'PROJECT_ROOT'")
+    logger.warning("You should to run 'source setup.sh' first!")
     HERE = path.dirname(path.abspath(__file__))
     PROJECT_ROOT = path.abspath(path.join(HERE, path.pardir))
 else:

--- a/cmsl1t/analyzers/demo_analyzer.py
+++ b/cmsl1t/analyzers/demo_analyzer.py
@@ -6,7 +6,7 @@ from functools import partial
 import numpy as np
 
 from .BaseAnalyzer import BaseAnalyzer
-from cmsl1t.collections import EfficiencyCollection
+from cmsl1t.collections import EfficiencyCollection, VectorizedHistCollection
 
 
 class Analyzer(BaseAnalyzer):
@@ -14,25 +14,30 @@ class Analyzer(BaseAnalyzer):
     def __init__(self, **kwargs):
         super(Analyzer, self).__init__(**kwargs)
 
-        self.met_calcs = dict(
-            RecalcL1EmuMETNot28=dict(
+        self.met_calcs = {
+            self.name + '_' + 'RecalcL1EmuMETNot28': dict(
                 title="Emulated MET, |ieta|<28",
                 attr='l1MetNot28'),
-            RecalcL1EmuMETNot28HF=dict(
+            self.name + '_' + 'RecalcL1EmuMETNot28HF': dict(
                 title="Emulated MET, |ieta|!=28",
                 attr='l1MetNot28HF'),
-        )
+        }
 
     def prepare_for_events(self, reader):
         bins = np.arange(0, 200, 25)
         thresholds = [70, 90, 110]
         puBins = list(range(0, 50, 10)) + [999]
 
+        self.hists = VectorizedHistCollection(innerBins=puBins, innerLabel='pu')
+
         self.efficiencies = EfficiencyCollection(pileupBins=puBins)
         add_met_variable = partial(
             self.efficiencies.add_variable,
             bins=bins, thresholds=thresholds)
         list(map(add_met_variable, self.met_calcs))
+
+        for met, config in self.met_calcs.items():
+            self.hists.add(met, bins=bins, title=config['title'])
         return True
 
     def reload_histograms(self, input_file):
@@ -43,16 +48,19 @@ class Analyzer(BaseAnalyzer):
     def fill_histograms(self, entry, event):
         pileup = event['Vertex_nVtx']
         self.efficiencies.set_pileup(pileup)
+        self.hists.inner_fill(pileup)
 
         offlineMetBE = event.Sums_caloMetBE
         for name, config in self.met_calcs.items():
             onlineMet = event[config['attr']]
             onlineMet = onlineMet.mag
             self.efficiencies.fill_array(name, offlineMetBE, onlineMet)
+            self.hists[pileup][name].fill(offlineMetBE)
         return True
 
     def write_histograms(self):
-        self.efficiencies.to_root(self.get_histogram_filename())
+        self.efficiencies.to_root(self.get_histogram_filename().replace('.root', '_efficiencies.root'))
+        self.hists.to_root(self.get_histogram_filename())
         return True
 
     def make_plots(self):

--- a/cmsl1t/analyzers/demo_analyzer.py
+++ b/cmsl1t/analyzers/demo_analyzer.py
@@ -37,7 +37,7 @@ class Analyzer(BaseAnalyzer):
         list(map(add_met_variable, self.met_calcs))
 
         for met, config in self.met_calcs.items():
-            self.hists.add(met, bins=bins, title=config['title'])
+            self.hists.insert(met, bins=bins, title=config['title'])
         return True
 
     def reload_histograms(self, input_file):

--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -357,12 +357,10 @@ class Analyzer(BaseAnalyzer):
         if self._doGen:
             genNVtx = event.Generator_nVtx
 
-        # TODO: vectorize
-        # pileup = self._lumiMu[(event['run'], event['lumi'])]
-        pileup = 51
+        pileup = self._lumiMu[(event['run'], event['lumi'])]
         # print pileup
-        if pileup >= 60 or pileup < 50:
-            return True
+        # if pileup >= 60 or pileup < 50:
+        #    return True
 
         for name in self._sumTypes:
             if 'pfMET' in name and not pfMetFilter(event):

--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -119,7 +119,7 @@ class Analyzer(BaseAnalyzer):
 
         lumiMuDict = dict()
         run_lumi_csv = os.path.join(cmsl1t.PROJECT_ROOT, 'run_lumi.csv')
-        with open(run_lumi_csv) as runLumiFile:
+        with open(run_lumi_csv, 'rb') as runLumiFile:
             reader = csv.reader(runLumiFile, delimiter=',')
             for line in reader:
                 lumiMuDict[(int(line[1]), int(line[2]))] = float(line[3])

--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -357,7 +357,9 @@ class Analyzer(BaseAnalyzer):
         if self._doGen:
             genNVtx = event.Generator_nVtx
 
-        pileup = self._lumiMu[(event['run'], event['lumi'])]
+        # TODO: vectorize
+        # pileup = self._lumiMu[(event['run'], event['lumi'])]
+        pileup = 51
         # print pileup
         # if pileup >= 60 or pileup < 50:
         #    return True

--- a/cmsl1t/collections/__init__.py
+++ b/cmsl1t/collections/__init__.py
@@ -5,10 +5,12 @@ from .base import BaseHistCollection
 from .by_pileup import HistogramsByPileUpCollection
 from .resolution import ResolutionCollection
 from .efficiency import EfficiencyCollection
+from .vectorized import VectorizedHistCollection
 
 __all__ = [
     'BaseHistCollection',
     'HistogramsByPileUpCollection',
     'ResolutionCollection',
     'EfficiencyCollection',
+    'VectorizedHistCollection',
 ]

--- a/cmsl1t/collections/base.py
+++ b/cmsl1t/collections/base.py
@@ -20,10 +20,10 @@ from cmsl1t.io import to_root
 logger = logging.getLogger(__name__)
 
 
-def create_n_dim_dict(dimensions, initiaValue=0):
+def create_n_dim_dict(dimensions, initialValue=0):
     if dimensions < 1:
-        return initiaValue
-    factory = partial(create_n_dim_dict, dimensions=dimensions - 1, initiaValue=initiaValue)
+        return initialValue
+    factory = partial(create_n_dim_dict, dimensions=dimensions - 1, initialValue=initialValue)
     return defaultdict(factory)
 
 
@@ -40,20 +40,20 @@ def create_n_dim_dict(dimensions, initiaValue=0):
 
 def len_n_dim_dict(dictionary, dimensions):
     if dimensions <= 1:
-        return len(dictionary)
+        return len(dictionary.keys())
     return sum(len_n_dim_dict(v, dimensions - 1)
                for v in six.itervalues(dictionary))
 
 
 class BaseHistCollection(defaultdict):
 
-    def __init__(self, dimensions, initiaValue=0):
+    def __init__(self, dimensions, initialValue=0):
         '''
             For each dimension create a dictionary
         '''
         # TODO: add possibility for different lambda expresions for each
         # dimension. This will allow to have custom dicts in certain dimensions
-        factory = partial(create_n_dim_dict, dimensions=dimensions - 1, initiaValue=initiaValue)
+        factory = partial(create_n_dim_dict, dimensions=dimensions - 1, initialValue=initialValue)
         if sys.version_info[0] < 3:
             defaultdict.__init__(self, factory)
         else:

--- a/cmsl1t/collections/by_pileup.py
+++ b/cmsl1t/collections/by_pileup.py
@@ -39,7 +39,7 @@ class HistogramsByPileUpCollection(BaseHistCollection):
                 'No bins specified for histogram {0}'.format(hist_name))
 
         if hist_name in self[self._pileupBins[0]].keys():
-            logger.warn('Histogram {0} already exists!'.format(hist_name))
+            logger.warning('Histogram {0} already exists!'.format(hist_name))
             return
         hist_names = []
         add_name = hist_names.append

--- a/cmsl1t/collections/efficiency.py
+++ b/cmsl1t/collections/efficiency.py
@@ -100,7 +100,7 @@ class EfficiencyCollection(HistogramsByPileUpCollection):
         """
         # TODO: this will no longer work since 1st dimension is pileup
         if variable in self.keys():
-            logger.warn('Variable {0} already exists!')
+            logger.warning('Variable {0} already exists!')
             return
         self._thresholds[variable] = thresholds
         hist_names = []
@@ -123,7 +123,7 @@ class EfficiencyCollection(HistogramsByPileUpCollection):
             logger.error('Histogram {0} does not exist'.format(hist_name))
             return
         if hist_name not in self._thresholds:
-            logger.warn('No valid current thresholds.')
+            logger.warning('No valid current thresholds.')
         for threshold in self._thresholds[hist_name]:
             h[threshold].fill(recoValue, l1Value, w)
 
@@ -136,7 +136,7 @@ class EfficiencyCollection(HistogramsByPileUpCollection):
             logger.error('Histogram {0} does not exist'.format(hist_name))
             return
         if hist_name not in self._thresholds:
-            logger.warn('No valid current thresholds.')
+            logger.warning('No valid current thresholds.')
         for threshold in self._thresholds[hist_name]:
             h[threshold].fill_array(recoValue, l1Value, w)
 

--- a/cmsl1t/collections/resolution.py
+++ b/cmsl1t/collections/resolution.py
@@ -55,7 +55,7 @@ class ResolutionCollection(HistogramsByPileUpCollection):
             logger.error('Histogram {0} does not exist'.format(hist_name))
             return
         if not self._currentRegions:
-            logger.warn(
+            logger.warning(
                 'No valid current regions. Did you set_region_by_eta()?')
         for region in self._currentRegions:
             h[region].fill(x, w)
@@ -63,7 +63,7 @@ class ResolutionCollection(HistogramsByPileUpCollection):
     def add_variable(self, variable, bins=[]):
         from rootpy.plotting import Hist
         if variable in self.keys():
-            logger.warn('Variable {0} already exists!')
+            logger.warning('Variable {0} already exists!')
             return
         hist_names = []
         add_name = hist_names.append

--- a/cmsl1t/collections/vectorized.py
+++ b/cmsl1t/collections/vectorized.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 import logging
-import numba
 import numpy as np
 from rootpy.plotting import Hist
 
@@ -55,10 +54,10 @@ class VectorizedHistCollection(BaseHistCollection):
         bins = np.asarray(bins)
         if bins.size == 0:
             logger.error(
-                'No bins specified for histogram {0}'.format(hist_name))
+                'No bins specified for histogram {0}'.format(name))
 
         if name in defaultdict.__getitem__(self, 1):
-            logger.warning('Histogram {0} already exists!'.format(hist_name))
+            logger.warning('Histogram {0} already exists!'.format(name))
             return
         names = []
         add_name = names.append

--- a/cmsl1t/collections/vectorized.py
+++ b/cmsl1t/collections/vectorized.py
@@ -42,7 +42,7 @@ class VectorizedHistCollection(BaseHistCollection):
 
         self._innerBins = innerBins
         self._innerLabel = innerLabel
-        self._innerHist = Hist(100, 0, 100, name=innerLabel + '_' + self._name)
+        self._innerHist = Hist(innerBins, name=innerLabel + '_' + self._name)
 
     def __getitem__(self, key):
         if not isinstance(key, (tuple, list, np.ndarray, np.generic)):
@@ -70,16 +70,17 @@ class VectorizedHistCollection(BaseHistCollection):
             logger.error(
                 'No bins specified for histogram {0}'.format(name))
 
-        if name in defaultdict.__getitem__(self, 1):
+        if name in super(VectorizedHistCollection, self).__getitem__(1):
             logger.warning('Histogram {0} already exists!'.format(name))
             return
         names = []
         add_name = names.append
 
         for i, hist_name in enumerate(self._create_hist_names(name)):
-            if i + 1 not in self or hist_name not in defaultdict.__getitem__(self, i + 1):
+            __current_slice = super(VectorizedHistCollection, self).__getitem__(i + 1)
+            if i + 1 not in self or hist_name not in __current_slice:
                 add_name(hist_name)
-                defaultdict.__getitem__(self, i + 1)[hist_name] = hist_type(bins, name=hist_name, title=title)
+                __current_slice[hist_name] = hist_type(bins, name=hist_name, title=title)
         logger.debug('Created {0} histograms: {1}'.format(
             len(names), ', '.join(names)))
 

--- a/cmsl1t/collections/vectorized.py
+++ b/cmsl1t/collections/vectorized.py
@@ -1,6 +1,14 @@
-import numbda
+from collections import defaultdict
+import logging
+import numba
+import numpy as np
+from rootpy.plotting import Hist
 
 from . import BaseHistCollection
+from ..utils.iterators import pairwise
+from .. import PY3
+
+logger = logging.getLogger(__name__)
 
 
 @numba.jit(nopython=True)
@@ -9,11 +17,23 @@ def extend(arr1, starts, stops):
     return np.repeat(arr1, repeat, axis=0)
 
 
-class VectorizedHistCollection(object):
+class VectorizedHistCollection(BaseHistCollection):
 
-    def __init__(self, innerBins):
+    def __init__(self, innerBins, innerLabel='inner', **kwargs):
+        # if we want to generalize to N dim, innerBins needs to be an array of innerBins
+        dimensions = kwargs.pop('dimensions', 2)
+        if PY3:
+            super(VectorizedHistCollection, self).__init__(dimensions)
+        else:
+            BaseHistCollection.__init__(self, dimensions)
+
         self._innerBins = innerBins
+        self._innerLabel = innerLabel
         self._innerHist = Hist(100, 0, 100, name='inner')
+
+    def __getitem__(self, key):
+        real_key = self._get_inner_indices(key)
+        return defaultdict.__getitem__(self, real_key)
 
     def _get_inner_indices(self, values):
         '''
@@ -23,6 +43,31 @@ class VectorizedHistCollection(object):
 
             :Example:
                 >>> hists = VectorizedHistCollection(innerBins=[0,10,15,20,30,999])
-                >>> hists._get_inner_indices([1, 11, 1111]) # returns [0, 1, 5]
+                >>> hists._get_inner_indices([1, 11, 1111]) # returns [1, 2, 6]
         '''
         return np.digitize(values, self._innerBins)
+
+    def add(self, name, bins, hist_type=Hist):
+
+        bins = np.asarray(bins)
+        if bins.size == 0:
+            logger.error(
+                'No bins specified for histogram {0}'.format(hist_name))
+
+        if name in self[1]:
+            logger.warning('Histogram {0} already exists!'.format(hist_name))
+            return
+        names = []
+        add_name = names.append
+        print(self)
+
+        for i, (lowerEdge, upperEdge) in enumerate(pairwise(self._innerBins)):
+            hist_name = f"{name}_{self._innerLabel}{lowerEdge}To{upperEdge}"
+            if i + 1 not in self or hist_name not in self[i + 1]:
+                add_name(hist_name)
+                self[i + 1][hist_name] = Hist(bins, name=hist_name)
+        logger.debug('Created {0} histograms: {1}'.format(
+            len(names), ', '.join(names)))
+
+    def fill(self):
+        pass

--- a/cmsl1t/collections/vectorized.py
+++ b/cmsl1t/collections/vectorized.py
@@ -88,7 +88,7 @@ class VectorizedHistCollection(BaseHistCollection):
             len(names), ', '.join(names)))
 
     def _create_hist_names(self, name):
-        for i, (lowerEdge, upperEdge) in enumerate(pairwise(self._innerBins)):
+        for lowerEdge, upperEdge in pairwise(self._innerBins):
             yield f"{name}_{self._innerLabel}{lowerEdge}To{upperEdge}"
 
     def get_hist_name(self, name, innerIndex):

--- a/cmsl1t/collections/vectorized.py
+++ b/cmsl1t/collections/vectorized.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 import logging
 import numpy as np
+import random
 from rootpy.plotting import Hist
 
 from . import BaseHistCollection
@@ -21,6 +22,7 @@ class VectorizedHistCollection(BaseHistCollection):
         # if we want to generalize to N dim, innerBins needs to be an array of innerBins
         # TODO: last dimension should probably be a normal dictionary
         dimensions = kwargs.pop('dimensions', 2)
+        name = kwargs.pop('name', str(hex(random.getrandbits(128)))[2:10])
         if PY3:
             super(VectorizedHistCollection, self).__init__(dimensions)
         else:
@@ -28,7 +30,7 @@ class VectorizedHistCollection(BaseHistCollection):
 
         self._innerBins = innerBins
         self._innerLabel = innerLabel
-        self._innerHist = Hist(100, 0, 100, name='inner')
+        self._innerHist = Hist(100, 0, 100, name=innerLabel + '_' + name)
 
     def __getitem__(self, key):
         if not isinstance(key, (list, np.ndarray, np.generic)):
@@ -147,6 +149,7 @@ class VectorizedHistProxy(object):
             hist = self._get_hist(i)
             hist.fill_array(x_i, w_i)
 
+# class VectorizedEfficiencyProxy(object):
 
 # def split_input():
 #     a = np.array([1, 12, 1, 10, 50, 10])

--- a/cmsl1t/collections/vectorized.py
+++ b/cmsl1t/collections/vectorized.py
@@ -11,7 +11,6 @@ from .. import PY3
 logger = logging.getLogger(__name__)
 
 
-@numba.jit(nopython=True)
 def extend(arr1, starts, stops):
     repeat = stops - starts
     return np.repeat(arr1, repeat, axis=0)
@@ -21,6 +20,7 @@ class VectorizedHistCollection(BaseHistCollection):
 
     def __init__(self, innerBins, innerLabel='inner', **kwargs):
         # if we want to generalize to N dim, innerBins needs to be an array of innerBins
+        # TODO: last dimension should probably be a normal dictionary
         dimensions = kwargs.pop('dimensions', 2)
         if PY3:
             super(VectorizedHistCollection, self).__init__(dimensions)
@@ -35,11 +35,8 @@ class VectorizedHistCollection(BaseHistCollection):
         if not isinstance(key, (list, np.ndarray, np.generic)):
             key = np.array([key])
         real_keys = self._get_inner_indices(key)
-        # Python tries to copy the whole nested default dict ... which is infinite
-        # print(key, real_keys)
-        # return object()
         return VectorizedBinProxy(self, real_keys)
-        return [defaultdict.__getitem__(self, k) for k in real_keys.tolist()]
+        # return [defaultdict.__getitem__(self, k) for k in real_keys.tolist()]
 
     def _get_inner_indices(self, values):
         '''
@@ -66,18 +63,24 @@ class VectorizedHistCollection(BaseHistCollection):
         names = []
         add_name = names.append
 
-        for i, (lowerEdge, upperEdge) in enumerate(pairwise(self._innerBins)):
-            hist_name = f"{name}_{self._innerLabel}{lowerEdge}To{upperEdge}"
+        for i, hist_name in enumerate(self._create_hist_names(name)):
             if i + 1 not in self or hist_name not in defaultdict.__getitem__(self, i + 1):
                 add_name(hist_name)
                 defaultdict.__getitem__(self, i + 1)[hist_name] = Hist(bins, name=hist_name)
         logger.debug('Created {0} histograms: {1}'.format(
             len(names), ', '.join(names)))
 
+    def _create_hist_names(self, name):
+        for i, (lowerEdge, upperEdge) in enumerate(pairwise(self._innerBins)):
+            yield f"{name}_{self._innerLabel}{lowerEdge}To{upperEdge}"
+
+    def get_hist_name(self, name, innerIndex):
+        lowerEdge, upperEdge = self._innerBins[innerIndex - 1], self._innerBins[innerIndex]
+        return f"{name}_{self._innerLabel}{lowerEdge}To{upperEdge}"
+
     def fill(self, x, w=None):
         if w is None:
             w = np.ones()
-
 
 
 class VectorizedBinProxy(object):
@@ -85,9 +88,10 @@ class VectorizedBinProxy(object):
     def __init__(self, collection, inner_indices):
         self.collection = collection
         self._inner_indices = inner_indices
+        # self._inner_values = inner_values
 
     def __getitem__(self, key):
-        # TODO, if key != string, return a BinProxy
+        # TODO, if key != string, return a BinProxy of the bin above
         return VectorizedHistProxy(self, key)
 
     def __add__(self, other):
@@ -109,12 +113,29 @@ class VectorizedBinProxy(object):
         self._inner_indices = np.unique(self._inner_indices)
         return self
 
+
 class VectorizedHistProxy(object):
 
     def __init__(self, bin_proxy, hist_name):
-        self._bin_proxy = bin_proxy.flatten()
+        self._bin_proxy = bin_proxy
         self._hist_name = hist_name
+
+    def _split_input(self, x, w):
+        inner_indices = self._bin_proxy._inner_indices
+        # TODO: what if x is not jagged
+        inner_indices = extend(inner_indices, x.starts, x.stops)
+        for u in np.unique(inner_indices):
+            mask = inner_indices == u
+            yield u, x.content[mask], w[mask]
+
+    def _get_hist(self, inner_index):
+        hist_name = self._bin_proxy.collection.get_hist_name(self._hist_name, inner_index)
+        return defaultdict.__getitem__(self._bin_proxy.collection, inner_index)[hist_name]
 
     def fill(self, x, w=None):
         if w is None:
-            w = np.ones(x)
+            # TODO: what if x is not jagged
+            w = np.ones(len(x.content))
+        for i, x_i, w_i in self._split_input(x, w):
+            hist = self._get_hist(i)
+            hist.fill_array(x_i, w_i)

--- a/cmsl1t/collections/vectorized.py
+++ b/cmsl1t/collections/vectorized.py
@@ -63,7 +63,7 @@ class VectorizedHistCollection(BaseHistCollection):
         '''
         return np.digitize(values, self._innerBins)
 
-    def add(self, name, bins, hist_type=Hist, **kwargs):
+    def insert(self, name, bins, hist_type=Hist, **kwargs):
         title = kwargs.pop('title', name)
         bins = np.asarray(bins)
         if bins.size == 0:

--- a/cmsl1t/collections/vectorized.py
+++ b/cmsl1t/collections/vectorized.py
@@ -78,9 +78,10 @@ class VectorizedHistCollection(BaseHistCollection):
         lowerEdge, upperEdge = self._innerBins[innerIndex - 1], self._innerBins[innerIndex]
         return f"{name}_{self._innerLabel}{lowerEdge}To{upperEdge}"
 
-    def fill(self, x, w=None):
+    def inner_fill(self, x, w=None):
         if w is None:
-            w = np.ones()
+            w = np.ones(len(x))
+        self._innerHist.fill_array(x, w)
 
 
 class VectorizedBinProxy(object):

--- a/cmsl1t/collections/vectorized.py
+++ b/cmsl1t/collections/vectorized.py
@@ -1,0 +1,28 @@
+import numbda
+
+from . import BaseHistCollection
+
+
+@numba.jit(nopython=True)
+def extend(arr1, starts, stops):
+    repeat = stops - starts
+    return np.repeat(arr1, repeat, axis=0)
+
+
+class VectorizedHistCollection(object):
+
+    def __init__(self, innerBins):
+        self._innerBins = innerBins
+        self._innerHist = Hist(100, 0, 100, name='inner')
+
+    def _get_inner_indices(self, values):
+        '''
+            Returns the pileup bin corresponding to the provided pileup value.
+             - bin 0 is underflow
+             - bin len(innerBins) is overflow
+
+            :Example:
+                >>> hists = VectorizedHistCollection(innerBins=[0,10,15,20,30,999])
+                >>> hists._get_inner_indices([1, 11, 1111]) # returns [0, 1, 5]
+        '''
+        return np.digitize(values, self._innerBins)

--- a/cmsl1t/collections/vectorized.py
+++ b/cmsl1t/collections/vectorized.py
@@ -19,15 +19,21 @@ def extend(arr1, starts, stops):
 
 def split_input(inner_indices, x, w):
     content = x
+    weights = w
     if hasattr(x, 'starts'):
         inner_indices = extend(inner_indices, x.starts, x.stops)
         content = x.content
+    if hasattr(w, 'starts'):
+        weights = w.content
+
+    if np.size(weights) < np.size(content) and hasattr(x, 'starts'):
+        weights = extend(weights, x.starts, x.stops)
 
     for u in np.unique(inner_indices):
         mask = inner_indices == u
         if not isinstance(mask, (tuple, list, np.ndarray, np.generic)):
             mask = np.array(mask)
-        yield u, content[mask], w[mask]
+        yield u, content[mask], weights[mask]
 
 
 class VectorizedHistCollection(BaseHistCollection):
@@ -147,6 +153,7 @@ class VectorizedHistProxy(object):
     def fill(self, x, w=None):
         if not isinstance(x, (tuple, list, np.ndarray, awkward.JaggedArray)):
             x = np.array(x)
+
         if w is None:
             n = np.size(x.content) if hasattr(x, 'content') else np.size(x)
             w = np.ones(n)

--- a/cmsl1t/collections/vectorized.py
+++ b/cmsl1t/collections/vectorized.py
@@ -25,8 +25,8 @@ def split_input(inner_indices, x, w):
 
     for u in np.unique(inner_indices):
         mask = inner_indices == u
-        if not isinstance(mask, (list, np.ndarray)):
-            mask = np.array([mask])
+        if not isinstance(mask, (tuple, list, np.ndarray, np.generic)):
+            mask = np.array(mask)
         yield u, content[mask], w[mask]
 
 
@@ -45,8 +45,8 @@ class VectorizedHistCollection(BaseHistCollection):
         self._innerHist = Hist(100, 0, 100, name=innerLabel + '_' + self._name)
 
     def __getitem__(self, key):
-        if not isinstance(key, (list, np.ndarray, np.generic)):
-            key = np.array([key])
+        if not isinstance(key, (tuple, list, np.ndarray, np.generic)):
+            key = np.array(key)
         real_keys = self._get_inner_indices(key)
         return VectorizedBinProxy(self, real_keys)
         # return [defaultdict.__getitem__(self, k) for k in real_keys.tolist()]
@@ -144,8 +144,8 @@ class VectorizedHistProxy(object):
         return defaultdict.__getitem__(self._bin_proxy.collection, inner_index)[hist_name]
 
     def fill(self, x, w=None):
-        if not isinstance(x, (list, np.ndarray, awkward.JaggedArray)):
-            x = np.array([x])
+        if not isinstance(x, (tuple, list, np.ndarray, awkward.JaggedArray)):
+            x = np.array(x)
         if w is None:
             n = np.size(x.content) if hasattr(x, 'content') else np.size(x)
             w = np.ones(n)

--- a/cmsl1t/collections/vectorized.py
+++ b/cmsl1t/collections/vectorized.py
@@ -7,7 +7,6 @@ from rootpy.plotting import Hist
 
 from . import BaseHistCollection
 from ..utils.iterators import pairwise
-from .. import PY3
 from ..io import to_root
 
 logger = logging.getLogger(__name__)
@@ -39,10 +38,7 @@ class VectorizedHistCollection(BaseHistCollection):
         dimensions = kwargs.pop('dimensions', 2)
         self._name = kwargs.pop('name', str(hex(random.getrandbits(128)))[2:10])
         self._execute_before_write = kwargs.pop('execute_before_write', [])
-        if PY3:
-            super(VectorizedHistCollection, self).__init__(dimensions)
-        else:
-            BaseHistCollection.__init__(self, dimensions)
+        super(VectorizedHistCollection, self).__init__(dimensions)
 
         self._innerBins = innerBins
         self._innerLabel = innerLabel

--- a/cmsl1t/config.py
+++ b/cmsl1t/config.py
@@ -314,7 +314,7 @@ class ConfigParser(object):
         forbidden_local_settings = ['name', 'input_files']
         for s in forbidden_local_settings:
             if s in analyzer:
-                logger.warn('Setting {0} is forbidden in analysis::analyzers::{1}'.format(s, analyzer_name))
+                logger.warning('Setting {0} is forbidden in analysis::analyzers::{1}'.format(s, analyzer_name))
                 analyzer.pop(s)
 
         global_settings = dict(

--- a/cmsl1t/playground/eventreader.py
+++ b/cmsl1t/playground/eventreader.py
@@ -367,7 +367,7 @@ class EventReader(object):
             try:
                 chain = TreeChain(path, input_files, cache=True, events=events)
             except RuntimeError:
-                logger.warn("Cannot find tree: {0} in input file".format(path))
+                logger.warning("Cannot find tree: {0} in input file".format(path))
                 continue
             self._names.append(name)
             self._trees.append(chain)

--- a/cmsl1t/playground/resolution.py
+++ b/cmsl1t/playground/resolution.py
@@ -36,7 +36,7 @@ class Resolution(object):
         for region in regions:
             name = prefix + region
             if name in self._hists:
-                logger.warn('Overwriting existing histogram {0}'.format(name))
+                logger.warning('Overwriting existing histogram {0}'.format(name))
                 del self._hists[name]
             logger.debug('Adding histogram {0}'.format(name))
             self._hists[name] = Hist(bins, name=name)

--- a/cmsl1t/producers/met.py
+++ b/cmsl1t/producers/met.py
@@ -76,7 +76,7 @@ class Producer(BaseProducer):
             self._method = Producer.METHODS[params['method']]
         else:
             msg = 'Could not find specified MET method, using default.'
-            logger.warn(msg)
+            logger.warning(msg)
             self._method = Producer.METHODS['default']
 
     def produce(self, event):

--- a/cmsl1t/producers/met_vectorized.py
+++ b/cmsl1t/producers/met_vectorized.py
@@ -79,7 +79,7 @@ class Producer(BaseProducer):
             self._method = Producer.METHODS[params['method']]
         else:
             msg = 'Could not find specified MET method, using default.'
-            logger.warn(msg)
+            logger.warning(msg)
             self._method = Producer.METHODS['default']
 
     def produce(self, event):

--- a/config/demo.yaml
+++ b/config/demo.yaml
@@ -52,6 +52,7 @@ analysis:
       outputs:
         - l1MetNot28HF
       method: l1MetNot28HF
+  filters: []
 
 output:
   # template is a list here that is joined (os.path.join) in the config parser

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+aghast
+git+https://github.com/scikit-hep/boost-histogram.git@develop
 numpy
 matplotlib
 pandas==0.23

--- a/test/collections/test_baseHistcollection.py
+++ b/test/collections/test_baseHistcollection.py
@@ -1,6 +1,8 @@
-from cmsl1t.collections import BaseHistCollection
-import unittest
 from collections import defaultdict
+import pytest
+import unittest
+
+from cmsl1t.collections import BaseHistCollection
 
 
 class TestBaseHistCollection(unittest.TestCase):
@@ -9,6 +11,7 @@ class TestBaseHistCollection(unittest.TestCase):
         dimensions = 4
         initial_value = 0
         hists = BaseHistCollection(dimensions, initial_value)
+        self.assertEqual(len(hists), 0)
         self.assertIs(type(hists[1]), defaultdict)
         self.assertIs(type(hists[1][2][3][4]), type(initial_value))
         self.assertEqual(hists[1][2][3][4], initial_value)
@@ -23,3 +26,9 @@ class TestBaseHistCollection(unittest.TestCase):
 
         # length_from_iterator = len(list(six.itervalues(hists)))
         # self.assertEqual(length_from_iterator, 3)
+
+
+@pytest.mark.parametrize("dimensions", [1, 2, 3])
+def test_empty(dimensions):
+    c = BaseHistCollection(dimensions)
+    assert len(c) == 0

--- a/test/collections/test_boost_histogram.py
+++ b/test/collections/test_boost_histogram.py
@@ -1,0 +1,29 @@
+# import aghast
+import awkward
+import boost.histogram as bh
+import numpy as np
+
+
+def test_fill():
+    pileup_bins = [0, 10, 15, 20, 30, 999]
+    jet_pt_bins = [35, 90, 120]
+    hist = bh.histogram(
+        bh.axis.variable(pileup_bins),
+        bh.axis.variable(jet_pt_bins, bh.storage.weight()),
+    )
+
+    ets = awkward.fromiter([
+        np.random.poisson(30, 5),
+        np.random.poisson(30, 2),
+        np.random.poisson(30, 3),
+    ])
+    repeat = ets.stops - ets.starts
+
+    weights = np.ones(len(ets))
+    weights = np.repeat(weights, repeat, axis=0)
+    pileup = np.random.poisson(50, len(ets))
+    pileup = np.repeat(pileup, repeat, axis=0)
+    # expand pileup to size ets
+    assert len(pileup) == len(ets.content)
+    # hist.fill(pileup, ets.content, bh.weight(weights))
+    hist(pileup, ets.content)

--- a/test/collections/test_boost_histogram.py
+++ b/test/collections/test_boost_histogram.py
@@ -25,5 +25,7 @@ def test_fill():
     pileup = np.repeat(pileup, repeat, axis=0)
     # expand pileup to size ets
     assert len(pileup) == len(ets.content)
+    # weights are not yet supported
     # hist.fill(pileup, ets.content, bh.weight(weights))
-    hist(pileup, ets.content)
+    hist.fill(pileup, ets.content)
+    # hist(pileup, ets.content)

--- a/test/collections/test_vectorized.py
+++ b/test/collections/test_vectorized.py
@@ -4,6 +4,7 @@ import numpy as np
 from rootpy.plotting import Hist
 
 from cmsl1t.collections import VectorizedHistCollection
+from cmsl1t.collections.vectorized import VectorizedBinProxy, VectorizedHistProxy
 
 
 @pytest.fixture
@@ -30,6 +31,29 @@ def test_add(collection):
     collection.add('test', bins=[35, 90, 120])
     assert len(collection) == len(collection._innerBins) - 1
 
+
+def test_access(collection):
+    collection.add('test', bins=[35, 90, 120])
+    innerValues = [1, 12, 1, 50]
+    assert collection[innerValues] == collection[1] + collection[12] + collection[1] + collection[50]
+    # assert type(collection[innerValues]) == Hist
+    assert type(collection[innerValues]['test']) == VectorizedHistProxy
+
+
+def test_copy(collection):
+    proxy = VectorizedBinProxy(collection, [1, 12, 1, 50])
+
+
+@pytest.mark.parametrize(
+    "values,expected",
+    [
+        ([1, 12, 1, 50], [1, 12, 50]),
+        ([1, 30, 12, 1, 50], [1, 12, 30, 50]),
+    ])
+def test_bin_proxy_flatten(collection, values, expected):
+    proxy = VectorizedBinProxy(collection, values)
+    assert proxy.flatten()._inner_indices.tolist() == expected
+
 # def test_fill(collection):
 #     innerValues = [1, 12, 1, 50]
 #     outerValues = awkward.fromiter([
@@ -38,3 +62,5 @@ def test_add(collection):
 #         [56, 34, 31],
 #     ])
 #     collection.add('test', bins=[35, 90, 120])
+#     weights = np.ones(len(outerValues.content))
+#     collection[innerValues][hist_name].fill(outerValues, weights)

--- a/test/collections/test_vectorized.py
+++ b/test/collections/test_vectorized.py
@@ -1,8 +1,17 @@
+import awkward
 import pytest
 import numpy as np
 from rootpy.plotting import Hist
 
 from cmsl1t.collections import VectorizedHistCollection
+
+
+@pytest.fixture
+def collection():
+    innerBins = np.array([0, 10, 15, 20, 30, 999])
+    coll = VectorizedHistCollection(innerBins)
+    # fill for [35, 90, 120]
+    return coll
 
 
 @pytest.mark.parametrize(
@@ -12,8 +21,20 @@ from cmsl1t.collections import VectorizedHistCollection
         ([1, 11, 1111], [1, 2, 6]),
         ([-10, 1111, 20], [0, 6, 4]),
     ])
-def test_inner_index(values, expected):
-    innerBins = np.array([0, 10, 15, 20, 30, 999])
-    coll = VectorizedHistCollection(innerBins)
+def test_inner_index(collection, values, expected):
+    np.testing.assert_array_equal(collection._get_inner_indices(values), expected)
 
-    np.testing.assert_array_equal(coll._get_inner_indices(values), expected)
+
+def test_add(collection):
+    assert len(collection) == 0
+    collection.add('test', bins=[35, 90, 120])
+    assert len(collection) == len(collection._innerBins) - 1
+
+# def test_fill(collection):
+#     innerValues = [1, 12, 1, 50]
+#     outerValues = awkward.fromiter([
+#         [60, 50, 40, 30, 20],
+#         [32, 23],
+#         [56, 34, 31],
+#     ])
+#     collection.add('test', bins=[35, 90, 120])

--- a/test/collections/test_vectorized.py
+++ b/test/collections/test_vectorized.py
@@ -111,6 +111,7 @@ def test_extend():
     innerValues = extend(innerValues, outerValues.starts, outerValues.stops)
     assert len(innerValues) == len(outerValues.content)
 
+
 def test_split_input():
     innerValues = [1, 12, 1, 50]
     outerValues = awkward.fromiter([

--- a/test/collections/test_vectorized.py
+++ b/test/collections/test_vectorized.py
@@ -1,7 +1,6 @@
 import awkward
 import pytest
 import numpy as np
-from rootpy.plotting import Hist
 
 from cmsl1t.collections import VectorizedHistCollection
 from cmsl1t.collections.vectorized import VectorizedBinProxy, VectorizedHistProxy, extend

--- a/test/collections/test_vectorized.py
+++ b/test/collections/test_vectorized.py
@@ -27,12 +27,12 @@ def test_inner_index(collection, values, expected):
 
 def test_add(collection):
     assert len(collection) == 0
-    collection.add('test', bins=[35, 90, 120])
+    collection.insert('test', bins=[35, 90, 120])
     assert len(collection) == len(collection._innerBins) - 1
 
 
 def test_access(collection):
-    collection.add('test', bins=[35, 90, 120])
+    collection.insert('test', bins=[35, 90, 120])
     innerValues = [1, 12, 1, 50]
     assert collection[innerValues] == collection[1] + collection[12] + collection[1] + collection[50]
     # assert type(collection[innerValues]) == Hist
@@ -92,7 +92,7 @@ def test_fill(collection):
     ]
 
     hist_name = 'test'
-    collection.add(hist_name, bins=[35, 90, 120])
+    collection.insert(hist_name, bins=[35, 90, 120])
     weights = np.ones(len(outerValues.content))
     collection[innerValues][hist_name].fill(outerValues, weights)
     for i in range(len(np.unique(innerValues))):

--- a/test/collections/test_vectorized.py
+++ b/test/collections/test_vectorized.py
@@ -39,8 +39,8 @@ def test_access(collection):
     assert type(collection[innerValues]['test']) == VectorizedHistProxy
 
 
-def test_copy(collection):
-    proxy = VectorizedBinProxy(collection, [1, 12, 1, 50])
+# def test_copy(collection):
+#     proxy = VectorizedBinProxy(collection, [1, 12, 1, 50])
 
 
 @pytest.mark.parametrize(

--- a/test/collections/test_vectorized.py
+++ b/test/collections/test_vectorized.py
@@ -1,0 +1,19 @@
+import pytest
+import numpy as np
+from rootpy.plotting import Hist
+
+from cmsl1t.collections import VectorizedHistCollection
+
+
+@pytest.mark.parametrize(
+    "values,expected",
+    [
+        ([1, 12, 1, 50], [1, 2, 1, 5]),
+        ([1, 11, 1111], [1, 2, 6]),
+        ([-10, 1111, 20], [0, 6, 4]),
+    ])
+def test_inner_index(values, expected):
+    innerBins = np.array([0, 10, 15, 20, 30, 999])
+    coll = VectorizedHistCollection(innerBins)
+
+    np.testing.assert_array_equal(coll._get_inner_indices(values), expected)


### PR DESCRIPTION
Fixes #39, #171

Introduces `VectorizedHistCollection` that adds two things w.r.t. `BaseHistCollection`:
 - access multiple histograms at once
 - fill multiple histograms at once

Accessing `collection[pileup]` with `pileup = [1, 12, 1, 50]` will automatically return the histograms for the correct pileup bins (not values). This part is generalized through the `VectorizedBinProxy`.

Filling histograms can be done with either `scalar`, `numpy.ndarray` or `awkward.JaggedArray`.

`VectorizedHistCollection` also introduces some experimental functionality, e.g. `execute_before_write`.
The `execute_before_write` parameter can be used to schedule function calls before the collection is written to disk. E.g. this could replace the EfficiencyCollection's `_calculateEfficiencies` call (i.e. a step towards the generalization of histogram collections). This part is generalized through the `VectorizedHistProxy`.

### Example
```python
import awkward
from cmsl1t.collections import VectorizedHistCollection

puBins = list(range(0, 50, 10)) + [999]
collection = VectorizedHistCollection(innerBins=puBins, innerLabel='pu')
collection.add('test', bins=[35, 90, 120])

pileup = [1, 12, 1, 50]
jet_et = awkward.fromiter([
        [60, 50, 40, 30, 20],
        [32, 23],
        [56, 34, 31],
        [],
    ])

collection[pileup]['test'].fill(jet_et)
```

### Further work needed
 - documentation
 - more tests & benchmarks (&gt; 2 dimensions, scalar values)
 - allowing for different histogram proxies: e.g. special fill for efficiencies