### PR TITLE
Show thresholds for multiple menu rates, save output to file

### DIFF
--- a/config/rates.yaml
+++ b/config/rates.yaml
@@ -3,19 +3,16 @@ name: 'Jet Met Rates'
 
 input:
   files:
-      # Zero Bias
-       # -  root://eoscms.cern.ch//eos/cms//store/group/dpg_trigger/comm_trigger/L1Trigger/bundocka/cmsl1t/zb_noLowEtSF_101.root
-       # - data/L1Ntuple_*.root
-       - test/data/*.root
+       - /eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/bundocka/condor/jecRatesDef_1603924698/*.root
   sample:
-    name: Data
-    title: 2017 Data
+    name: NuGun
+    title: 
   trigger:
-    name: zbNoLowEtSF
-    title: Zero Bias
+    name: JECOld
+    title: 
   pileup_file: ""
   run_number:
-  lumi_json: "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions18/13TeV/PromptReco/Cert_314472-325175_13TeV_PromptReco_Collisions18_JSON.txt"
+  lumi_json: #"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions18/13TeV/PromptReco/Cert_314472-325175_13TeV_PromptReco_Collisions18_JSON.txt"
   ntuple_map_file: config/ntuple_content_RAWEMU.yaml
 
 analysis:
@@ -26,7 +23,7 @@ analysis:
     - upgrade
   do_fit: True
   pu_type: 0PU24,25PU49,50PU
-  pu_bins: [0,25,50,999]
+  pu_bins: [0,999]
   thresholds:
     HT:       [120, 200, 320]
     METBE:    [80, 100, 120]
@@ -34,11 +31,11 @@ analysis:
     JetET_BE: [35, 90, 120]
     JetET_HF: [35, 90, 120]
   rates:
-    HT:           11 #kHz
-    METBE:        18
-    METHF:        18
-    JetET_BE:     70
-    JetET_HF:     3 # guess
+    HT:           [5, 2000] #kHz
+    METBE:        [5, 2000]
+    METHF:        [5, 2000]
+    JetET_BE:     [5, 2000]
+    JetET_HF:     [1, 400] # guess
 
   analyzers:
      HW_Emu_jetMet_rates:


### PR DESCRIPTION
Now print out thresholds for more than one menu rate supplied in the config. 
Also update rates config to use multiple thresholds.