### PR TITLE
Restrict version of pytest and dependent more-itertools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,10 @@ dill
 mock
 boltons
 tabulate
-pytest>=3.5.0
+pytest>=3.5.0,<4.0.0
 uproot
 mock
 requests
 plumbum
 six
+more-itertools<6.0.0


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### What does this pull request implement/fix? Explain your changes.

Need to restrict pytest to earlier than version 4, otherwise setup doesn't work.  more-itertools also then needs restricting to earlier version (<6)

