### PR TITLE
Extending vectorization to most common analyzers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,8 +99,8 @@ ENV/
 .*sw[po]
 
 # Custom ignores
-external
-workspace
-data
-benchmark
-output
+external/*
+workspace/*
+data/*
+benchmark/*
+output/*

--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,10 @@ test: lint test-code
 test-all: lint test-code-full
 
 test-code:
-	@pytest -v -m "not xrootdtest" test
+	@python -m pytest -v -m "not xrootdtest" test
 
 test-code-full:
-	@pytest -v test
+	@python -m pytest -v test
 
 changelog:
 	@github_changelog_generator -u cms-l1t-offline -p cms-l1t-analysis

--- a/Makefile
+++ b/Makefile
@@ -34,17 +34,12 @@ setup-build-dir:
 create-data-dir:
 		@mkdir -p data
 
-setup-data-dir: create-data-dir data/L1Ntuple_test_1.root data/L1Ntuple_test_2.root data/L1Ntuple_test_3.root
+setup-data-dir: create-data-dir
+
+download-test-data: data/L1Ntuple_test_1.root
 
 data/L1Ntuple_test_1.root:
-	@xrdcp root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/bundocka/cmsl1t/test_0.root ./data/L1Ntuple_test_1.root || true
-
-data/L1Ntuple_test_2.root:
-	@xrdcp root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/bundocka/cmsl1t/test_1.root ./data/L1Ntuple_test_2.root || true
-
-data/L1Ntuple_test_3.root:
-	@xrdcp root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/bundocka/cmsl1t/test_2.root ./data/L1Ntuple_test_3.root || true
-
+	@xrdcp root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/bundocka/SingleMuon/smMETa/190606_105654/0000/L1Ntuple_99.root ./data/L1Ntuple_test_1.root || true
 
 # tests
 pep8:

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ cd cms-l1t-analysis
 git remote add upstream https://github.com/cms-l1t-offline/cms-l1t-analysis.git
 git pull --rebase upstream master
 source setup.sh
+make setup
+# if you want to download test data:
 # you will need your grid cert
 voms-proxy-init --voms cms
-make setup
+make download-test-data
 ```
 
 ### On OS X/other Linux/Windows
@@ -38,9 +40,11 @@ vagrant up
 vagrant ssh
 cd /vagrant
 source setup.sh
+make setup
+# if you want to download test data:
 # you will need your grid cert
 voms-proxy-init --voms cms
-make setup
+make download-test-data
 ```
 
 ### running tests

--- a/bin/cmsl1t
+++ b/bin/cmsl1t
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 import ROOT
 import os
 
@@ -12,23 +11,23 @@ import click_log
 import yaml
 import logging
 
+from cmsl1t import logger
 from cmsl1t.config import ConfigParser
 from cmsl1t.filters import create_event_mask
 from cmsl1t.io.eventreader import EventReader
 from cmsl1t.utils.module import load_L1TNTupleLibrary
 from cmsl1t.utils.timers import timerfunc_log_to
 
-logger = logging.getLogger(__name__)
 logging.getLogger("rootpy.tree.chain").setLevel(logging.WARNING)
-click_log.basic_config(logger)
+#click_log.basic_config(logger)
 
 TODAY = datetime.now().timetuple()
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 ROOT.gROOT.SetBatch(1)
 ROOT.TH1.SetDefaultSumw2(True)
-separator = '=' * 80
+separator = '=' * 20
 section = [separator, '{0}', separator]
-section = '\n'.join(section)
+section = '    '.join(section)
 
 
 @timerfunc_log_to(logger.info)
@@ -40,13 +39,14 @@ def process_tuples(config, nevents, analyzers, producers, filters=None):
     logger.info("Input files:")
 
     if len(input_files) > 10:
-        file_msg = [input_files[:10], "... and",
+        file_msg = ['    ' + '\n'.join(input_files[:10]), "\n    ... and",
                     len(input_files) - 10, "more files"]
         file_msg = map(str, file_msg)
         file_msg = " ".join(file_msg)
         logger.info(file_msg)
     else:
-        logger.info(input_files)
+        for f in input_files:
+            logger.info('    ' + f)
 
     ntuple_map = config.get('input', 'ntuple_map_file')
     with open(ntuple_map) as f:
@@ -70,26 +70,26 @@ def process_tuples(config, nevents, analyzers, producers, filters=None):
     counter_rate = available_events // 10
     if nevents <= 10000 and not nevents < 0:
         counter_rate = nevents / 10
-    for entry, event in enumerate(reader):
-        if entry % counter_rate == 0:
+    for event in reader:
+        processed_events = reader.processed_events
+        if processed_events % counter_rate == 0:
             if nevents > 0:
-                logger.info("{} of {}".format(entry, nevents))
+                logger.info("{} of {}".format(processed_events, nevents))
             else:
-                logger.info("{} of {}".format(entry, available_events))
+                logger.info("{} of {}".format(processed_events, available_events))
         results = [p.produce(event) for p in producers]
         check(results, producers, 'produce')
-        # # TODO: add filters
         if filters:
             masks = [f(event) for f in filters]
             mask = create_event_mask(masks)
             event = event.mask(mask)
-        # if not event:
-        #     logger.debug('Event did not pass any of the filters')
-        #     continue
-        # results = [analyzer.process_event(entry, event) for analyzer in analyzers]
-        # check(results, analyzers, 'process_event')
-        # if all(results) is not True:
-        #     break
+        if not event:
+            logger.debug('Event did not pass any of the filters')
+            continue
+        results = [analyzer.process_event(processed_events, event) for analyzer in analyzers]
+        check(results, analyzers, 'process_event')
+        if all(results) is not True:
+            break
 
 
 @timerfunc_log_to(logger.info)
@@ -159,12 +159,13 @@ def run(config, nevents, reload_histograms):
         analyzer.write_histograms()
 
     # Turn the histograms to plots
+    logging.getLogger("ROOT.TCanvas.Print").setLevel(logging.WARNING)
     logger.info(section.format("Making plots"))
     results = [analyzer.make_plots() for analyzer in analyzers]
     check(results, analyzers, 'make_plots')
 
     # Finalize
-    print(section.format("Finalizing things"))
+    logger.info(section.format("Finalizing things"))
     results = [analyzer.finalize() for analyzer in analyzers]
     check(results, analyzers, 'finalize')
 
@@ -208,19 +209,19 @@ def analyze(config_file, nevents, reload_histograms, hist_files):
 
     isok = run(config, nevents, reload_histograms)
 
-    print('\n' + separator + '\n')
+    logger.info('\n' + separator + '\n')
     if isok is not True:
-        logger.info("There were errors during running:")
-        logger.info(isok)
-        logger.info('\n' + separator + '\n')
+        logger.error("There were errors during running:")
+        logger.error(isok)
+        logger.error('\n' + separator + '\n')
 
 
 def load_analyzer(analyzer, output_cfg):
     name = analyzer['name']
     module = analyzer.pop('module')
-    logger.info("Try loading analyzer: {0} ({1})".format(name, module))
+    logger.debug("Try loading analyzer: {0} ({1})".format(name, module))
     module = import_module(module)
-    logger.info("Successfully loaded analyzer: {0} ({1})".format(name, module))
+    logger.debug("Successfully loaded analyzer: {0} ({1})".format(name, module))
     cfg = dict(output_folder=output_cfg['folder'],
                plots_folder=output_cfg['plots_folder'],
                file_format=output_cfg.get('plot_format', 'pdf'),
@@ -232,9 +233,9 @@ def load_analyzer(analyzer, output_cfg):
 def load_producer(producer, output_cfg):
     name = producer.pop('name')
     module = producer.pop('module')
-    logger.info("Try loading producer: {0} ({1})".format(name, module))
+    logger.debug("Try loading producer: {0} ({1})".format(name, module))
     module = import_module(module)
-    logger.info("Successfully loaded producer: {0} ({1})".format(name, module))
+    logger.debug("Successfully loaded producer: {0} ({1})".format(name, module))
     # TODO: is this part needed for producers?
     cfg = dict(output_folder=output_cfg['folder'],
                plots_folder=output_cfg['plots_folder'],
@@ -247,12 +248,12 @@ def load_producer(producer, output_cfg):
 def load_filter(filter):
     name = filter.pop('name')
     module = filter.pop('module')
-    logger.info("Try loading filter: {0} ({1})".format(name, module))
+    logger.debug("Try loading filter: {0} ({1})".format(name, module))
     tokens = module.split('.')
     module_path = '.'.join(tokens[:-1])
     module = import_module(module_path)
     caller = getattr(module, tokens[-1])
-    logger.info("Successfully loaded filter: {0} ({1})".format(name, caller))
+    logger.debug("Successfully loaded filter: {0} ({1})".format(name, caller))
     cfg = {}
     cfg.update(filter)
     return caller(**cfg)

--- a/bin/cmsl1t
+++ b/bin/cmsl1t
@@ -2,6 +2,8 @@
 from __future__ import print_function
 import ROOT
 import os
+
+import numpy as np
 from datetime import datetime
 from importlib import import_module
 
@@ -64,25 +66,22 @@ def process_tuples(config, nevents, analyzers, producers, filters=None):
 
     logger.info(section.format("Processing events"))
     # Fill the histograms from the tuples
-    counter_rate = 1000
+    available_events = reader.numentries
+    counter_rate = available_events // 10
     if nevents <= 10000 and not nevents < 0:
         counter_rate = nevents / 10
     for entry, event in enumerate(reader):
-        print(entry)
         if entry % counter_rate == 0:
             if nevents > 0:
                 logger.info("{} of {}".format(entry, nevents))
             else:
-                logger.info("{} of <all>".format(entry))
+                logger.info("{} of {}".format(entry, available_events))
         results = [p.produce(event) for p in producers]
         check(results, producers, 'produce')
         # # TODO: add filters
         if filters:
-            print(len(filters))
-            print(filters)
-            print("Creating event mask")
-            mask = create_event_mask([f(event) for f in filters])
-            print("Filtering event")
+            masks = [f(event) for f in filters]
+            mask = create_event_mask(masks)
             event = event.mask(mask)
         # if not event:
         #     logger.debug('Event did not pass any of the filters')

--- a/bin/cmsl1t
+++ b/bin/cmsl1t
@@ -19,6 +19,7 @@ from cmsl1t.utils.module import load_L1TNTupleLibrary
 from cmsl1t.utils.timers import timerfunc_log_to
 
 logging.getLogger("rootpy.tree.chain").setLevel(logging.WARNING)
+logging.getLogger("matplotlib").setLevel(logging.WARNING)
 #click_log.basic_config(logger)
 
 TODAY = datetime.now().timetuple()

--- a/bin/cmsl1t
+++ b/bin/cmsl1t
@@ -84,7 +84,7 @@ def process_tuples(config, nevents, analyzers, producers, filters=None):
             mask = create_event_mask(masks)
             event = event.mask(mask)
         if not event:
-            logger.debug('Event did not pass any of the filters')
+            logger.warning('Event did not pass any of the filters')
             continue
         results = [analyzer.process_event(processed_events, event) for analyzer in analyzers]
         check(results, analyzers, 'process_event')

--- a/bin/cmsl1t
+++ b/bin/cmsl1t
@@ -58,6 +58,7 @@ def process_tuples(config, nevents, analyzers, producers, filters=None):
         batch_size=config.try_get('analysis', 'batch_size', default=1),
     )
 
+    logger.info(section.format("Preparing analysis modules"))
     results = [analyzer.prepare_for_events(reader) for analyzer in analyzers]
     check(results, analyzers, 'prepare_for_events')
 
@@ -67,6 +68,7 @@ def process_tuples(config, nevents, analyzers, producers, filters=None):
     if nevents <= 10000 and not nevents < 0:
         counter_rate = nevents / 10
     for entry, event in enumerate(reader):
+        print(entry)
         if entry % counter_rate == 0:
             if nevents > 0:
                 logger.info("{} of {}".format(entry, nevents))
@@ -74,18 +76,21 @@ def process_tuples(config, nevents, analyzers, producers, filters=None):
                 logger.info("{} of <all>".format(entry))
         results = [p.produce(event) for p in producers]
         check(results, producers, 'produce')
-        # TODO: add filters
+        # # TODO: add filters
         if filters:
+            print(len(filters))
+            print(filters)
+            print("Creating event mask")
             mask = create_event_mask([f(event) for f in filters])
+            print("Filtering event")
             event = event.mask(mask)
-        if not event:
-            logger.debug('Event did not pass any of the filters')
-            continue
-        results = [analyzer.process_event(entry, event)
-                   for analyzer in analyzers]
-        check(results, analyzers, 'process_event')
-        if all(results) is not True:
-            break
+        # if not event:
+        #     logger.debug('Event did not pass any of the filters')
+        #     continue
+        # results = [analyzer.process_event(entry, event) for analyzer in analyzers]
+        # check(results, analyzers, 'process_event')
+        # if all(results) is not True:
+        #     break
 
 
 @timerfunc_log_to(logger.info)

--- a/cmsl1t/__init__.py
+++ b/cmsl1t/__init__.py
@@ -11,10 +11,11 @@ logger = logging.getLogger(__name__)
 logger.propagate = False
 # add loggers
 ch = logging.StreamHandler()
-if not os.environ.get("DEBUG", False):
-    ch.setLevel(logging.INFO)
-else:
-    ch.setLevel(logging.DEBUG)
+CMSL1T_LOGLEVEL = logging.INFO
+if os.environ.get("DEBUG", False):
+    CMSL1T_LOGLEVEL = logging.DEBUG
+
+ch.setLevel(CMSL1T_LOGLEVEL)
 # log format
 formatter = logging.Formatter(
     '%(asctime)s [%(name)s]  %(levelname)s: %(message)s')

--- a/cmsl1t/__init__.py
+++ b/cmsl1t/__init__.py
@@ -8,8 +8,7 @@ __version__ = '0.5.1'
 
 # logging
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-
+logger.propagate = False
 # add loggers
 ch = logging.StreamHandler()
 if not os.environ.get("DEBUG", False):

--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -3,6 +3,8 @@ import csv
 from math import pi
 import os
 
+import numpy as np
+
 import cmsl1t
 from .BaseAnalyzer import BaseAnalyzer
 from ..energySums import EnergySum, Met
@@ -346,25 +348,20 @@ class Analyzer(BaseAnalyzer):
             )
 
     def fill_histograms(self, entry, event):
-        offline, online = extractSums(
-            event, self._doEmu, self._doReco, self._doGen)
-        print(offline, online)
-        return True
+        offline, online = extractSums(event, self._doEmu, self._doReco, self._doGen)
 
-        recoNVtx = 1
-        genNVtx = 1
+        recoNVtx = np.ones(len(event))
+        genNVtx = np.ones(len(event))
 
         if self._doReco or self._doVertex:
             recoNVtx = event.Vertex_nVtx
         if self._doGen:
             genNVtx = event.Generator_nVtx
+        return True
 
         # TODO: vectorize
         # pileup = self._lumiMu[(event['run'], event['lumi'])]
         pileup = 51
-        # print pileup
-        # if pileup >= 60 or pileup < 50:
-        #    return True
 
         for name in self._sumTypes:
             if 'pfMET' in name and not pfMetFilter(event):

--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -1,11 +1,8 @@
 from collections import namedtuple
-import csv
 from math import pi
-import os
 
 import numpy as np
 
-import cmsl1t
 from .BaseAnalyzer import BaseAnalyzer
 from ..energySums import EnergySum, Met
 from ..filters import pfMetFilter
@@ -118,15 +115,6 @@ class Analyzer(BaseAnalyzer):
 
     def __init__(self, **kwargs):
         super(Analyzer, self).__init__(**kwargs)
-
-        lumiMuDict = dict()
-        run_lumi_csv = os.path.join(cmsl1t.PROJECT_ROOT, 'run_lumi.csv')
-        with open(run_lumi_csv, 'r') as runLumiFile:
-            reader = csv.reader(runLumiFile, delimiter=',')
-            for line in reader:
-                lumiMuDict[(int(line[1]), int(line[2]))] = float(line[3])
-        self._lumiMu = lumiMuDict
-
         # TODO: this needs changing, these should be analyser parameters
         # or even move out into separate calls of the same analyzer
         loaded_trees = self.params['load_trees']
@@ -357,11 +345,9 @@ class Analyzer(BaseAnalyzer):
             recoNVtx = event.Vertex_nVtx
         if self._doGen:
             genNVtx = event.Generator_nVtx
-        return True
 
-        # TODO: vectorize
-        # pileup = self._lumiMu[(event['run'], event['lumi'])]
-        pileup = 51
+        pileup = event['pileup_from_csv']
+        return True
 
         for name in self._sumTypes:
             if 'pfMET' in name and not pfMetFilter(event):

--- a/cmsl1t/analyzers/jetMet_analyzer.py
+++ b/cmsl1t/analyzers/jetMet_analyzer.py
@@ -119,7 +119,7 @@ class Analyzer(BaseAnalyzer):
 
         lumiMuDict = dict()
         run_lumi_csv = os.path.join(cmsl1t.PROJECT_ROOT, 'run_lumi.csv')
-        with open(run_lumi_csv, 'rb') as runLumiFile:
+        with open(run_lumi_csv, 'r') as runLumiFile:
             reader = csv.reader(runLumiFile, delimiter=',')
             for line in reader:
                 lumiMuDict[(int(line[1]), int(line[2]))] = float(line[3])
@@ -348,6 +348,8 @@ class Analyzer(BaseAnalyzer):
     def fill_histograms(self, entry, event):
         offline, online = extractSums(
             event, self._doEmu, self._doReco, self._doGen)
+        print(offline, online)
+        return True
 
         recoNVtx = 1
         genNVtx = 1

--- a/cmsl1t/filters/__init__.py
+++ b/cmsl1t/filters/__init__.py
@@ -40,6 +40,8 @@ def combine_with_OR(filters):
 def create_event_mask(filters, method=combine_with_AND):
     if not filters:
         return []
+    if len(filters) == 1:
+        return filters[0]
     return method(filters)
 
 

--- a/cmsl1t/filters/jets_vectorized.py
+++ b/cmsl1t/filters/jets_vectorized.py
@@ -21,8 +21,7 @@ def _pfJetID(jet):
         (isForwardCentralJet & (jet.nMult <= 2)) | \
         (isForwardJet & (jet.nemef >= 0.9)) | \
         (isForwardJet & (jet.nMult <= 10))
-
-    return jet.select(~reject_if)
+    return jet[~reject_if]
 
 
 def pfJetFilter(jets):

--- a/cmsl1t/filters/luminosity.py
+++ b/cmsl1t/filters/luminosity.py
@@ -1,22 +1,17 @@
 import json
 import six
-import six.moves.urllib as urllib
 import numpy as np
 
 from .. import logger
 from ..math import isin_nd
+from ..io import RemoteFile
 
 
 def _load_json(lumi_json):
-    input_file = lumi_json
-    is_remote = input_file.startswith('http')
-    has_local_prefix = input_file.startswith('file://')
-    if not is_remote and not has_local_prefix:
-        input_file = 'file://' + input_file
-    logger.debug('Loading file {} for LuminosityFilter'.format(input_file))
-    input_stream = urllib.request.urlopen(input_file)
-    data = json.load(input_stream)
-    return data
+    logger.debug('Loading file {} for LuminosityFilter'.format(lumi_json))
+    with RemoteFile(lumi_json) as f:
+        data = json.load(f)
+        return data
 
 
 def _expand_lumi_range(lumi_range):

--- a/cmsl1t/filters/luminosity.py
+++ b/cmsl1t/filters/luminosity.py
@@ -45,7 +45,9 @@ class LuminosityFilter(object):
 
     def __call__(self, event):
         to_test = np.array(list(zip(event.run, event.lumi)))
+        print('Test array done')
         mask = filter_lumis(to_test, self.valid_lumi_sections)
+        print('mask done')
         return mask
 
 

--- a/cmsl1t/io/__init__.py
+++ b/cmsl1t/io/__init__.py
@@ -4,6 +4,8 @@ from cmsl1t.hist.hist_collection import HistogramCollection
 # no pickles without dill
 import dill  # noqa: F401
 
+from .remote import RemoteFile
+
 
 def to_root(obj, output_file):
     '''
@@ -31,3 +33,10 @@ def from_root(input_file):
                     hist.SetDirectory(None)
 
     return reloaded
+
+
+__all__ = [
+    'to_root',
+    'from_root',
+    'RemoteFile',
+]

--- a/cmsl1t/io/remote.py
+++ b/cmsl1t/io/remote.py
@@ -1,0 +1,29 @@
+import os
+
+import six.moves.urllib as urllib
+
+from .. import logger
+
+
+class RemoteFile(object):
+
+    def __init__(self, file_name):
+        is_remote = file_name.startswith('http')
+        has_local_prefix = file_name.startswith('file://')
+        if not is_remote and not has_local_prefix:
+            file_name = os.path.abspath(file_name)
+            file_name = 'file://' + file_name
+        logger.debug('Opening file {}'.format(file_name))
+        try:
+            self.file_obj = urllib.request.urlopen(file_name)
+        except urllib.error.URLError as e:
+            if is_remote:
+                raise urllib.error.URLError(e)
+            else:
+                raise IOError(e)
+
+    def __enter__(self):
+        return self.file_obj
+
+    def __exit__(self, type, value, traceback):
+        self.file_obj.close()

--- a/cmsl1t/jet.py
+++ b/cmsl1t/jet.py
@@ -13,9 +13,10 @@ class Jet(object):
             self.et, self.eta, self.phi, self.etCorr = args
 
     def __getitem__(self, name):
-        # TODO: check if "name" is a list
-        # if yes --> to selection
-        return object.__getattribute__(self, name)
+        if isinstance(name, str):
+            return object.__getattribute__(self, name)
+        else:
+            return self.select(name)
 
     def select(self, mask):
         selected_values = [self[v][mask] for v in self.__slots__]

--- a/cmsl1t/math.py
+++ b/cmsl1t/math.py
@@ -24,3 +24,22 @@ def _reversed_cumulative_sum(values):
     cumsum = np.cumsum(reversed_values)
     reversed_cumsum = np.array(np.flipud(cumsum))
     return reversed_cumsum
+
+
+def view1D(a, b):
+    """
+        From https://stackoverflow.com/a/45313353/
+    """
+    a = np.ascontiguousarray(a)
+    b = np.ascontiguousarray(b)
+    void_dt = np.dtype((np.void, a.dtype.itemsize * a.shape[1]))
+    return a.view(void_dt).ravel(),  b.view(void_dt).ravel()
+
+
+def isin_nd(a, b):
+    """
+        From https://stackoverflow.com/questions/54791950
+    """
+    # a,b are the 3D input arrays to give us "isin-like" functionality across them
+    A, B = view1D(a.reshape(a.shape[0], -1), b.reshape(b.shape[0], -1))
+    return np.isin(A, B)

--- a/cmsl1t/producers/jets.py
+++ b/cmsl1t/producers/jets.py
@@ -8,7 +8,6 @@ from .base import BaseProducer
 
 
 def _load_filter_module(filterPath):
-    print(filterPath)
     if filterPath is None:
         return None
     tokens = filterPath.split('.')

--- a/cmsl1t/producers/jets_vectorized.py
+++ b/cmsl1t/producers/jets_vectorized.py
@@ -8,7 +8,6 @@ from .base import BaseProducer
 
 
 def _load_filter_module(filterPath):
-    print(filterPath)
     if filterPath is None:
         return None
     tokens = filterPath.split('.')

--- a/cmsl1t/producers/l1sums.py
+++ b/cmsl1t/producers/l1sums.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import ROOT
 
 from cmsl1t.energySums import EnergySum, Mex, Mey, Met

--- a/cmsl1t/producers/l1sums_vectorized.py
+++ b/cmsl1t/producers/l1sums_vectorized.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import ROOT
 
 from cmsl1t.energySums import EnergySum, Mex, Mey, Met

--- a/cmsl1t/producers/pileup_from_csv.py
+++ b/cmsl1t/producers/pileup_from_csv.py
@@ -2,12 +2,11 @@ import numpy as np
 import pandas as pd
 
 from .base import BaseProducer
+from .. import logger
 
 
 def _load_csv(csv_file):
-    lumiMuDict = dict()
-    df = pd.read_csv(csv_file, names=['entry', 'run', 'lumi', 'pileup'], index_col=['run', 'lumi'])
-    return df
+    return pd.read_csv(csv_file, names=['entry', 'run', 'lumi', 'pileup'], index_col=['run', 'lumi'])
 
 
 class Producer(BaseProducer):
@@ -21,5 +20,23 @@ class Producer(BaseProducer):
 
     def produce(self, event):
         variables = [event[i] for i in self._inputs]
+        pileup = np.zeros(np.size(variables[0]))
+        # TODO:
+        """
+          /software/miniconda/envs/hep_py3/lib/python3.6/site-packages/pandas/core/indexing.py:969: FutureWarning:
+          Passing list-likes to .loc or [] with any missing label will raise
+          KeyError in the future, you can use .reindex() as an alternative.
 
-        setattr(event, self._outputs[0], self._data.loc[list(zip(*variables)), 'pileup'].fillna(0).to_numpy())
+          See the documentation here:
+          https://pandas.pydata.org/pandas-docs/stable/indexing.html#deprecate-loc-reindex-listlike
+          return self._getitem_nested_tuple(tup)
+
+          -- Docs: https://docs.pytest.org/en/latest/warnings.html
+        """
+        try:
+            pileup = self._data.loc[list(zip(*variables)), 'pileup'].fillna(0).to_numpy()
+        except KeyError:
+            logger.warning('Could not find any (run, lum) combination in {}'.format(self._run_lumi_file))
+        setattr(event, self._outputs[0], pileup)
+
+        return True

--- a/cmsl1t/producers/pileup_from_csv.py
+++ b/cmsl1t/producers/pileup_from_csv.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pandas as pd
+
+from .base import BaseProducer
+
+
+def _load_csv(csv_file):
+    lumiMuDict = dict()
+    df = pd.read_csv(csv_file, names=['entry', 'run', 'lumi', 'pileup'], index_col=['run', 'lumi'])
+    return df
+
+
+class Producer(BaseProducer):
+
+    def __init__(self, inputs, outputs, **kwargs):
+        self._expected_input_order = ['run', 'lumi']
+        self._run_lumi_file = kwargs.pop('csv_file')
+        super(Producer, self).__init__(inputs, outputs, **kwargs)
+
+        self._data = _load_csv(self._run_lumi_file)
+
+    def produce(self, event):
+        variables = [event[i] for i in self._inputs]
+
+        setattr(event, self._outputs[0], self._data.loc[list(zip(*variables)), 'pileup'].fillna(0).to_numpy())

--- a/cmsl1t/producers/pileup_from_csv.py
+++ b/cmsl1t/producers/pileup_from_csv.py
@@ -36,7 +36,7 @@ class Producer(BaseProducer):
         try:
             pileup = self._data.loc[list(zip(*variables)), 'pileup'].fillna(0).to_numpy()
         except KeyError:
-            logger.warning('Could not find any (run, lum) combination in {}'.format(self._run_lumi_file))
+            logger.warning('Could not find any (run, lumi) combination in {}'.format(self._run_lumi_file))
         setattr(event, self._outputs[0], pileup)
 
         return True

--- a/cmsl1t/utils/module.py
+++ b/cmsl1t/utils/module.py
@@ -30,6 +30,7 @@ def exists(module_name):
 
 
 def load_L1TNTupleLibrary(lib_name='L1TAnalysisDataformats.so'):
+    pass
     import ROOT
     external_includes = os.path.join(PROJECT_ROOT, 'external')
     if external_includes not in ROOT.gSystem.GetIncludePath():

--- a/config/all2017.yaml
+++ b/config/all2017.yaml
@@ -96,6 +96,14 @@ analysis:
       filter: null
       outputs:
         - l1Jets
+    pileup_from_json:
+      module: cmsl1t.producers.pileup_from_csv
+      inputs:
+        - run
+        - lumi
+      csv_file: run_lumi.csv
+      outputs:
+        - pileup_from_csv
 
 output:
   template:

--- a/config/all2017.yaml
+++ b/config/all2017.yaml
@@ -28,7 +28,7 @@ input:
 
 analysis:
   vectorized: True
-  batch_size: 1000
+  batch_size: 10000
   load_trees:
     - event
     - upgrade

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aghast
 git+https://github.com/scikit-hep/boost-histogram.git@develop
 numpy
 matplotlib
-pandas==0.23
+pandas==0.24
 memory_profiler
 flake8
 pep8

--- a/setup.sh
+++ b/setup.sh
@@ -97,20 +97,14 @@ then
     echo "No CVMFS available, setting up Anaconda Python"
     if [ ! -d "${CMSL1T_CONDA_PATH}" ]
     then
-      wget -nv https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O /tmp/miniconda.sh
+      wget -nv https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh
       bash /tmp/miniconda.sh -b -p ${CMSL1T_CONDA_PATH}
       PATH=${CMSL1T_CONDA_PATH}/bin:$PATH; export PATH
-      rm -f miniconda.sh
+      rm -f /tmp/miniconda.sh
       echo "Finished conda installation, creating new conda environment"
-      conda config --add channels http://conda.anaconda.org/NLeSC
-      conda config --set show_channel_urls yes
-      conda create -n cms python=2.7 -yq
+      conda create -n cms python=3 -yq
       source activate cms
-      conda install -y -q \
-        matplotlib \
-        numpy \
-        root>=6.04 \
-        rootpy
+      conda install -y -q -c conda-forge root=6
       echo "Created conda environment, installing basic dependencies"
       pip install -U pip
       pip install -r requirements.txt

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,12 @@
+
+
+class DummyEvent(dict):
+
+    def __init__(self, **kwargs):
+        super(DummyEvent, self).update(kwargs)
+
+    def __getattribute__(self, name):
+        return self[name]
+
+    def __setattr__(self, name, value):
+        self[name] = value

--- a/test/filters/test_masks.py
+++ b/test/filters/test_masks.py
@@ -3,10 +3,11 @@ import pytest
 
 from cmsl1t.filters import combine_with_AND, combine_with_OR
 
-
 scalar_filters_all_passing = [True, True, True]
 scalar_filters_all_failing = [False, False, False]
 scalar_filters_all_but_one_failing = [False, True, False]
+# TODO: assumptions are wrong. The combination of those vectors
+# should be of size 3
 vector_filters_all_passing = [
     np.array([True, True, True]),
     np.array([True, True, True]),

--- a/test/io/test_remote_file.py
+++ b/test/io/test_remote_file.py
@@ -1,0 +1,32 @@
+import pytest
+import six.moves.urllib as urllib
+
+from cmsl1t.io import RemoteFile
+
+
+@pytest.fixture(params=['local_file', 'remote_file'])
+def file_url(request):
+    if request.param == 'local_file':
+        return 'run_lumi.csv'
+    if request.param == 'remote_file':
+        return 'https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions17' + \
+            '/13TeV/PromptReco/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt'
+
+
+def test_access(file_url):
+    with RemoteFile(file_url) as f:
+        assert len(f.readlines()) > 0
+
+
+def test_invalid_file_local():
+    with pytest.raises(IOError) as e:
+        with RemoteFile("sdfbksdjhflksdj") as _:
+            pass
+        assert "No such file" in str(e.value)
+
+
+def test_invalid_file_remote():
+    with pytest.raises(urllib.error.URLError) as e:
+        with RemoteFile("http://sdfbksdjhflksdj") as _:
+            pass
+        assert "No such file" in str(e.value)

--- a/test/producers/test_pileup_from_csv.py
+++ b/test/producers/test_pileup_from_csv.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+
+import cmsl1t
+from cmsl1t.producers.pileup_from_csv import Producer
+
+from .. import DummyEvent
+
+@pytest.fixture
+def events():
+    return DummyEvent(
+        run=[324980, 324980, 324980, 324980, 324878, 324878, 324878, 1],
+        lumi=[40, 41, 42, 43, 620, 621, 622, 42],
+    )
+
+
+def test_pileup_from_csv(events):
+    expected = [6.4, 15.6, 36.1, 51.7, 33.4, 33.4, 33.4, 0]
+    run_lumi_csv = os.path.join(cmsl1t.PROJECT_ROOT, 'run_lumi.csv')
+    p = Producer(inputs=['run', 'lumi'], outputs=['pileup_from_csv'], csv_file=run_lumi_csv)
+    p.produce(events)
+    assert hasattr(events, 'pileup_from_csv')
+    assert events.pileup_from_csv.tolist() == expected

--- a/test/producers/test_pileup_from_csv.py
+++ b/test/producers/test_pileup_from_csv.py
@@ -1,21 +1,30 @@
+import numpy as np
 import os
 import pytest
+
 
 import cmsl1t
 from cmsl1t.producers.pileup_from_csv import Producer
 
 from .. import DummyEvent
 
-@pytest.fixture
-def events():
-    return DummyEvent(
-        run=[324980, 324980, 324980, 324980, 324878, 324878, 324878, 1],
-        lumi=[40, 41, 42, 43, 620, 621, 622, 42],
-    )
+
+@pytest.fixture(params=['events', 'events_not_in_csv'])
+def data(request):
+    if request.param == 'events':
+        return DummyEvent(
+            run=[324980, 324980, 324980, 324980, 324878, 324878, 324878, 1],
+            lumi=[40, 41, 42, 43, 620, 621, 622, 42],
+        ), [6.4, 15.6, 36.1, 51.7, 33.4, 33.4, 33.4, 0]
+    if request.param == 'events_not_in_csv':
+        return DummyEvent(
+            run=np.zeros(10),
+            lumi=np.zeros(10),
+        ), [0] * 10
 
 
-def test_pileup_from_csv(events):
-    expected = [6.4, 15.6, 36.1, 51.7, 33.4, 33.4, 33.4, 0]
+def test_pileup_from_csv(data):
+    events, expected = data
     run_lumi_csv = os.path.join(cmsl1t.PROJECT_ROOT, 'run_lumi.csv')
     p = Producer(inputs=['run', 'lumi'], outputs=['pileup_from_csv'], csv_file=run_lumi_csv)
     p.produce(events)


### PR DESCRIPTION
 - improved speed for LumiFilter (x700 speedup)
 - vectorized lumiDictionary (from `cmsl1t.analyzers.jetMet_analyzer` to look up pileup) &rarr; `cmsl1t.producers.pileup_from_csv`
 - fixes for the makefile
 - new `io.RemoteFile` to consolidate remote and local file access (e.g. JSON & CSV files)
 - tweaking the logger to produce more relevant and standardized messages

Next steps:
 - consolidation of histogram collections (`EfficiencyCollection`, `ResolutionCollection`) under `VectorizedHistCollection` (will become a meta class)