### PR TITLE
Bugfix for reloading histograms

### DIFF
--- a/cmsl1t/analyzers/BaseAnalyzer.py
+++ b/cmsl1t/analyzers/BaseAnalyzer.py
@@ -74,6 +74,7 @@ class BaseAnalyzer(object):
              provided with the filename, and passed to from_root
          """
         results = []
+        comp_title = ""
         if do_comparison:
             self._doComp = True
             comp_title = input_filename.split(':')[0]


### PR DESCRIPTION
Small bugfix for the -r reloading histograms from root files option.
Variable wasn't assigned when simply reloading histograms and not comparing/overlaying multiple sets of histograms.